### PR TITLE
Auswertungs-Szenarien: Börsenweisheiten + Charttechnik (erster Ansatz)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,14 +58,20 @@ inkrementell fortgeschrieben).
   Optionales Feld `Strategy.gewichte_fn` macht die Ziel-Gewichte zeitabhängig
   statt konstant (Signatur `(rows, i) -> dict[ticker, Decimal]`, darf nur auf
   `rows[:i+1]` zugreifen, kein Lookahead-Bias) — Basis für `scenarios.py`.
-- `scenarios.py` — Auswertungs-Szenarien (Börsenweisheiten, Charttechnik) als
-  gewöhnliche `Strategy`-Instanzen mit gesetztem `gewichte_fn`: "Sell in May
-  and Go Away" (saisonal defensiv Mai–September), "Buy & Hold" (nie aktiv
-  rebalancieren) und ein SMA-Crossover (Golden/Death Cross, 10/40 Wochen) auf
-  dem MSCI-World-ETF als Trendindikator. Erster Ansatz, Parameter nicht
-  optimiert/gebacktestet. Weitere denkbare Szenarien (nicht implementiert):
-  Momentum-/Relative-Stärke-Rotation zwischen den Wachstums-Instrumenten,
-  volatilitätsbasierte Aktienquote, Cost-Average-Einstieg statt Einmalanlage.
+- `scenarios.py` — Auswertungs-Szenarien als gewöhnliche `Strategy`-Instanzen
+  mit gesetztem `gewichte_fn`, in drei Kategorien: (1) Börsenweisheiten —
+  "Sell in May and Go Away" (saisonal defensiv Mai–September), "Buy & Hold"
+  (nie aktiv rebalancieren), "Jahresendrallye" (Dez/Jan Wachstumsquote auf
+  95%), "Antizyklisch kaufen" (Wachstumsquote auf 95% nach >10% Rückgang vom
+  Rolling-Hoch) und "Verluste begrenzen" (Trailing-Stop je Wachstums-
+  Instrument, >15% Rückgang vom eigenen Rolling-Hoch schaltet nur dieses
+  Instrument auf 0%); (2) Charttechnik — SMA-Crossover (Golden/Death Cross,
+  10/40 Wochen) auf dem MSCI-World-ETF; (3) weitere Ansätze — Momentum-/
+  Relative-Stärke-Rotation (Top-2 der Wachstums-Instrumente nach
+  12-Wochen-Trailing-Rendite), volatilitätsbasierte Aktienquote (50–90%
+  Wachstum je nach realisierter EUNL-Volatilität) und Cost-Average-Einstieg
+  (Wachstumsquote rampt über 10 Wochen linear hoch statt Einmalanlage).
+  Erster Ansatz, Parameter nicht optimiert/gebacktestet.
   `scripts/build_dashboard.py` rendert `STRATEGIES + SCENARIOS` standardmäßig.
 - `history_store.py` — **einziger** Schreibzugriff auf
   `data/price_history.csv` / `data/fetch_log.csv`. `record_week()` ist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ pytest tests/test_engine.py::test_simple_strategy_end_to_end_exact_values -q  # 
 
 python scripts/run_fetch.py                        # Kursabruf via Alpha Vantage (benötigt ALPHAVANTAGE_API_KEY env var)
 python scripts/record_prices.py --date 2026-08-17 --prices '{"EUNL": 82.1, ...}'  # manueller Kurseintrag
-python scripts/build_dashboard.py                  # baut docs/index.html aus data/price_history.csv
-python scripts/build_dashboard.py --strategy "Barbell 20/80"  # nur eine Strategie rendern
+python scripts/build_dashboard.py                  # baut docs/index.html aus data/price_history.csv (Strategien + Szenarien)
+python scripts/build_dashboard.py --strategy "Barbell 20/80"  # nur eine Strategie/ein Szenario rendern
 ```
 
 Kein Lint-/Format-Tooling konfiguriert; `pytest.ini` setzt `pythonpath = src`,
@@ -55,6 +55,18 @@ inkrementell fortgeschrieben).
   Sub-Gewichte, Rebalancing-Schwelle, Startkapital) + strategieübergreifende
   Steuer-/Gebührkonstanten. Die Engine enthält **keine** Barbell-spezifischen
   Annahmen — neue Strategien sind nur ein weiterer Eintrag in `STRATEGIES`.
+  Optionales Feld `Strategy.gewichte_fn` macht die Ziel-Gewichte zeitabhängig
+  statt konstant (Signatur `(rows, i) -> dict[ticker, Decimal]`, darf nur auf
+  `rows[:i+1]` zugreifen, kein Lookahead-Bias) — Basis für `scenarios.py`.
+- `scenarios.py` — Auswertungs-Szenarien (Börsenweisheiten, Charttechnik) als
+  gewöhnliche `Strategy`-Instanzen mit gesetztem `gewichte_fn`: "Sell in May
+  and Go Away" (saisonal defensiv Mai–September), "Buy & Hold" (nie aktiv
+  rebalancieren) und ein SMA-Crossover (Golden/Death Cross, 10/40 Wochen) auf
+  dem MSCI-World-ETF als Trendindikator. Erster Ansatz, Parameter nicht
+  optimiert/gebacktestet. Weitere denkbare Szenarien (nicht implementiert):
+  Momentum-/Relative-Stärke-Rotation zwischen den Wachstums-Instrumenten,
+  volatilitätsbasierte Aktienquote, Cost-Average-Einstieg statt Einmalanlage.
+  `scripts/build_dashboard.py` rendert `STRATEGIES + SCENARIOS` standardmäßig.
 - `history_store.py` — **einziger** Schreibzugriff auf
   `data/price_history.csv` / `data/fetch_log.csv`. `record_week()` ist
   Wochen-idempotent (schlüsselt über ISO-Kalenderwoche, nicht Kalenderdatum)
@@ -109,3 +121,6 @@ Strategien plus Determinismus (zweifacher Lauf → identisches Ergebnis).
 `tests/test_history_store.py` prüft Wochen-Idempotenz und Carry-Forward.
 `tests/test_sources.py` / `tests/test_alphavantage.py` mocken die jeweilige
 Provider-API vollständig (kein echter Netzwerkzugriff in Tests).
+`tests/test_scenarios.py` verifiziert die generische `gewichte_fn`-Mechanik
+in der Engine anhand handgerechneter Werte sowie die konkreten Szenarien
+(Sell in May, Buy & Hold, SMA-Crossover) als End-to-End-Smoke-Tests.

--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -10,12 +10,18 @@ import _bootstrap  # noqa: F401
 
 from boersenspiel.dashboard import DEFAULT_OUTPUT, build_dashboard
 from boersenspiel.history_store import read_price_history
+from boersenspiel.scenarios import SCENARIOS, SCENARIOS_BY_NAME
 from boersenspiel.strategies import STRATEGIES, STRATEGIES_BY_NAME
+
+ALL_STRATEGIES = STRATEGIES + SCENARIOS
+ALL_STRATEGIES_BY_NAME = {**STRATEGIES_BY_NAME, **SCENARIOS_BY_NAME}
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--strategy", help="Nur diese Strategie rendern (Name aus strategies.py)")
+    parser.add_argument(
+        "--strategy", help="Nur diese Strategie/dieses Szenario rendern (Name aus strategies.py/scenarios.py)"
+    )
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Zielpfad der HTML-Datei")
     args = parser.parse_args()
 
@@ -23,11 +29,11 @@ def main() -> int:
     if not price_history:
         raise SystemExit("Kurshistorie ist leer - noch kein Dashboard erzeugbar. Erst Kurse abrufen.")
 
-    strategies = STRATEGIES
+    strategies = ALL_STRATEGIES
     if args.strategy:
-        if args.strategy not in STRATEGIES_BY_NAME:
-            raise SystemExit(f"Unbekannte Strategie: {args.strategy!r}. Verfuegbar: {list(STRATEGIES_BY_NAME)}")
-        strategies = [STRATEGIES_BY_NAME[args.strategy]]
+        if args.strategy not in ALL_STRATEGIES_BY_NAME:
+            raise SystemExit(f"Unbekannte Strategie: {args.strategy!r}. Verfuegbar: {list(ALL_STRATEGIES_BY_NAME)}")
+        strategies = [ALL_STRATEGIES_BY_NAME[args.strategy]]
 
     output_path = build_dashboard(price_history, strategies, args.output)
     print(f"Dashboard erzeugt: {output_path}")

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -27,16 +27,24 @@ def _f(value: Decimal) -> float:
     return float(value)
 
 
-def _build_strategy_view(strategy: Strategy, result: SimulationResult) -> dict:
+def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: list[PriceRow]) -> dict:
     points = result.value_history
     labels = [vp.date.isoformat() for vp in points]
     total_values = [_f(vp.total_value) for vp in points]
 
     topf_names = [topf.name for topf in strategy.toepfe]
     topf_series = {name: [_f(vp.topf_weights.get(name, Decimal(0))) * 100 for vp in points] for name in topf_names}
-    topf_targets = {topf.name: _f(topf.gewicht_gesamt) * 100 for topf in strategy.toepfe}
 
-    ticker_targets = strategy.alle_ticker_gewichte()
+    # Bei Szenario-Strategien (gewichte_fn gesetzt) sind die Ziel-Gewichte zeitabhängig -
+    # fuer die Anzeige wird das Ziel-Regime der letzten Kurszeile herangezogen.
+    if strategy.gewichte_fn is not None:
+        ticker_targets = strategy.gewichte_fn(rows, len(rows) - 1)
+    else:
+        ticker_targets = strategy.alle_ticker_gewichte()
+    topf_targets = {
+        topf.name: _f(sum((ticker_targets.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0))) * 100
+        for topf in strategy.toepfe
+    }
     last = points[-1]
     holdings_table = []
     for ticker, units in sorted(result.holdings.items()):
@@ -87,8 +95,9 @@ def build_dashboard(
     if not price_history:
         raise ValueError("Kurshistorie ist leer - kein Dashboard erzeugbar")
     strategies = strategies if strategies is not None else STRATEGIES
+    rows = sorted(price_history, key=lambda r: r.date)
 
-    views = [_build_strategy_view(s, simulate(price_history, s)) for s in strategies]
+    views = [_build_strategy_view(s, simulate(rows, s), rows) for s in strategies]
 
     env = Environment(
         loader=FileSystemLoader(str(TEMPLATE_DIR)),

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -92,8 +92,16 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
         raise ValueError("Kurshistorie ist leer - Simulation benötigt mindestens eine Zeile")
 
     rows = sorted(price_history, key=lambda r: r.date)
-    weights = strategy.alle_ticker_gewichte()
-    tickers = sorted(weights.keys())
+    base_weights = strategy.alle_ticker_gewichte()
+    tickers = sorted(base_weights.keys())
+
+    def weights_at(i: int) -> dict[str, Decimal]:
+        """Ziel-Gewichte für Zeile ``i``: dynamisch via ``gewichte_fn`` (z. B.
+        saisonale/charttechnische Szenarien) oder sonst die konstanten
+        Barbell-Gewichte, unverändert wie bisher."""
+        if strategy.gewichte_fn is not None:
+            return strategy.gewichte_fn(rows, i)
+        return base_weights
 
     positions: dict[str, _Position] = {t: _Position() for t in tickers}
     trades: list[Trade] = []
@@ -129,13 +137,15 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
         return {t: positions[t].units * prices[t] for t in tickers if t in prices}
 
     def rebalance_to_targets(
-        prices: dict[str, Decimal], trade_date: date, reason: str
+        prices: dict[str, Decimal], trade_date: date, reason: str, weights: dict[str, Decimal]
     ) -> bool:
         values = current_values(prices)
         total_value = sum(values.values(), Decimal(0))
         if total_value <= 0:
             return False
-        diffs = {t: weights[t] * total_value - values.get(t, Decimal(0)) for t in tickers}
+        diffs = {
+            t: weights.get(t, Decimal(0)) * total_value - values.get(t, Decimal(0)) for t in tickers
+        }
         executed = False
         for t in tickers:
             diff = diffs[t]
@@ -227,6 +237,7 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
         reset_year_if_needed(row.date.year)
 
         if i == 0:
+            initial_weights = weights_at(0)
             num_instruments = len(tickers)
             total_fees = ORDERGEBUEHR * num_instruments
             investable = strategy.startkapital - total_fees
@@ -234,7 +245,7 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                 price = prices.get(t)
                 if price is None:
                     continue
-                buy_value = investable * weights[t]
+                buy_value = investable * initial_weights.get(t, Decimal(0))
                 units = buy_value / price
                 positions[t].units = units
                 positions[t].cost_total = buy_value
@@ -244,13 +255,21 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
             total_value = sum(values.values(), Decimal(0))
             if total_value > 0:
                 ziel_topf = next(t for t in strategy.toepfe if t.name == strategy.ziel_topf)
+                if strategy.gewichte_fn is not None:
+                    current_weights = strategy.gewichte_fn(rows, i)
+                    ziel_gewicht_effektiv = sum(
+                        (current_weights.get(t, Decimal(0)) for t in ziel_topf.sub_gewichte), Decimal(0)
+                    )
+                else:
+                    current_weights = base_weights
+                    ziel_gewicht_effektiv = strategy.ziel_gewicht
                 ziel_topf_value = sum(
                     (values.get(t, Decimal(0)) for t in ziel_topf.sub_gewichte), Decimal(0)
                 )
                 ist_gewicht = ziel_topf_value / total_value
-                abweichung_pp = abs(ist_gewicht - strategy.ziel_gewicht) * 100
+                abweichung_pp = abs(ist_gewicht - ziel_gewicht_effektiv) * 100
                 if abweichung_pp > strategy.rebalancing_schwelle_pp:
-                    if rebalance_to_targets(prices, row.date, "rebalance"):
+                    if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
                         last_rebalance_date = row.date
 
         if row.date in harvest_dates:

--- a/src/boersenspiel/scenarios.py
+++ b/src/boersenspiel/scenarios.py
@@ -5,19 +5,21 @@ gesetztem ``gewichte_fn`` - die Engine (``engine.py``) kennt keinerlei Details d
 Regeln, sie ruft ``gewichte_fn(rows, i)`` pro Kurszeile auf und rebalanciert wie gehabt
 auf die zurückgegebenen Ziel-Gewichte. Toepfe/Sub-Gewichte der Instrumente bleiben
 strukturell die der Barbell-Strategie (Topf A "Sicherheit", Topf B "Wachstum") - die
-Szenarien verschieben nur, WANN und WIE STARK zwischen beiden Töpfen umgeschichtet wird.
+Szenarien verschieben nur, WANN und WIE STARK zwischen (und innerhalb) beider Töpfe
+umgeschichtet wird. Jedes ``gewichte_fn`` liest ausschließlich ``rows[:i+1]`` (kein
+Lookahead-Bias).
 
 Dies ist ein erster Ansatz (bewusst einfache Regeln, keine Optimierung/Backtesting der
 Parameter) für drei Kategorien:
 
-1. Börsenweisheiten: "Sell in May and Go Away" (saisonal) und "Buy & Hold" (Gegenbeispiel:
-   gar keine taktische Umschichtung, nur halten - ebenfalls eine klassische Weisheit,
-   "Hin und her macht Taschen leer").
+1. Börsenweisheiten: "Sell in May and Go Away", "Buy & Hold" (Gegenbeispiel: gar keine
+   taktische Umschichtung), "Jahresendrallye" (Santa-Claus-Rally), "Antizyklisch kaufen"
+   (Buy the Dip) und "Verluste begrenzen" (Trailing-Stop je Wachstums-Instrument).
 2. Charttechnik: gleitender-Durchschnitt-Crossover (Golden Cross / Death Cross) auf dem
    MSCI-World-ETF als Trendindikator fürs Gesamtdepot.
-3. Weitere denkbare Szenarien (nicht implementiert, siehe README/PR-Beschreibung):
-   Momentum-/Relative-Stärke-Rotation zwischen den Wachstums-Instrumenten, volatilitätsbasierte
-   Aktienquote, Cost-Average-Einstieg statt Einmalanlage.
+3. Weitere Ansätze: Momentum-/Relative-Stärke-Rotation zwischen den Wachstums-
+   Instrumenten, volatilitätsbasierte Aktienquote, Cost-Average-Einstieg statt
+   Einmalanlage.
 """
 
 from __future__ import annotations
@@ -29,19 +31,52 @@ from .strategies import BARBELL_20_80, Strategy, Topf
 
 TOPF_SICHERHEIT: Topf = BARBELL_20_80.toepfe[0]
 TOPF_WACHSTUM: Topf = BARBELL_20_80.toepfe[1]
+GROWTH_TICKER: list[str] = list(TOPF_WACHSTUM.sub_gewichte.keys())
+TREND_TICKER = "EUNL"  # MSCI-World-ETF als Proxy fuer den breiten Markttrend
 
 _NORMAL_GEWICHTE: dict[str, Decimal] = BARBELL_20_80.alle_ticker_gewichte()
 
 # Ziel-Gewichte, wenn eine Regel "defensiv" auslöst: 100% Topf A (Sicherheit),
-# Topf B (Wachstum) komplett auf 0 - keine neue Töpfe/Instrumente, nur eine
+# Topf B (Wachstum) komplett auf 0 - keine neuen Töpfe/Instrumente, nur eine
 # andere Verteilung der bestehenden.
 _DEFENSIV_GEWICHTE: dict[str, Decimal] = {
     **TOPF_SICHERHEIT.sub_gewichte,
     **{t: Decimal(0) for t in TOPF_WACHSTUM.sub_gewichte},
 }
 
+# Ziel-Gewichte, wenn eine Regel "aggressiv" auslöst: Wachstum auf 95% hochgefahren,
+# Sicherheit auf 5% reduziert (Sub-Gewichte innerhalb der Töpfe bleiben unverändert).
+_AGGRESSIVE_WACHSTUMSQUOTE = Decimal("0.95")
+_AGGRESSIV_GEWICHTE: dict[str, Decimal] = {
+    **{t: g * (Decimal(1) - _AGGRESSIVE_WACHSTUMSQUOTE) for t, g in TOPF_SICHERHEIT.sub_gewichte.items()},
+    **{t: g * _AGGRESSIVE_WACHSTUMSQUOTE for t, g in TOPF_WACHSTUM.sub_gewichte.items()},
+}
 
-# --- Szenario 1: "Sell in May and Go Away" ----------------------------------
+
+def _rolling_prices(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> list[Decimal] | None:
+    """Kurse der letzten ``fenster_wochen`` Zeilen (inkl. Zeile ``i``), oder ``None``
+    falls noch nicht genug Historie vorhanden oder ein Kurs fehlt."""
+    start = i - fenster_wochen + 1
+    if start < 0:
+        return None
+    kurse = [rows[j].prices.get(ticker) for j in range(start, i + 1)]
+    if any(k is None for k in kurse):
+        return None
+    return kurse  # type: ignore[return-value]
+
+
+def _sma(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> Decimal | None:
+    kurse = _rolling_prices(rows, i, ticker, fenster_wochen)
+    if kurse is None:
+        return None
+    return sum(kurse, Decimal(0)) / Decimal(fenster_wochen)
+
+
+# =====================================================================================
+# 1. Börsenweisheiten
+# =====================================================================================
+
+# --- 1a: "Sell in May and Go Away" ---------------------------------------------------
 #
 # Klassische Börsenweisheit: Aktien im Sommerhalbjahr meiden ("...and come back
 # on St. Leger's Day", Mitte September) - hier vereinfacht als Mai bis
@@ -70,7 +105,7 @@ SELL_IN_MAY = Strategy(
 )
 
 
-# --- Szenario 1b: "Buy & Hold" -----------------------------------------------
+# --- 1b: "Buy & Hold" -----------------------------------------------------------------
 #
 # Gegenstück zur taktischen Umschichtung: klassische Weisheit "Hin und her
 # macht Taschen leer" - Anfangsallokation wird nie aktiv rebalanciert (die
@@ -89,27 +124,128 @@ BUY_AND_HOLD = Strategy(
 )
 
 
-# --- Szenario 2: Charttechnik - gleitender-Durchschnitt-Crossover -----------
+# --- 1c: "Jahresendrallye" (Santa-Claus-Rally) -----------------------------------------
 #
+# Börsenweisheit: die Aktienmärkte tendieren zum Jahreswechsel (Dezember bis
+# Anfang Januar) überdurchschnittlich stark zu steigen ("Santa Claus Rally").
+# In diesem Fenster wird die Wachstumsquote von 80% auf 95% hochgefahren,
+# sonst gilt die normale Barbell-Verteilung.
+
+_JAHRESENDRALLYE_MONATE = {12, 1}
+
+
+def santa_claus_rally_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    monat = rows[i].date.month
+    if monat in _JAHRESENDRALLYE_MONATE:
+        return _AGGRESSIV_GEWICHTE
+    return _NORMAL_GEWICHTE
+
+
+SANTA_CLAUS_RALLY = Strategy(
+    name="Börsenweisheit: Jahresendrallye",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=santa_claus_rally_gewichte,
+)
+
+
+# --- 1d: "Antizyklisch kaufen" (Buy the Dip) -------------------------------------------
+#
+# Börsenweisheit ("kaufe, wenn die Kanonen donnern" / Rothschild): nach einem
+# deutlichen Kursrückgang antizyklisch stärker investieren statt zu verkaufen.
+# Liegt der MSCI-World-ETF mehr als BUY_THE_DIP_SCHWELLE unter seinem
+# gleitenden Höchststand der letzten BUY_THE_DIP_FENSTER_WOCHEN Wochen, wird
+# die Wachstumsquote auf 95% hochgefahren, sonst gilt die normale Verteilung.
+
+BUY_THE_DIP_FENSTER_WOCHEN = 20
+BUY_THE_DIP_SCHWELLE = Decimal("0.10")  # 10% Rückgang vom Rolling-Hoch
+
+
+def buy_the_dip_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    kurse = _rolling_prices(rows, i, TREND_TICKER, BUY_THE_DIP_FENSTER_WOCHEN)
+    if kurse is None:
+        return _NORMAL_GEWICHTE
+    rolling_hoch = max(kurse)
+    aktueller_kurs = kurse[-1]
+    if rolling_hoch <= 0:
+        return _NORMAL_GEWICHTE
+    ruckgang = (rolling_hoch - aktueller_kurs) / rolling_hoch
+    if ruckgang > BUY_THE_DIP_SCHWELLE:
+        return _AGGRESSIV_GEWICHTE
+    return _NORMAL_GEWICHTE
+
+
+BUY_THE_DIP = Strategy(
+    name="Börsenweisheit: Antizyklisch kaufen",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=buy_the_dip_gewichte,
+)
+
+
+# --- 1e: "Verluste begrenzen" (Trailing-Stop je Wachstums-Instrument) ------------------
+#
+# Börsenweisheit "cut your losses short": fällt ein einzelnes Wachstums-
+# Instrument mehr als CUT_LOSSES_SCHWELLE unter sein Rolling-Hoch der letzten
+# CUT_LOSSES_FENSTER_WOCHEN Wochen, wird NUR dieses Instrument auf 0% gesetzt -
+# das freiwerdende Gewicht fließt anteilig in den Sicherheits-Topf. Andere
+# Wachstums-Instrumente bleiben unangetastet (im Gegensatz zu den
+# marktweiten Szenarien oben, die immer das ganze Depot umschichten).
+
+CUT_LOSSES_FENSTER_WOCHEN = 20
+CUT_LOSSES_SCHWELLE = Decimal("0.15")  # 15% Rückgang vom eigenen Rolling-Hoch
+
+
+def cut_losses_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    gewichte = dict(_NORMAL_GEWICHTE)
+    freigewordenes_gewicht = Decimal(0)
+    for ticker in GROWTH_TICKER:
+        kurse = _rolling_prices(rows, i, ticker, CUT_LOSSES_FENSTER_WOCHEN)
+        if kurse is None:
+            continue
+        rolling_hoch = max(kurse)
+        aktueller_kurs = kurse[-1]
+        if rolling_hoch <= 0:
+            continue
+        ruckgang = (rolling_hoch - aktueller_kurs) / rolling_hoch
+        if ruckgang > CUT_LOSSES_SCHWELLE:
+            freigewordenes_gewicht += gewichte[ticker]
+            gewichte[ticker] = Decimal(0)
+    if freigewordenes_gewicht > 0:
+        for ticker, sub_gewicht in TOPF_SICHERHEIT.sub_gewichte.items():
+            gewichte[ticker] = gewichte.get(ticker, Decimal(0)) + freigewordenes_gewicht * sub_gewicht
+    return gewichte
+
+
+CUT_LOSSES = Strategy(
+    name="Börsenweisheit: Verluste begrenzen",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=cut_losses_gewichte,
+)
+
+
+# =====================================================================================
+# 2. Charttechnik
+# =====================================================================================
+
 # Golden Cross / Death Cross auf dem MSCI-World-ETF (EUNL) als Proxy für den
 # breiten Markttrend: kurzer SMA unter langem SMA ("Death Cross") -> defensiv
 # (100% Topf A), sonst ("Golden Cross"/normal) -> reguläre Barbell-Gewichte.
 # Fensterlängen sind an wöchentliche Kursdaten angepasst (10/40 Wochen statt
 # der bei Tagesdaten üblichen 50/200 Tage).
 
-TREND_TICKER = "EUNL"
 SMA_KURZ_WOCHEN = 10
 SMA_LANG_WOCHEN = 40
-
-
-def _sma(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> Decimal | None:
-    start = i - fenster_wochen + 1
-    if start < 0:
-        return None
-    kurse = [rows[j].prices.get(ticker) for j in range(start, i + 1)]
-    if any(k is None for k in kurse):
-        return None
-    return sum(kurse, Decimal(0)) / Decimal(fenster_wochen)
 
 
 def chart_sma_crossover_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
@@ -134,6 +270,169 @@ CHART_SMA_CROSSOVER = Strategy(
 )
 
 
-SCENARIOS: list[Strategy] = [SELL_IN_MAY, BUY_AND_HOLD, CHART_SMA_CROSSOVER]
+# =====================================================================================
+# 3. Weitere Ansätze
+# =====================================================================================
+
+# --- 3a: Momentum-/Relative-Stärke-Rotation --------------------------------------------
+#
+# Innerhalb des Wachstums-Topfs (Gesamtgewicht bleibt bei 80%) werden nur die
+# MOMENTUM_TOP_N Instrumente mit der höchsten Trailing-Rendite der letzten
+# MOMENTUM_FENSTER_WOCHEN Wochen gleichgewichtet gehalten, die übrigen auf 0%
+# gesetzt. Der Sicherheits-Topf bleibt unverändert bei den normalen Barbell-
+# Gewichten.
+
+MOMENTUM_FENSTER_WOCHEN = 12
+MOMENTUM_TOP_N = 2
+
+
+def _trailing_return(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> Decimal | None:
+    start = i - fenster_wochen
+    if start < 0:
+        return None
+    kurs_start = rows[start].prices.get(ticker)
+    kurs_aktuell = rows[i].prices.get(ticker)
+    if kurs_start is None or kurs_aktuell is None or kurs_start == 0:
+        return None
+    return (kurs_aktuell - kurs_start) / kurs_start
+
+
+def momentum_rotation_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    renditen = {}
+    for ticker in GROWTH_TICKER:
+        rendite = _trailing_return(rows, i, ticker, MOMENTUM_FENSTER_WOCHEN)
+        if rendite is not None:
+            renditen[ticker] = rendite
+    if len(renditen) < MOMENTUM_TOP_N:
+        # Noch nicht genug Historie fuer alle Instrumente -> regulaer investiert.
+        return _NORMAL_GEWICHTE
+
+    rangliste = sorted(renditen.items(), key=lambda kv: kv[1], reverse=True)
+    top_ticker = {ticker for ticker, _ in rangliste[:MOMENTUM_TOP_N]}
+    anteil_je_top_ticker = TOPF_WACHSTUM.gewicht_gesamt / Decimal(len(top_ticker))
+
+    gewichte = dict(_NORMAL_GEWICHTE)  # Sicherheits-Topf unveraendert
+    for ticker in GROWTH_TICKER:
+        gewichte[ticker] = anteil_je_top_ticker if ticker in top_ticker else Decimal(0)
+    return gewichte
+
+
+MOMENTUM_ROTATION = Strategy(
+    name="Momentum: Relative-Stärke-Rotation",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=momentum_rotation_gewichte,
+)
+
+
+# --- 3b: Volatilitätsbasierte Aktienquote ----------------------------------------------
+#
+# Die Wachstumsquote (normal 80%) wird abhängig von der realisierten Volatilität
+# (Standardabweichung der wöchentlichen Renditen der letzten
+# VOLATILITAET_FENSTER_WOCHEN Wochen) des MSCI-World-ETF linear zwischen
+# WACHSTUMSQUOTE_MIN (bei hoher Volatilität) und WACHSTUMSQUOTE_MAX (bei
+# niedriger Volatilität) skaliert - klassisches Risk-Parity-/Vol-Targeting-Prinzip.
+
+VOLATILITAET_FENSTER_WOCHEN = 12
+VOLATILITAET_NIEDRIG = Decimal("0.015")  # 1.5% woechentliche Standardabweichung
+VOLATILITAET_HOCH = Decimal("0.05")  # 5% woechentliche Standardabweichung
+WACHSTUMSQUOTE_MAX = Decimal("0.90")
+WACHSTUMSQUOTE_MIN = Decimal("0.50")
+
+
+def _weekly_returns(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> list[Decimal] | None:
+    kurse = _rolling_prices(rows, i, ticker, fenster_wochen + 1)
+    if kurse is None:
+        return None
+    return [(kurse[j] - kurse[j - 1]) / kurse[j - 1] for j in range(1, len(kurse)) if kurse[j - 1] != 0]
+
+
+def _volatility(rendite: list[Decimal]) -> Decimal | None:
+    n = len(rendite)
+    if n == 0:
+        return None
+    mittelwert = sum(rendite, Decimal(0)) / Decimal(n)
+    varianz = sum(((r - mittelwert) ** 2 for r in rendite), Decimal(0)) / Decimal(n)
+    return varianz.sqrt()
+
+
+def volatility_target_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    rendite = _weekly_returns(rows, i, TREND_TICKER, VOLATILITAET_FENSTER_WOCHEN)
+    volatilitaet = _volatility(rendite) if rendite is not None else None
+    if volatilitaet is None:
+        return _NORMAL_GEWICHTE
+
+    if volatilitaet <= VOLATILITAET_NIEDRIG:
+        wachstumsquote = WACHSTUMSQUOTE_MAX
+    elif volatilitaet >= VOLATILITAET_HOCH:
+        wachstumsquote = WACHSTUMSQUOTE_MIN
+    else:
+        anteil = (volatilitaet - VOLATILITAET_NIEDRIG) / (VOLATILITAET_HOCH - VOLATILITAET_NIEDRIG)
+        wachstumsquote = WACHSTUMSQUOTE_MAX - anteil * (WACHSTUMSQUOTE_MAX - WACHSTUMSQUOTE_MIN)
+    sicherheitsquote = Decimal(1) - wachstumsquote
+
+    gewichte = {t: sub * sicherheitsquote for t, sub in TOPF_SICHERHEIT.sub_gewichte.items()}
+    gewichte.update({t: sub * wachstumsquote for t, sub in TOPF_WACHSTUM.sub_gewichte.items()})
+    return gewichte
+
+
+VOLATILITY_TARGET = Strategy(
+    name="Volatilitätsbasierte Aktienquote",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=volatility_target_gewichte,
+)
+
+
+# --- 3c: Cost-Average-Einstieg (statt Einmalanlage) -------------------------------------
+#
+# Statt das Startkapital sofort komplett zu investieren, wird die Wachstumsquote
+# über die ersten COST_AVERAGE_FENSTER_WOCHEN Wochen linear von 0% (alles im
+# Sicherheits-Topf "geparkt") auf die normale Barbell-Verteilung hochgefahren -
+# eine Annäherung an ratierliches Investieren statt einer Einmalanlage
+# ("Cost-Average-Effekt"). Ab Woche COST_AVERAGE_FENSTER_WOCHEN gilt die normale
+# Verteilung dauerhaft.
+
+COST_AVERAGE_FENSTER_WOCHEN = 10
+
+
+def cost_average_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    anteil = min(Decimal(i) / Decimal(COST_AVERAGE_FENSTER_WOCHEN), Decimal(1))
+    if anteil >= 1:
+        return _NORMAL_GEWICHTE
+    return {
+        t: _DEFENSIV_GEWICHTE.get(t, Decimal(0)) * (Decimal(1) - anteil) + _NORMAL_GEWICHTE.get(t, Decimal(0)) * anteil
+        for t in _NORMAL_GEWICHTE
+    }
+
+
+COST_AVERAGE_ENTRY = Strategy(
+    name="Cost-Average-Einstieg (10 Wochen)",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("3"),
+    gewichte_fn=cost_average_gewichte,
+)
+
+
+SCENARIOS: list[Strategy] = [
+    SELL_IN_MAY,
+    BUY_AND_HOLD,
+    SANTA_CLAUS_RALLY,
+    BUY_THE_DIP,
+    CUT_LOSSES,
+    CHART_SMA_CROSSOVER,
+    MOMENTUM_ROTATION,
+    VOLATILITY_TARGET,
+    COST_AVERAGE_ENTRY,
+]
 
 SCENARIOS_BY_NAME: dict[str, Strategy] = {s.name: s for s in SCENARIOS}

--- a/src/boersenspiel/scenarios.py
+++ b/src/boersenspiel/scenarios.py
@@ -1,0 +1,139 @@
+"""Auswertungs-Szenarien: zeitabhängige Handelsregeln statt konstanter Barbell-Gewichte.
+
+Jedes Szenario ist eine ganz normale ``Strategy`` (aus ``strategies.py``), nur mit
+gesetztem ``gewichte_fn`` - die Engine (``engine.py``) kennt keinerlei Details dieser
+Regeln, sie ruft ``gewichte_fn(rows, i)`` pro Kurszeile auf und rebalanciert wie gehabt
+auf die zurückgegebenen Ziel-Gewichte. Toepfe/Sub-Gewichte der Instrumente bleiben
+strukturell die der Barbell-Strategie (Topf A "Sicherheit", Topf B "Wachstum") - die
+Szenarien verschieben nur, WANN und WIE STARK zwischen beiden Töpfen umgeschichtet wird.
+
+Dies ist ein erster Ansatz (bewusst einfache Regeln, keine Optimierung/Backtesting der
+Parameter) für drei Kategorien:
+
+1. Börsenweisheiten: "Sell in May and Go Away" (saisonal) und "Buy & Hold" (Gegenbeispiel:
+   gar keine taktische Umschichtung, nur halten - ebenfalls eine klassische Weisheit,
+   "Hin und her macht Taschen leer").
+2. Charttechnik: gleitender-Durchschnitt-Crossover (Golden Cross / Death Cross) auf dem
+   MSCI-World-ETF als Trendindikator fürs Gesamtdepot.
+3. Weitere denkbare Szenarien (nicht implementiert, siehe README/PR-Beschreibung):
+   Momentum-/Relative-Stärke-Rotation zwischen den Wachstums-Instrumenten, volatilitätsbasierte
+   Aktienquote, Cost-Average-Einstieg statt Einmalanlage.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .history_store import PriceRow
+from .strategies import BARBELL_20_80, Strategy, Topf
+
+TOPF_SICHERHEIT: Topf = BARBELL_20_80.toepfe[0]
+TOPF_WACHSTUM: Topf = BARBELL_20_80.toepfe[1]
+
+_NORMAL_GEWICHTE: dict[str, Decimal] = BARBELL_20_80.alle_ticker_gewichte()
+
+# Ziel-Gewichte, wenn eine Regel "defensiv" auslöst: 100% Topf A (Sicherheit),
+# Topf B (Wachstum) komplett auf 0 - keine neue Töpfe/Instrumente, nur eine
+# andere Verteilung der bestehenden.
+_DEFENSIV_GEWICHTE: dict[str, Decimal] = {
+    **TOPF_SICHERHEIT.sub_gewichte,
+    **{t: Decimal(0) for t in TOPF_WACHSTUM.sub_gewichte},
+}
+
+
+# --- Szenario 1: "Sell in May and Go Away" ----------------------------------
+#
+# Klassische Börsenweisheit: Aktien im Sommerhalbjahr meiden ("...and come back
+# on St. Leger's Day", Mitte September) - hier vereinfacht als Mai bis
+# September (inklusive) defensiv, Oktober bis April normal investiert.
+
+_SELL_IN_MAY_MONATE = {5, 6, 7, 8, 9}
+
+
+def sell_in_may_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    monat = rows[i].date.month
+    if monat in _SELL_IN_MAY_MONATE:
+        return _DEFENSIV_GEWICHTE
+    return _NORMAL_GEWICHTE
+
+
+SELL_IN_MAY = Strategy(
+    name="Börsenweisheit: Sell in May",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    # Kleinere Schwelle als beim reinen Rebalancing, damit der saisonale
+    # Regimewechsel (Mai <-> Oktober) zuverlässig eine Umschichtung auslöst.
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=sell_in_may_gewichte,
+)
+
+
+# --- Szenario 1b: "Buy & Hold" -----------------------------------------------
+#
+# Gegenstück zur taktischen Umschichtung: klassische Weisheit "Hin und her
+# macht Taschen leer" - Anfangsallokation wird nie aktiv rebalanciert (die
+# Rebalancing-Schwelle liegt oberhalb jeder erreichbaren Abweichung). Der
+# Dezember-Verlustverrechnungs-Mechanismus (steuerliche Optimierung, keine
+# Umschichtung der Zielgewichte) bleibt wie bei den anderen Strategien aktiv.
+
+BUY_AND_HOLD = Strategy(
+    name="Börsenweisheit: Buy & Hold",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("1000"),
+    gewichte_fn=None,
+)
+
+
+# --- Szenario 2: Charttechnik - gleitender-Durchschnitt-Crossover -----------
+#
+# Golden Cross / Death Cross auf dem MSCI-World-ETF (EUNL) als Proxy für den
+# breiten Markttrend: kurzer SMA unter langem SMA ("Death Cross") -> defensiv
+# (100% Topf A), sonst ("Golden Cross"/normal) -> reguläre Barbell-Gewichte.
+# Fensterlängen sind an wöchentliche Kursdaten angepasst (10/40 Wochen statt
+# der bei Tagesdaten üblichen 50/200 Tage).
+
+TREND_TICKER = "EUNL"
+SMA_KURZ_WOCHEN = 10
+SMA_LANG_WOCHEN = 40
+
+
+def _sma(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> Decimal | None:
+    start = i - fenster_wochen + 1
+    if start < 0:
+        return None
+    kurse = [rows[j].prices.get(ticker) for j in range(start, i + 1)]
+    if any(k is None for k in kurse):
+        return None
+    return sum(kurse, Decimal(0)) / Decimal(fenster_wochen)
+
+
+def chart_sma_crossover_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    sma_kurz = _sma(rows, i, TREND_TICKER, SMA_KURZ_WOCHEN)
+    sma_lang = _sma(rows, i, TREND_TICKER, SMA_LANG_WOCHEN)
+    if sma_kurz is None or sma_lang is None:
+        # Noch nicht genug Historie fuer den langen SMA -> regulaer investiert.
+        return _NORMAL_GEWICHTE
+    if sma_kurz < sma_lang:
+        return _DEFENSIV_GEWICHTE
+    return _NORMAL_GEWICHTE
+
+
+CHART_SMA_CROSSOVER = Strategy(
+    name="Charttechnik: SMA-Crossover (10/40 Wochen)",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=chart_sma_crossover_gewichte,
+)
+
+
+SCENARIOS: list[Strategy] = [SELL_IN_MAY, BUY_AND_HOLD, CHART_SMA_CROSSOVER]
+
+SCENARIOS_BY_NAME: dict[str, Strategy] = {s.name: s for s in SCENARIOS}

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -14,6 +14,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from decimal import Decimal
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from .history_store import PriceRow
 
 
 @dataclass(frozen=True)
@@ -36,6 +40,14 @@ class Strategy:
     ziel_topf: str  # Name des Topfs, dessen Gewicht am Gesamtdepot überwacht wird (Rebalancing-Trigger)
     ziel_gewicht: Decimal  # Zielgewicht dieses Topfs, z. B. Decimal("0.20")
     rebalancing_schwelle_pp: Decimal  # Abweichung in Prozentpunkten, ab der rebalanciert wird
+    # Optional: macht die Ziel-Gewichte zeitabhängig statt konstant (z. B. saisonale
+    # Regeln oder charttechnische Signale wie "Sell in May" / SMA-Crossover). Bekommt
+    # die komplette (chronologisch sortierte) Kurshistorie plus den Index der aktuellen
+    # Zeile und liefert die Ziel-Gewichte am Gesamtdepot für GENAU diese Zeile - darf
+    # dabei nur auf rows[:i+1] zugreifen, um kein "Blick in die Zukunft" (Lookahead-Bias)
+    # einzubauen. None bedeutet: konstante Gewichte aus den toepfe/sub_gewichte (Barbell-
+    # Rebalancing-Verhalten, wie bisher).
+    gewichte_fn: Callable[[list["PriceRow"], int], dict[str, Decimal]] | None = None
 
     def alle_ticker_gewichte(self) -> dict[str, Decimal]:
         """Ziel-Gewicht jedes Instruments am Gesamtdepot."""

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,172 @@
+"""Tests für zeitabhängige Auswertungs-Szenarien (``strategies.gewichte_fn``).
+
+Erster Block: eine handgerechnete Zwei-Töpfe-Strategie mit einer einfachen
+monatsabhängigen Regel, um die generische Engine-Mechanik (``weights_at``/
+``gewichte_fn``) exakt zu verifizieren - analog zu ``test_engine.py``s
+SIMPLE_STRATEGY, aber mit dynamischen statt konstanten Ziel-Gewichten.
+
+Zweiter Block: Smoke-Tests für die konkreten Szenarien aus ``scenarios.py``
+(Sell in May, Buy & Hold, SMA-Crossover) gegen die reale Barbell-Instrumente-
+Struktur.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from boersenspiel.engine import simulate
+from boersenspiel.history_store import PriceRow
+from boersenspiel.scenarios import (
+    BUY_AND_HOLD,
+    CHART_SMA_CROSSOVER,
+    SELL_IN_MAY,
+    chart_sma_crossover_gewichte,
+    sell_in_may_gewichte,
+)
+from boersenspiel.strategies import BARBELL_20_80, Strategy, Topf
+
+
+def _monats_regel(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    """Volles Gewicht auf T1 im Mai, sonst 50/50 - fuer handgerechnete Werte."""
+    if rows[i].date.month == 5:
+        return {"T1": Decimal("1"), "T2": Decimal("0")}
+    return {"T1": Decimal("0.5"), "T2": Decimal("0.5")}
+
+
+DYNAMIC_STRATEGY = Strategy(
+    name="Test-Dynamisch",
+    startkapital=Decimal("1002"),
+    toepfe=[
+        Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T1": Decimal("1")}),
+        Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T2": Decimal("1")}),
+    ],
+    ziel_topf="TopfX",
+    ziel_gewicht=Decimal("0.5"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=_monats_regel,
+)
+
+
+def test_dynamic_gewichte_fn_drives_initial_buy_and_rebalance():
+    rows = [
+        # Initialkauf im April -> Regel liefert 50/50, wie bei einer konstanten
+        # Strategie: 1002 - 2*1 Gebuehr = 1000 investierbar, je 500 -> 5 Einheiten
+        # zu Kurs 100.
+        PriceRow(date(2024, 4, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+        # Mai: Regel schaltet auf 100% T1 / 0% T2 um, Kurse unveraendert (100/100)
+        # -> Ist-Gewicht TopfX ist 50%, Ziel jetzt 100% -> Abweichung 50pp > 5pp
+        # -> volles Rebalancing in T1.
+        PriceRow(date(2024, 5, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+    ]
+    result = simulate(rows, DYNAMIC_STRATEGY)
+
+    assert result.holdings["T2"] == Decimal("0")
+    # Rebalancing-Diffs werden gegen den Depotwert VOR dem Trade berechnet (500/500):
+    # T2 komplett verkauft (Ziel 0%, -500), T1 um +500 auf Zielwert 1000 aufgestockt
+    # -> 5 (Bestand) + 500/100 (Zukauf) = 10 Einheiten T1.
+    assert result.holdings["T1"] == Decimal("10")
+    assert result.last_rebalance_date == date(2024, 5, 1)
+
+
+def test_dynamic_gewichte_fn_no_rebalance_when_regime_unchanged():
+    rows = [
+        PriceRow(date(2024, 4, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+        # Juni: Regel liefert wieder 50/50 (wie beim Initialkauf) und Kurse sind
+        # unveraendert -> keine Abweichung -> kein Rebalancing.
+        PriceRow(date(2024, 6, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+    ]
+    result = simulate(rows, DYNAMIC_STRATEGY)
+    assert result.last_rebalance_date is None
+    assert result.holdings["T1"] == Decimal("5")
+    assert result.holdings["T2"] == Decimal("5")
+
+
+def test_static_strategy_unaffected_by_gewichte_fn_default():
+    """Ohne gewichte_fn (None) ist das Verhalten identisch zur bisherigen
+    ausschließlich konstanten Gewichten - Regressionsschutz für BARBELL_20_80."""
+    rows = [
+        PriceRow(
+            date(2024, 1, 1),
+            {
+                "EUNL": Decimal("80"),
+                "EUNA": Decimal("5"),
+                "4GLD": Decimal("60"),
+                "LYMS": Decimal("20"),
+                "SEMI": Decimal("45"),
+                "EIMI": Decimal("30"),
+                "BTC-EUR": Decimal("40000"),
+            },
+        ),
+    ]
+    result = simulate(rows, BARBELL_20_80)
+    assert result.strategy_name == "Barbell 20/80"
+    assert all(units > 0 for units in result.holdings.values())
+
+
+def _sample_rows() -> list[PriceRow]:
+    prices_by_ticker = {
+        "EUNL": Decimal("80"),
+        "EUNA": Decimal("5"),
+        "4GLD": Decimal("60"),
+        "LYMS": Decimal("20"),
+        "SEMI": Decimal("45"),
+        "EIMI": Decimal("30"),
+        "BTC-EUR": Decimal("40000"),
+    }
+    rows: list[PriceRow] = []
+    d = date(2024, 1, 1)
+    for week in range(60):
+        prices = {t: p + Decimal(week) for t, p in prices_by_ticker.items()}
+        rows.append(PriceRow(date.fromordinal(d.toordinal() + week * 7), prices))
+    return rows
+
+
+def test_sell_in_may_shifts_fully_defensive_in_summer_months():
+    rows = _sample_rows()
+    mai_row = next(r for r in rows if r.date.month == 5)
+    i = rows.index(mai_row)
+    gewichte = sell_in_may_gewichte(rows, i)
+    assert gewichte["LYMS"] == Decimal("0")
+    assert gewichte["SEMI"] == Decimal("0")
+    assert gewichte["EIMI"] == Decimal("0")
+    assert gewichte["BTC-EUR"] == Decimal("0")
+    assert gewichte["EUNL"] == Decimal("0.50")
+
+    dezember_row = next(r for r in rows if r.date.month == 12)
+    j = rows.index(dezember_row)
+    normal = sell_in_may_gewichte(rows, j)
+    assert normal["LYMS"] == Decimal("0.80") * Decimal("0.40")
+
+
+def test_sell_in_may_scenario_runs_end_to_end():
+    result = simulate(_sample_rows(), SELL_IN_MAY)
+    assert result.strategy_name == "Börsenweisheit: Sell in May"
+    last_point = result.value_history[-1]
+    assert last_point.total_value > 0
+    total_weight = sum(last_point.ticker_weights.values())
+    assert abs(total_weight - Decimal("1")) < Decimal("0.0001")
+    # Im Sommer sollten Trades stattgefunden haben (Umschichtung in den Sicherheits-Topf).
+    assert len(result.trades) > len(BARBELL_20_80.alle_ticker_gewichte())
+
+
+def test_buy_and_hold_never_rebalances():
+    result = simulate(_sample_rows(), BUY_AND_HOLD)
+    assert result.last_rebalance_date is None
+    reasons = {t.reason for t in result.trades}
+    assert reasons <= {"initial_buy", "december_harvest", "december_harvest_rebuy"}
+
+
+def test_chart_sma_crossover_defaults_to_normal_weights_without_enough_history():
+    rows = _sample_rows()[:5]
+    gewichte = chart_sma_crossover_gewichte(rows, 4)
+    # Ticker-Gewicht am Gesamtdepot = Topf-A-Gewicht (0.20) * Sub-Gewicht (0.50).
+    assert gewichte["EUNL"] == Decimal("0.10")
+
+
+def test_chart_sma_crossover_scenario_runs_end_to_end():
+    result = simulate(_sample_rows(), CHART_SMA_CROSSOVER)
+    assert result.strategy_name == "Charttechnik: SMA-Crossover (10/40 Wochen)"
+    last_point = result.value_history[-1]
+    total_weight = sum(last_point.ticker_weights.values())
+    assert abs(total_weight - Decimal("1")) < Decimal("0.0001")

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -19,10 +19,22 @@ from boersenspiel.engine import simulate
 from boersenspiel.history_store import PriceRow
 from boersenspiel.scenarios import (
     BUY_AND_HOLD,
+    BUY_THE_DIP,
     CHART_SMA_CROSSOVER,
+    COST_AVERAGE_ENTRY,
+    CUT_LOSSES,
+    MOMENTUM_ROTATION,
+    SANTA_CLAUS_RALLY,
     SELL_IN_MAY,
+    VOLATILITY_TARGET,
+    buy_the_dip_gewichte,
     chart_sma_crossover_gewichte,
+    cost_average_gewichte,
+    cut_losses_gewichte,
+    momentum_rotation_gewichte,
+    santa_claus_rally_gewichte,
     sell_in_may_gewichte,
+    volatility_target_gewichte,
 )
 from boersenspiel.strategies import BARBELL_20_80, Strategy, Topf
 
@@ -170,3 +182,229 @@ def test_chart_sma_crossover_scenario_runs_end_to_end():
     last_point = result.value_history[-1]
     total_weight = sum(last_point.ticker_weights.values())
     assert abs(total_weight - Decimal("1")) < Decimal("0.0001")
+
+
+# --- Jahresendrallye (Santa-Claus-Rally) -------------------------------------------
+
+
+def test_santa_claus_rally_switches_aggressive_in_december_and_january():
+    rows = _sample_rows()
+    dezember_row = next(r for r in rows if r.date.month == 12)
+    i = rows.index(dezember_row)
+    gewichte = santa_claus_rally_gewichte(rows, i)
+    # 95% Wachstum, gleichmaessig auf die Sub-Gewichte des Wachstums-Topfs verteilt.
+    assert gewichte["LYMS"] == Decimal("0.95") * Decimal("0.40")
+    assert gewichte["EUNL"] == Decimal("0.05") * Decimal("0.50")
+
+    juni_row = next(r for r in rows if r.date.month == 6)
+    j = rows.index(juni_row)
+    normal = santa_claus_rally_gewichte(rows, j)
+    assert normal["LYMS"] == Decimal("0.80") * Decimal("0.40")
+
+
+def test_santa_claus_rally_scenario_runs_end_to_end():
+    result = simulate(_sample_rows(), SANTA_CLAUS_RALLY)
+    last_point = result.value_history[-1]
+    assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")
+
+
+# --- Antizyklisch kaufen (Buy the Dip) ----------------------------------------------
+
+
+def _rows_with_dip() -> list[PriceRow]:
+    """EUNL faellt in Woche 20 um mehr als 10% unter sein 20-Wochen-Hoch."""
+    rows = []
+    d = date(2024, 1, 1)
+    for week in range(25):
+        eunl = Decimal("100") if week < 20 else Decimal("85")
+        rows.append(
+            PriceRow(
+                date.fromordinal(d.toordinal() + week * 7),
+                {
+                    "EUNL": eunl,
+                    "EUNA": Decimal("5"),
+                    "4GLD": Decimal("60"),
+                    "LYMS": Decimal("20"),
+                    "SEMI": Decimal("45"),
+                    "EIMI": Decimal("30"),
+                    "BTC-EUR": Decimal("40000"),
+                },
+            )
+        )
+    return rows
+
+
+def test_buy_the_dip_switches_aggressive_after_drawdown():
+    rows = _rows_with_dip()
+    gewichte_vor_dip = buy_the_dip_gewichte(rows, 19)
+    assert gewichte_vor_dip["LYMS"] == Decimal("0.80") * Decimal("0.40")
+
+    gewichte_nach_dip = buy_the_dip_gewichte(rows, 20)
+    assert gewichte_nach_dip["LYMS"] == Decimal("0.95") * Decimal("0.40")
+
+
+def test_buy_the_dip_scenario_runs_end_to_end():
+    result = simulate(_rows_with_dip(), BUY_THE_DIP)
+    last_point = result.value_history[-1]
+    assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")
+
+
+# --- Verluste begrenzen (Trailing-Stop je Wachstums-Instrument) ---------------------
+
+
+def _rows_with_single_loser() -> list[PriceRow]:
+    """LYMS faellt um mehr als 15% unter sein Hoch, SEMI/EIMI/BTC-EUR bleiben flach."""
+    rows = []
+    d = date(2024, 1, 1)
+    for week in range(25):
+        lyms = Decimal("20") if week < 20 else Decimal("16")
+        rows.append(
+            PriceRow(
+                date.fromordinal(d.toordinal() + week * 7),
+                {
+                    "EUNL": Decimal("80"),
+                    "EUNA": Decimal("5"),
+                    "4GLD": Decimal("60"),
+                    "LYMS": lyms,
+                    "SEMI": Decimal("45"),
+                    "EIMI": Decimal("30"),
+                    "BTC-EUR": Decimal("40000"),
+                },
+            )
+        )
+    return rows
+
+
+def test_cut_losses_zeroes_only_the_losing_instrument():
+    rows = _rows_with_single_loser()
+    gewichte = cut_losses_gewichte(rows, 20)
+    assert gewichte["LYMS"] == Decimal("0")
+    # SEMI (anderes Wachstums-Instrument) bleibt unveraendert bei seinem normalen Gewicht.
+    assert gewichte["SEMI"] == Decimal("0.80") * Decimal("0.30")
+    # Das freigewordene LYMS-Gewicht (0.80*0.40=0.32) fliesst anteilig in den
+    # Sicherheits-Topf, EUNL bekommt davon 50%.
+    erwartetes_eunl_gewicht = Decimal("0.20") * Decimal("0.50") + Decimal("0.32") * Decimal("0.50")
+    assert gewichte["EUNL"] == erwartetes_eunl_gewicht
+
+
+def test_cut_losses_scenario_runs_end_to_end():
+    result = simulate(_rows_with_single_loser(), CUT_LOSSES)
+    last_point = result.value_history[-1]
+    assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")
+
+
+# --- Momentum-/Relative-Stärke-Rotation ----------------------------------------------
+
+
+def _rows_with_momentum_spread() -> list[PriceRow]:
+    """LYMS und BTC-EUR steigen ueber 12 Wochen deutlich, SEMI/EIMI bleiben flach."""
+    rows = []
+    d = date(2024, 1, 1)
+    for week in range(15):
+        rows.append(
+            PriceRow(
+                date.fromordinal(d.toordinal() + week * 7),
+                {
+                    "EUNL": Decimal("80"),
+                    "EUNA": Decimal("5"),
+                    "4GLD": Decimal("60"),
+                    "LYMS": Decimal("20") + Decimal(week) * Decimal("2"),
+                    "SEMI": Decimal("45"),
+                    "EIMI": Decimal("30"),
+                    "BTC-EUR": Decimal("40000") + Decimal(week) * Decimal("2000"),
+                },
+            )
+        )
+    return rows
+
+
+def test_momentum_rotation_overweights_top_performers():
+    rows = _rows_with_momentum_spread()
+    gewichte = momentum_rotation_gewichte(rows, 12)
+    assert gewichte["LYMS"] == Decimal("0.80") / 2
+    assert gewichte["BTC-EUR"] == Decimal("0.80") / 2
+    assert gewichte["SEMI"] == Decimal("0")
+    assert gewichte["EIMI"] == Decimal("0")
+    # Sicherheits-Topf bleibt bei den normalen Barbell-Gewichten.
+    assert gewichte["EUNL"] == Decimal("0.20") * Decimal("0.50")
+
+
+def test_momentum_rotation_falls_back_to_normal_without_enough_history():
+    rows = _rows_with_momentum_spread()[:5]
+    gewichte = momentum_rotation_gewichte(rows, 4)
+    assert gewichte["LYMS"] == Decimal("0.80") * Decimal("0.40")
+
+
+def test_momentum_rotation_scenario_runs_end_to_end():
+    result = simulate(_rows_with_momentum_spread(), MOMENTUM_ROTATION)
+    last_point = result.value_history[-1]
+    assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")
+
+
+# --- Volatilitätsbasierte Aktienquote --------------------------------------------------
+
+
+def _rows_with_high_volatility() -> list[PriceRow]:
+    """EUNL schwankt stark zwischen 70 und 100 -> hohe woechentliche Volatilitaet."""
+    rows = []
+    d = date(2024, 1, 1)
+    for week in range(15):
+        eunl = Decimal("100") if week % 2 == 0 else Decimal("70")
+        rows.append(
+            PriceRow(
+                date.fromordinal(d.toordinal() + week * 7),
+                {
+                    "EUNL": eunl,
+                    "EUNA": Decimal("5"),
+                    "4GLD": Decimal("60"),
+                    "LYMS": Decimal("20"),
+                    "SEMI": Decimal("45"),
+                    "EIMI": Decimal("30"),
+                    "BTC-EUR": Decimal("40000"),
+                },
+            )
+        )
+    return rows
+
+
+def test_volatility_target_reduces_growth_quote_when_volatile():
+    rows = _rows_with_high_volatility()
+    gewichte = volatility_target_gewichte(rows, 14)
+    wachstumsquote = gewichte["LYMS"] / Decimal("0.40")
+    assert wachstumsquote < Decimal("0.80")
+    assert wachstumsquote == Decimal("0.50")  # bei dieser Schwankungsbreite am unteren Anschlag
+
+
+def test_volatility_target_falls_back_to_normal_without_enough_history():
+    rows = _rows_with_high_volatility()[:5]
+    gewichte = volatility_target_gewichte(rows, 4)
+    assert gewichte["LYMS"] == Decimal("0.80") * Decimal("0.40")
+
+
+def test_volatility_target_scenario_runs_end_to_end():
+    result = simulate(_rows_with_high_volatility(), VOLATILITY_TARGET)
+    last_point = result.value_history[-1]
+    assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")
+
+
+# --- Cost-Average-Einstieg ------------------------------------------------------------
+
+
+def test_cost_average_gewichte_ramps_linearly_then_stays_normal():
+    rows = _sample_rows()
+    gewichte_start = cost_average_gewichte(rows, 0)
+    assert gewichte_start["LYMS"] == Decimal("0")  # Woche 0 -> 0% Wachstum, komplett defensiv
+    assert gewichte_start["EUNL"] == Decimal("0.50")
+
+    gewichte_mitte = cost_average_gewichte(rows, 5)
+    # Nach halber Rampe (5 von 10 Wochen) liegt die Wachstumsquote bei 40% (halb 80%).
+    assert gewichte_mitte["LYMS"] == Decimal("0.40") * Decimal("0.40")
+
+    gewichte_ende = cost_average_gewichte(rows, 10)
+    assert gewichte_ende["LYMS"] == Decimal("0.80") * Decimal("0.40")
+
+
+def test_cost_average_entry_scenario_runs_end_to_end():
+    result = simulate(_sample_rows(), COST_AVERAGE_ENTRY)
+    last_point = result.value_history[-1]
+    assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")


### PR DESCRIPTION
## Summary

- `Strategy` (in `strategies.py`) bekommt ein optionales Feld `gewichte_fn: Callable[[rows, i], dict[ticker, Decimal]] | None`, mit dem die Ziel-Gewichte pro Kurszeile **zeitabhängig** statt konstant sein können. `engine.simulate()` nutzt es, wenn gesetzt, sonst exakt das bisherige (konstante) Verhalten — kein Verhaltensunterschied für die bestehenden Barbell-Strategien.
- Neues Modul `src/boersenspiel/scenarios.py` mit drei ersten Auswertungs-Szenarien auf Basis der Barbell-Instrumente-Struktur (Topf A "Sicherheit" / Topf B "Wachstum"):
  1. **Börsenweisheit „Sell in May and Go Away“** — Mai bis September vollständig defensiv (100% Topf A), sonst normale Barbell-20/80-Gewichte.
  2. **Börsenweisheit „Buy & Hold“** — nie aktiv rebalancieren (Gegenbeispiel: „Hin und her macht Taschen leer“), Dezember-Verlustverrechnung bleibt aktiv.
  3. **Charttechnik: SMA-Crossover (10/40 Wochen, Golden/Death Cross)** auf dem MSCI-World-ETF (EUNL) als Trendindikator — bei Death Cross vollständig defensiv, sonst normal investiert.
- `scripts/build_dashboard.py` rendert standardmäßig `STRATEGIES + SCENARIOS` und kann beide per `--strategy <Name>` gezielt auswählen; `dashboard.py` zeigt bei Szenario-Strategien die Ziel-Gewichte des aktuellen Regimes (letzte Kurszeile) statt eines statischen Werts.
- `CLAUDE.md` um die neue Architektur-Erweiterung ergänzt.

Weitere Szenario-Ideen (bewusst noch nicht implementiert, siehe Kommentar in `scenarios.py`): Momentum-/Relative-Stärke-Rotation zwischen den Wachstums-Instrumenten, volatilitätsbasierte Aktienquote, Cost-Average-Einstieg statt Einmalanlage.

## Test plan

- [x] `pytest -q` — gesamte Testsuite (28 Tests, inkl. neuer `tests/test_scenarios.py`) grün.
- [x] Neue Tests verifizieren die generische `gewichte_fn`-Mechanik in der Engine anhand handgerechneter Werte (Regressionsschutz für bestehende statische Strategien) sowie End-to-End-Smoke-Tests für alle drei Szenarien.
- [x] `build_dashboard()` manuell mit synthetischer Kurshistorie gegen `STRATEGIES + SCENARIOS` ausgeführt, HTML-Output geprüft (Ziel-Gewichte je Szenario plausibel).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLB1ojRWESLQ6ASSoNkfLR)_