### PR TITLE
README: Link zum GitHub-Pages-Dashboard ergänzen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Börsenspiel – Barbell-Portfolio-Dashboard
 
+**📊 Dashboard:** [s540d.github.io/Boersenspiel](https://s540d.github.io/Boersenspiel/)
+
 Virtuelles Portfolio nach Barbell-Strategie, auf Basis des Pflichtenhefts
 `Pflichtenheft_PortfolioProjekt_v2.md`. Technisch wurde bewusst abweichend
 umgesetzt (siehe [Abweichungen](#abweichungen-vom-pflichtenheft) unten):


### PR DESCRIPTION
## Summary

- Fügt einen direkten Link zum GitHub-Pages-Dashboard (`https://s540d.github.io/Boersenspiel/`) am Anfang der README ein, damit die Live-Ansicht ohne Suchen auffindbar ist.

## Test plan

- [x] `pytest -q` — gesamte Testsuite (42 Tests) weiterhin grün (reine Doku-Änderung, keine Code-Auswirkung).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLB1ojRWESLQ6ASSoNkfLR)_