### PR TITLE
Dashboard: Vergleichsübersicht der Renditen aller Szenarien

### DIFF
--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -9,6 +9,7 @@ Berechnungslogik - alle Zahlen kommen aus ``engine.simulate()``.
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -25,6 +26,14 @@ DEFAULT_OUTPUT = Path(__file__).resolve().parents[2] / "docs" / "index.html"
 
 def _f(value: Decimal) -> float:
     return float(value)
+
+
+_UMLAUT_TRANSLIT = str.maketrans({"ä": "ae", "ö": "oe", "ü": "ue", "ß": "ss"})
+
+
+def _slug(name: str) -> str:
+    normalisiert = name.lower().translate(_UMLAUT_TRANSLIT)
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", normalisiert)).strip("-")
 
 
 def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: list[PriceRow]) -> dict:
@@ -63,8 +72,15 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
             }
         )
 
+    gewinn = last.total_value - strategy.startkapital
+    rendite_pct = (gewinn / strategy.startkapital) * 100 if strategy.startkapital > 0 else Decimal(0)
+
     return {
         "name": result.strategy_name,
+        "id": _slug(result.strategy_name),
+        "rendite_pct": _f(rendite_pct),
+        "rendite_pct_label": f"{rendite_pct:+.2f}",
+        "gewinn_label": f"{gewinn:+.2f}",
         "labels_json": json.dumps(labels),
         "total_values_json": json.dumps(total_values),
         "topf_series_json": json.dumps(topf_series),
@@ -98,6 +114,7 @@ def build_dashboard(
     rows = sorted(price_history, key=lambda r: r.date)
 
     views = [_build_strategy_view(s, simulate(rows, s), rows) for s in strategies]
+    summary = sorted(views, key=lambda v: v["rendite_pct"], reverse=True)
 
     env = Environment(
         loader=FileSystemLoader(str(TEMPLATE_DIR)),
@@ -106,6 +123,7 @@ def build_dashboard(
     template = env.get_template("dashboard.html.j2")
     html = template.render(
         strategies=views,
+        summary=summary,
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
         row_count=len(price_history),
         last_date=price_history[-1].date.isoformat(),

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -94,6 +94,10 @@
   th { color: var(--text-muted); font-weight: 500; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.02em; }
   .overflow-x { overflow-x: auto; }
   footer { max-width: 1100px; margin: 24px auto 0; color: var(--text-muted); font-size: 0.8rem; }
+  .summary-chart-box { position: relative; height: 340px; margin-bottom: 20px; }
+  table.summary-table a { color: inherit; text-decoration: underline; text-decoration-color: var(--border); }
+  .positive { color: var(--good); }
+  .negative { color: var(--series-2); }
 </style>
 </head>
 <body>
@@ -102,8 +106,27 @@
   <div class="meta">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
 </header>
 <main>
+  <section class="strategy" id="uebersicht">
+    <h2>Übersicht: Rendite im Vergleich</h2>
+    <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
+    <div class="overflow-x">
+      <table class="summary-table">
+        <thead><tr><th>Strategie / Szenario</th><th>Rendite %</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
+        <tbody>
+        {% for s in summary %}
+          <tr>
+            <td><a href="#{{ s.id }}">{{ s.name }}</a></td>
+            <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
+            <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.gewinn_label }}</td>
+            <td>{{ s.total_value }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
 {% for s in strategies %}
-  <section class="strategy">
+  <section class="strategy" id="{{ s.id }}">
     <h2>{{ s.name }}</h2>
     <div class="stat-row">
       <div class="stat-tile"><div class="label">Gesamtwert</div><div class="value">{{ s.total_value }} &euro;</div></div>
@@ -163,6 +186,27 @@
     y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
   };
   const seriesPalette = [colors.series1, colors.series2, colors.series3, colors.series4];
+
+  new Chart(document.getElementById('summary-chart'), {
+    type: 'bar',
+    data: {
+      labels: {{ summary | map(attribute='name') | list | tojson }},
+      datasets: [{
+        label: 'Rendite %',
+        data: {{ summary | map(attribute='rendite_pct') | list | tojson }},
+        backgroundColor: {{ summary | map(attribute='rendite_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+      }],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false }, title: { display: true, text: 'Rendite seit Simulationsbeginn (%)', color: colors.text } },
+      scales: {
+        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+      },
+    },
+  });
 
   {% for s in strategies %}
   new Chart(document.getElementById('value-chart-{{ loop.index }}'), {

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,71 @@
+"""Tests für die Dashboard-Rendering-Schicht (``dashboard.py``).
+
+Prüft insbesondere die Vergleichsübersicht (Rendite je Strategie/Szenario)
+und die Verlinkung zu den Detailabschnitten - reine Darstellungslogik, keine
+eigene Berechnung (die kommt aus ``engine.simulate()``).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+from boersenspiel.dashboard import _slug, build_dashboard
+from boersenspiel.history_store import PriceRow
+from boersenspiel.strategies import Strategy, Topf
+
+ZWEI_STRATEGIEN = [
+    Strategy(
+        name="A: Verdoppler",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T1": Decimal("1")})],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    ),
+    Strategy(
+        name="B: Verlierer",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T1": Decimal("1")})],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    ),
+]
+
+
+def _rows() -> list[PriceRow]:
+    return [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("150")}),
+    ]
+
+
+def test_slug_transliterates_umlaute_and_strips_special_chars():
+    assert _slug("Börsenweisheit: Sell in May") == "boersenweisheit-sell-in-may"
+    assert _slug("Charttechnik: SMA-Crossover (10/40 Wochen)") == "charttechnik-sma-crossover-10-40-wochen"
+
+
+def test_build_dashboard_renders_comparison_overview_with_correct_ranking(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    assert "Übersicht: Rendite im Vergleich" in html
+    assert 'id="a-verdoppler"' in html
+    assert 'id="b-verlierer"' in html
+    assert 'href="#a-verdoppler"' in html
+    assert 'href="#b-verlierer"' in html
+
+    # Beide Strategien kaufen dasselbe Instrument T1 zum selben Startkapital
+    # (kein Rebalancing, Schwelle ist unerreichbar hoch) -> identisches Ergebnis:
+    # 999 investierbar (1000 - 1 Gebuehr) / 100 = 9.99 Einheiten, Endwert bei
+    # Kurs 150 = 1498.50, Rendite (1498.50-1000)/1000 = +49.85%.
+    assert html.count("+49.85") == 2
+
+
+def test_build_dashboard_summary_matches_detail_total_value(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+    # Endwert taucht sowohl in der Uebersichtstabelle als auch im Detail-Stat-Tile auf.
+    assert html.count("1498.50") >= 2


### PR DESCRIPTION
## Summary

- Grund für "im Dashboard fehlen die Szenarien": `docs/index.html` wird nicht committet, sondern bei jedem Workflow-Lauf (wöchentlich Montag 06:00 UTC oder manuell per `workflow_dispatch`) frisch gebaut und als Pages-Artefakt deployed. Der letzte Deploy lief vor dem Merge der Szenarien (PR #1) — die neuen Strategien waren im Code bereits vorhanden, aber noch nicht auf der Live-Seite. Dieser PR löst zusätzlich das eigentlich angefragte Feature; ein manuell ausgelöster Workflow-Lauf bringt danach die Szenarien live.
- Neue Sektion **"Übersicht: Rendite im Vergleich"** ganz oben im Dashboard (`dashboard.html.j2`): Balkendiagramm + nach Rendite sortierte Tabelle (Rendite %, Gewinn/Verlust €, Endwert €) über alle gerenderten Strategien/Szenarien, mit Sprunglinks zu den jeweiligen Detailabschnitten.
- `dashboard.py`: Rendite (`(Endwert - Startkapital) / Startkapital`) und ein URL-Slug je Strategie werden rein aus den vorhandenen `engine.simulate()`-Ergebnissen abgeleitet — keine neue Berechnungslogik in der Engine.

## Test plan

- [x] `pytest -q` — gesamte Testsuite (45 Tests, inkl. neuer `tests/test_dashboard.py` mit handgerechneten Renditewerten) grün.
- [x] `build_dashboard()` manuell mit synthetischer Kurshistorie gegen alle 11 Strategien/Szenarien ausgeführt: Übersichtstabelle, Balkendiagramm und Anker-Links (`href="#..."` ↔ `id="..."`) geprüft, inkl. korrekter Umlaut-Transliteration in den Slugs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLB1ojRWESLQ6ASSoNkfLR)_