### PR TITLE
Neue Strategie: Barbell 20/60/20 + Einzelaktien-Satellit (10 volatile Aktien)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,9 @@ inkrementell fortgeschrieben).
 
 ### Trennung der Verantwortlichkeiten (wichtig beim Erweitern)
 
-- `instruments.py` — die 7 Instrumente (Ticker, ISIN), **quellenunabhängig**.
-  Kein Provider-Symbol-Mapping hier.
+- `instruments.py` — die 17 Instrumente (7 Barbell-Basisinstrumente + 10
+  Einzelaktien-Satellit, s.u.), **quellenunabhängig**. Kein
+  Provider-Symbol-Mapping hier.
 - `strategies.py` — austauschbare `Strategy`-Definitionen (Töpfe,
   Sub-Gewichte, Rebalancing-Schwelle, Startkapital) + strategieübergreifende
   Steuer-/Gebührkonstanten. Die Engine enthält **keine** Barbell-spezifischen
@@ -58,6 +59,15 @@ inkrementell fortgeschrieben).
   Optionales Feld `Strategy.gewichte_fn` macht die Ziel-Gewichte zeitabhängig
   statt konstant (Signatur `(rows, i) -> dict[ticker, Decimal]`, darf nur auf
   `rows[:i+1]` zugreifen, kein Lookahead-Bias) — Basis für `scenarios.py`.
+  `BARBELL_20_60_20_SATELLIT` erweitert Barbell 20/80 um einen dritten Topf
+  "Einzelaktien-Satellit" (10 gleichgewichtete Einzelaktien statt breiter
+  ETFs): Topf A (Sicherheit) bleibt bei 20%, Topf B (breite ETFs/BTC) sinkt
+  von 80% auf 60%, die freiwerdenden 20% gehen in den neuen Topf C — das
+  80/20-Risikoprofil bleibt damit erhalten. Die 10 Aktien mischen bewusst
+  hoch-volatile Wachstums-/Themenwerte (Lumentum, BYD, SolarEdge, SMA Solar,
+  Tesla, Palantir, Strategy/vorm. MicroStrategy, Rivian) mit zwei defensiven
+  Blue Chips (Coca-Cola, Roche) als Gegenbeispiel — erster Ansatz, keine
+  Optimierung/Backtesting der Auswahl oder Gewichtung.
 - `scenarios.py` — Auswertungs-Szenarien als gewöhnliche `Strategy`-Instanzen
   mit gesetztem `gewichte_fn`, in drei Kategorien: (1) Börsenweisheiten —
   "Sell in May and Go Away" (saisonal defensiv Mai–September), "Buy & Hold"
@@ -84,7 +94,11 @@ inkrementell fortgeschrieben).
   `yfinance_stooq.py` existiert noch als Referenzimplementierung, wird aber
   von `scripts/run_fetch.py` nicht mehr aufgerufen (yfinance scheiterte
   produktiv wiederholt an Yahoos Crumb/Cookie-Auth). Provider-Symbol-Mapping
-  gehört ausschließlich in die jeweilige Source-Datei.
+  gehört ausschließlich in die jeweilige Source-Datei — jeder Ticker in
+  `instruments.py` (außer BTC-EUR, eigener Krypto-Endpunkt) braucht einen
+  Eintrag in `ALPHAVANTAGE_SYMBOLS`, sonst liefert der Abruf stillschweigend
+  "missing" (siehe `tests/test_satellit_strategy.py` für den
+  Regressionstest, der das für alle Ticker prüft).
 - `engine.py` — die Simulation. Modellierungsentscheidungen, die beim
   Ändern zu beachten sind: Initialkauf-Gebühren werden vom Startkapital
   *vor* der Aufteilung abgezogen; spätere Trades (Rebalancing,
@@ -130,3 +144,7 @@ Provider-API vollständig (kein echter Netzwerkzugriff in Tests).
 `tests/test_scenarios.py` verifiziert die generische `gewichte_fn`-Mechanik
 in der Engine anhand handgerechneter Werte sowie die konkreten Szenarien
 (Sell in May, Buy & Hold, SMA-Crossover) als End-to-End-Smoke-Tests.
+`tests/test_satellit_strategy.py` prüft den Einzelaktien-Satellit
+(`BARBELL_20_60_20_SATELLIT`): Symbol-Mapping-Vollständigkeit, Ziel-Gewichte
+summieren zu 1, 80/20-Risikoprofil bleibt erhalten, End-to-End-Smoke-Test
+mit allen 17 Instrumenten.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Kurshistorie + identische Strategie ergeben immer dasselbe Ergebnis.
 
 | Datei | Zweck |
 |---|---|
-| `src/boersenspiel/instruments.py` | Die 7 Instrumente (Ticker, ISIN) – quellenunabhängig |
+| `src/boersenspiel/instruments.py` | Die 17 Instrumente (7 Barbell-Basisinstrumente + 10 Einzelaktien-Satellit; Ticker, ISIN) – quellenunabhängig |
 | `src/boersenspiel/strategies.py` | Austauschbare Strategie-Definitionen (Gewichte, Töpfe, Rebalancing-Schwelle) + Steuer-/Gebührkonstanten |
 | `src/boersenspiel/history_store.py` | Einziger Schreibzugriff auf `data/price_history.csv` / `data/fetch_log.csv` |
 | `src/boersenspiel/sources/` | Austauschbare Kursquellen (Standard: `alphavantage.py`) |
@@ -72,8 +72,9 @@ werden, ohne Code umzubauen.
 ### Alpha Vantage einrichten
 
 1. API-Key auf [alphavantage.co](https://www.alphavantage.co/support/#api-key)
-   holen (kostenloser Plan: 25 Requests/Tag, max. 1 Request/Sekunde – für 7
-   Ticker einmal wöchentlich ausreichend).
+   holen (kostenloser Plan: 25 Requests/Tag, max. 1 Request/Sekunde – bei
+   aktuell 17 Tickern einmal wöchentlich noch ausreichend, aber ohne viel
+   Spielraum für zusätzliche manuelle Abrufe am selben Tag).
 2. Als GitHub-Actions-Secret hinterlegen: Settings → Secrets and variables
    → Actions → New repository secret → Name `ALPHAVANTAGE_API_KEY`.
 3. Ticker-Symbole wurden per `SYMBOL_SEARCH` verifiziert und weichen teils
@@ -81,7 +82,10 @@ werden, ohne Code umzubauen.
    läuft auf Xetra unter dem lokalen Kürzel `IBC3.DEX`; SEMI (iShares
    Global Semiconductors) ist auf Xetra nicht gelistet, nur über die
    Amsterdam-Notierung `SEMI.AMS` (ebenfalls in EUR) verfügbar. BTC-EUR
-   läuft über den separaten `DIGITAL_CURRENCY_DAILY`-Endpunkt.
+   läuft über den separaten `DIGITAL_CURRENCY_DAILY`-Endpunkt. Die 10
+   Einzelaktien des Satelliten-Topfs laufen bis auf SMA Solar (`S92.DEX`,
+   Xetra) direkt über ihren US-Ticker in USD, inkl. der beiden ADRs BYDDY
+   (BYD) und RHHBY (Roche).
 
 ## Strategie hinzufügen
 
@@ -91,8 +95,14 @@ Sub-Gewichten, Ziel-Topf, Ziel-Gewicht, Rebalancing-Schwelle in
 Prozentpunkten) und zur `STRATEGIES`-Liste hinzugefügt – die Engine enthält
 keine Barbell-spezifischen Annahmen, `dashboard.py` rendert automatisch
 alle in `STRATEGIES` hinterlegten Strategien nebeneinander. Aktuell
-hinterlegt: `Barbell 20/80` (aus dem Pflichtenheft) und `Barbell 30/70`
-(Beispiel für eine alternative Gewichtung).
+hinterlegt: `Barbell 20/80` (aus dem Pflichtenheft), `Barbell 30/70`
+(Beispiel für eine alternative Gewichtung) und `Barbell 20/60/20 +
+Einzelaktien-Satellit` (erweitert Barbell 20/80 um einen dritten Topf mit
+10 gleichgewichteten Einzelaktien statt breiter ETFs – Gesamtrisikoprofil
+80% riskant / 20% sicher bleibt erhalten, siehe `strategies.py` für die
+Details und Auswahlbegründung). Zusätzlich gibt es in `scenarios.py`
+zeitabhängige Auswertungs-Szenarien (Börsenweisheiten, Charttechnik,
+weitere Ansätze) auf Basis der Barbell-20/80-Instrumente.
 
 ## Lokale Ausführung
 
@@ -147,7 +157,8 @@ pytest -q
   Crumb/Cookie-Authentifizierung, die die gepinnte Version (0.2.43) nicht
   mehr unterstützte. Deshalb Umstieg auf Alpha Vantage als Standardquelle.
 - **Alpha Vantage Free-Tier-Limit:** 25 Requests/Tag, max. 1 Request/Sekunde.
-  Bei 7 Tickern einmal wöchentlich unproblematisch; `AlphaVantageSource`
+  Bei aktuell 17 Tickern einmal wöchentlich noch unproblematisch, aber kaum
+  noch Puffer für weitere manuelle Abrufe am selben Tag; `AlphaVantageSource`
   hält zwischen den Requests einen Sleep ein. Schlägt ein Kurs dennoch fehl
   (z. B. durch Rate-Limit oder eine leere Antwort), wird der letzte bekannte
   Kurs übernommen und in `fetch_log.csv` vermerkt (nie eine Zeile mit

--- a/src/boersenspiel/instruments.py
+++ b/src/boersenspiel/instruments.py
@@ -27,6 +27,20 @@ INSTRUMENTS: dict[str, Instrument] = {
         Instrument("SEMI", "Global Semiconductors ETF (iShares)", "IE000I8KRLL9"),
         Instrument("EIMI", "EM IMI ETF (iShares Core)", "IE00BKM4GZ66"),
         Instrument("BTC-EUR", "Bitcoin", None),
+        # Einzelaktien-Satellit (volatile Einzelwerte, siehe strategies.py
+        # BARBELL_20_60_20_SATELLIT) - bewusst gemischt aus hoch-volatilen
+        # Wachstumswerten und zwei defensiven Blue-Chips (Coca-Cola, Roche)
+        # als Gegenbeispiel innerhalb desselben Topfs.
+        Instrument("LITE", "Lumentum Holdings (Optik/Photonik)", "US55024U1097"),
+        Instrument("BYDDY", "BYD Company (ADR, E-Autos)", "US05606L1008"),
+        Instrument("SEDG", "SolarEdge Technologies (Solar-Wechselrichter)", "US83417M1045"),
+        Instrument("S92", "SMA Solar Technology AG", "DE000A0DJ6J9"),
+        Instrument("TSLA", "Tesla", "US88160R1014"),
+        Instrument("PLTR", "Palantir Technologies", "US69608A1088"),
+        Instrument("MSTR", "Strategy Inc. (vormals MicroStrategy)", "US5949724083"),
+        Instrument("RIVN", "Rivian Automotive", "US76954A1034"),
+        Instrument("KO", "Coca-Cola (defensiver Blue Chip)", "US1912161007"),
+        Instrument("RHHBY", "Roche Holding (ADR, defensiver Blue Chip)", "US7711951043"),
     ]
 }
 

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -2,9 +2,11 @@
 Scraping - deutlich zuverlässiger für GitHub Actions als yfinance, das
 wiederholt an Yahoos Crumb/Cookie-Authentifizierung scheiterte (siehe README).
 
-Free-Tier-Limits: 25 Requests/Tag, max. 1 Request/Sekunde. Bei 7 Tickern
-einmal wöchentlich unproblematisch; zwischen den Requests wird ein kleiner
-Sleep eingehalten, um das Sekundenlimit nicht zu reißen.
+Free-Tier-Limits: 25 Requests/Tag, max. 1 Request/Sekunde. Bei aktuell 17
+Tickern (7 Barbell-Basisinstrumente + 10 Einzelaktien-Satellit) einmal
+wöchentlich noch unproblematisch, lässt aber kaum noch Spielraum für
+zusätzliche manuelle Abrufe am selben Tag; zwischen den Requests wird ein
+kleiner Sleep eingehalten, um das Sekundenlimit nicht zu reißen.
 
 Läuft in GitHub Actions gegen die reine REST-API (nicht über den
 Alpha-Vantage-MCP-Server, der nur innerhalb einer Claude-Session verfügbar
@@ -31,6 +33,10 @@ ALPHAVANTAGE_URL = "https://www.alphavantage.co/query"
 # Semiconductors) ist auf Xetra nicht verfuegbar, nur ueber die
 # Amsterdam-Notierung ".AMS" (ebenfalls in EUR). BTC-EUR laeuft ueber einen
 # eigenen Krypto-Endpunkt, siehe _fetch_crypto.
+#
+# Einzelaktien-Satellit: US-notierte Werte (inkl. ADRs wie BYDDY/RHHBY)
+# laufen direkt unter ihrem Ticker in USD, nur SMA Solar (S92) ist analog zu
+# den ETFs oben ueber die Xetra-Notierung (".DEX") angebunden.
 ALPHAVANTAGE_SYMBOLS: dict[str, str] = {
     "EUNL": "EUNL.DEX",
     "EUNA": "EUNA.DEX",
@@ -38,6 +44,16 @@ ALPHAVANTAGE_SYMBOLS: dict[str, str] = {
     "LYMS": "LYMS.DEX",
     "EIMI": "IBC3.DEX",
     "SEMI": "SEMI.AMS",
+    "LITE": "LITE",
+    "BYDDY": "BYDDY",
+    "SEDG": "SEDG",
+    "S92": "S92.DEX",
+    "TSLA": "TSLA",
+    "PLTR": "PLTR",
+    "MSTR": "MSTR",
+    "RIVN": "RIVN",
+    "KO": "KO",
+    "RHHBY": "RHHBY",
 }
 
 _REQUEST_INTERVAL_SECONDS = 1.1

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -126,7 +126,66 @@ BARBELL_30_70 = Strategy(
     rebalancing_schwelle_pp=Decimal("15"),
 )
 
-STRATEGIES: list[Strategy] = [BARBELL_20_80, BARBELL_30_70]
+# --- Strategie 3: Barbell 20/60/20 + Einzelaktien-Satellit -----------------
+#
+# Erweitert Barbell 20/80 um einen dritten Topf mit 10 volatilen
+# Einzelaktien (statt breiter ETFs) als Satelliten-Beimischung. Topf A
+# (Sicherheit) bleibt bei 20% unveraendert; der bisherige Wachstums-Topf
+# (breite ETFs/BTC) wird von 80% auf 60% reduziert, die freiwerdenden 20%
+# gehen 1:1 in den neuen Einzelaktien-Topf - das Gesamtrisikoprofil (80%
+# "riskant" vs. 20% "sicher") bleibt damit wie beim Original-Barbell
+# erhalten, nur granularer gestreut. Die 10 Einzelaktien sind bewusst
+# gleichgewichtet (je 10% des Topfs) und mischen hoch-volatile Wachstums-
+# /Themenwerte mit zwei defensiven Blue Chips (Coca-Cola, Roche) als
+# Gegenbeispiel - kein Optimierungsziel, sondern Illustrationszweck fuer den
+# Renditevergleich mit den reinen ETF-Strategien.
+
+BARBELL_20_60_20_SATELLIT = Strategy(
+    name="Barbell 20/60/20 + Einzelaktien-Satellit",
+    startkapital=Decimal("10000"),
+    toepfe=[
+        Topf(
+            name="Topf A - Sicherheit",
+            gewicht_gesamt=Decimal("0.20"),
+            sub_gewichte={
+                "EUNL": Decimal("0.50"),
+                "EUNA": Decimal("0.35"),
+                "4GLD": Decimal("0.15"),
+            },
+        ),
+        Topf(
+            name="Topf B - Wachstum",
+            gewicht_gesamt=Decimal("0.60"),
+            sub_gewichte={
+                "LYMS": Decimal("0.40"),
+                "SEMI": Decimal("0.30"),
+                "EIMI": Decimal("0.20"),
+                "BTC-EUR": Decimal("0.10"),
+            },
+        ),
+        Topf(
+            name="Topf C - Einzelaktien-Satellit",
+            gewicht_gesamt=Decimal("0.20"),
+            sub_gewichte={
+                "LITE": Decimal("0.10"),
+                "BYDDY": Decimal("0.10"),
+                "SEDG": Decimal("0.10"),
+                "S92": Decimal("0.10"),
+                "TSLA": Decimal("0.10"),
+                "PLTR": Decimal("0.10"),
+                "MSTR": Decimal("0.10"),
+                "RIVN": Decimal("0.10"),
+                "KO": Decimal("0.10"),
+                "RHHBY": Decimal("0.10"),
+            },
+        ),
+    ],
+    ziel_topf="Topf A - Sicherheit",
+    ziel_gewicht=Decimal("0.20"),
+    rebalancing_schwelle_pp=Decimal("10"),
+)
+
+STRATEGIES: list[Strategy] = [BARBELL_20_80, BARBELL_30_70, BARBELL_20_60_20_SATELLIT]
 
 STRATEGIES_BY_NAME: dict[str, Strategy] = {s.name: s for s in STRATEGIES}
 

--- a/tests/test_satellit_strategy.py
+++ b/tests/test_satellit_strategy.py
@@ -1,0 +1,125 @@
+"""Tests für die Erweiterung um 10 volatile Einzelaktien (Einzelaktien-Satellit).
+
+Erster Block: strukturelle Konsistenz von Instrumenten-Universum und
+Alpha-Vantage-Symbol-Mapping (Regressionsschutz - jeder neue Ticker in
+``instruments.py`` braucht ein Mapping, sonst liefert der Kursabruf
+stillschweigend "missing", siehe ``alphavantage._fetch_quote``).
+
+Zweiter Block: die neue Strategie ``BARBELL_20_60_20_SATELLIT`` selbst -
+Ziel-Gewichte summieren zu 1, Gesamtrisikoprofil (80% riskant / 20% sicher)
+bleibt wie bei Barbell 20/80 erhalten, End-to-End-Smoke-Test mit allen 17
+Instrumenten.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from boersenspiel.engine import simulate
+from boersenspiel.history_store import PriceRow
+from boersenspiel.instruments import TICKERS
+from boersenspiel.sources.alphavantage import ALPHAVANTAGE_SYMBOLS
+from boersenspiel.strategies import BARBELL_20_60_20_SATELLIT, STRATEGIES
+
+EINZELAKTIEN_SATELLIT_TICKER = [
+    "LITE",
+    "BYDDY",
+    "SEDG",
+    "S92",
+    "TSLA",
+    "PLTR",
+    "MSTR",
+    "RIVN",
+    "KO",
+    "RHHBY",
+]
+
+
+def test_every_non_crypto_ticker_has_alphavantage_symbol_mapping():
+    fehlend = [t for t in TICKERS if t != "BTC-EUR" and t not in ALPHAVANTAGE_SYMBOLS]
+    assert fehlend == []
+
+
+def test_satellit_strategy_is_registered_in_strategies_list():
+    assert BARBELL_20_60_20_SATELLIT in STRATEGIES
+
+
+def test_satellit_strategy_ticker_gewichte_summieren_zu_eins():
+    gewichte = BARBELL_20_60_20_SATELLIT.alle_ticker_gewichte()
+    assert sum(gewichte.values()) == Decimal("1")
+
+
+def test_satellit_strategy_haelt_barbell_risikoprofil_80_20():
+    gewichte = BARBELL_20_60_20_SATELLIT.alle_ticker_gewichte()
+    sicherheit = sum(
+        g for t, g in gewichte.items() if t in {"EUNL", "EUNA", "4GLD"}
+    )
+    riskant = sum(g for t, g in gewichte.items() if t not in {"EUNL", "EUNA", "4GLD"})
+    assert sicherheit == Decimal("0.20")
+    assert riskant == Decimal("0.80")
+
+
+def test_satellit_strategy_gewichtet_alle_10_einzelaktien_gleich():
+    gewichte = BARBELL_20_60_20_SATELLIT.alle_ticker_gewichte()
+    for ticker in EINZELAKTIEN_SATELLIT_TICKER:
+        assert gewichte[ticker] == Decimal("0.02")  # 20% Topf * 10% Sub-Gewicht
+
+
+def test_satellit_strategy_runs_end_to_end_with_all_17_instrumenten():
+    rows = [
+        PriceRow(
+            date(2024, 1, 1),
+            {
+                "EUNL": Decimal("80"),
+                "EUNA": Decimal("5"),
+                "4GLD": Decimal("60"),
+                "LYMS": Decimal("20"),
+                "SEMI": Decimal("45"),
+                "EIMI": Decimal("30"),
+                "BTC-EUR": Decimal("40000"),
+                "LITE": Decimal("70"),
+                "BYDDY": Decimal("55"),
+                "SEDG": Decimal("15"),
+                "S92": Decimal("60"),
+                "TSLA": Decimal("250"),
+                "PLTR": Decimal("40"),
+                "MSTR": Decimal("300"),
+                "RIVN": Decimal("12"),
+                "KO": Decimal("65"),
+                "RHHBY": Decimal("35"),
+            },
+        ),
+        PriceRow(
+            date(2024, 6, 1),
+            {
+                "EUNL": Decimal("90"),
+                "EUNA": Decimal("5.2"),
+                "4GLD": Decimal("65"),
+                "LYMS": Decimal("28"),
+                "SEMI": Decimal("55"),
+                "EIMI": Decimal("27"),
+                "BTC-EUR": Decimal("60000"),
+                "LITE": Decimal("90"),
+                "BYDDY": Decimal("48"),
+                "SEDG": Decimal("22"),
+                "S92": Decimal("50"),
+                "TSLA": Decimal("310"),
+                "PLTR": Decimal("62"),
+                "MSTR": Decimal("410"),
+                "RIVN": Decimal("9"),
+                "KO": Decimal("67"),
+                "RHHBY": Decimal("36"),
+            },
+        ),
+    ]
+    result = simulate(rows, BARBELL_20_60_20_SATELLIT)
+
+    assert result.strategy_name == "Barbell 20/60/20 + Einzelaktien-Satellit"
+    last_point = result.value_history[-1]
+    assert last_point.total_value > 0
+    total_weight = sum(last_point.ticker_weights.values())
+    assert abs(total_weight - Decimal("1")) < Decimal("0.0001")
+    assert all(units >= 0 for units in result.holdings.values())
+    for ticker in EINZELAKTIEN_SATELLIT_TICKER:
+        assert ticker in result.holdings


### PR DESCRIPTION
## Summary

- Erweitert das Instrumenten-Universum (`instruments.py`) um 10 Einzelaktien, per Alpha-Vantage-`SYMBOL_SEARCH` verifiziert und ISINs web-recherchiert:
  - **Volatile Wachstums-/Themenwerte:** Lumentum Holdings (`LITE`, `US55024U1097` — die vom Nutzer genannte ISIN), BYD (`BYDDY`, ADR), SolarEdge (`SEDG`), SMA Solar (`S92`, Xetra), Tesla (`TSLA`), Palantir (`PLTR`), Strategy Inc./vorm. MicroStrategy (`MSTR`), Rivian (`RIVN`)
  - **Bewusste defensive Gegenbeispiele** (explizit vom Nutzer genannt, obwohl beide historisch eher niedrig-volatil sind): Coca-Cola (`KO`), Roche (`RHHBY`, ADR)
- **Bestehende Strategien bleiben unangetastet** (Integrationsoption "a" wie abgestimmt): Barbell 20/80 und 30/70 sind unverändert. Die 10 Aktien landen ausschließlich in einer neuen dritten Strategie `BARBELL_20_60_20_SATELLIT` mit einem zusätzlichen Topf C "Einzelaktien-Satellit" (10× gleichgewichtet à 10%). Topf B (breite ETFs/BTC) sinkt von 80% auf 60%, die freiwerdenden 20% gehen 1:1 in Topf C — das Barbell-Risikoprofil (80% riskant / 20% sicher) bleibt damit erhalten.
- `sources/alphavantage.py`: Symbol-Mapping für alle 10 neuen Ticker ergänzt (direkt per US-Ticker in USD, außer SMA Solar über `S92.DEX`).
- Neuer Regressionstest (`test_every_non_crypto_ticker_has_alphavantage_symbol_mapping`) stellt sicher, dass künftig kein Ticker ohne Symbol-Mapping bleibt — das würde sonst beim Kursabruf still zu `status="missing"` führen.

## Test plan

- [x] `pytest -q` — gesamte Testsuite (51 Tests, inkl. neuer `tests/test_satellit_strategy.py`: Symbol-Mapping-Vollständigkeit, Ziel-Gewichte summieren zu 1, 80/20-Risikoprofil bleibt erhalten, End-to-End-Smoke-Test mit allen 17 Instrumenten) grün.
- [x] `build_dashboard()` manuell mit synthetischer Kurshistorie (alle 17 Ticker) gegen alle 12 Strategien/Szenarien ausgeführt — neue Strategie erscheint korrekt in Detailsektion und Vergleichsübersicht.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLB1ojRWESLQ6ASSoNkfLR)_