### PR TITLE
Währungskonsistenz-Fix (USD-Satelliten-Aktien) + historischer Backfill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ pytest tests/test_engine.py::test_simple_strategy_end_to_end_exact_values -q  # 
 
 python scripts/run_fetch.py                        # Kursabruf via Alpha Vantage (benötigt ALPHAVANTAGE_API_KEY env var)
 python scripts/record_prices.py --date 2026-08-17 --prices '{"EUNL": 82.1, ...}'  # manueller Kurseintrag
+python scripts/backfill_history.py --years 5        # einmaliger historischer Backfill (ersetzt price_history.csv, ~18 API-Requests)
 python scripts/build_dashboard.py                  # baut docs/index.html aus data/price_history.csv (Strategien + Szenarien)
 python scripts/build_dashboard.py --strategy "Barbell 20/80"  # nur eine Strategie/ein Szenario rendern
 ```
@@ -98,7 +99,13 @@ inkrementell fortgeschrieben).
   `instruments.py` (außer BTC-EUR, eigener Krypto-Endpunkt) braucht einen
   Eintrag in `ALPHAVANTAGE_SYMBOLS`, sonst liefert der Abruf stillschweigend
   "missing" (siehe `tests/test_satellit_strategy.py` für den
-  Regressionstest, der das für alle Ticker prüft).
+  Regressionstest, der das für alle Ticker prüft). **Währungskonsistenz:**
+  `USD_TICKERS` markiert die Satelliten-Aktien ohne EUR-Notierung (alle
+  außer S92/SMA Solar) - `AlphaVantageSource.fetch()` rechnet sie bei jedem
+  Abruf per aktuellem `CURRENCY_EXCHANGE_RATE` (USD→EUR) um, damit die
+  (währungsblinde) Engine nicht USD-Beträge als EUR fehlinterpretiert.
+  Schlägt der EUR/USD-Abruf fehl, werden betroffene Ticker als `missing`
+  markiert statt falsch umgerechnet zu werden.
 - `engine.py` — die Simulation. Modellierungsentscheidungen, die beim
   Ändern zu beachten sind: Initialkauf-Gebühren werden vom Startkapital
   *vor* der Aufteilung abgezogen; spätere Trades (Rebalancing,
@@ -124,6 +131,26 @@ statt `scripts/run_fetch.py` einfach `scripts/record_prices.py --date ...
 GitHub-Actions-Cron-Schritt kann dafür deaktiviert werden, ohne den Rest des
 Systems anzufassen.
 
+### Historischer Backfill
+
+`data/price_history.csv` wächst im Normalbetrieb nur Woche für Woche seit
+Projektstart, weil `GLOBAL_QUOTE` nur den aktuellen Kurs liefert.
+`scripts/backfill_history.py` nutzt stattdessen `TIME_SERIES_WEEKLY` /
+`DIGITAL_CURRENCY_WEEKLY` (komplette verfügbare Historie in **einem**
+Request pro Ticker) und schreibt über `history_store.record_week()`
+(derselbe Pfad wie der Live-Abruf) die komplette Historie neu. USD-Ticker
+werden mit dem historischen `FX_WEEKLY`-Kurs derselben Woche umgerechnet
+(Forward-Fill bei fehlender Woche). Reine Datenbeschaffung
+(`collect_weekly_series`) und CSV-Schreiben (`write_backfilled_history`)
+sind als separate, unabhängig testbare Funktionen im Skript
+implementiert - siehe `tests/test_backfill_history.py` (mockt
+`AlphaVantageSource`, kein echter Netzwerkzugriff). **Stand:** Skript ist
+implementiert und per Mock-Tests verifiziert, aber noch nicht live gegen
+die echte Alpha-Vantage-API gelaufen (Tageslimit beim Verifizieren der
+Satelliten-Ticker-Symbole aufgebraucht) — vor dem ersten echten Lauf kurz
+gegenprüfen, dass `TIME_SERIES_WEEKLY`/`FX_WEEKLY`/`DIGITAL_CURRENCY_WEEKLY`
+im Free-Tier verfügbar sind.
+
 ### GitHub Actions (`.github/workflows/weekly-update.yml`)
 
 Läuft wöchentlich (Montag 06:00 UTC) + `workflow_dispatch`: Tests →
@@ -147,4 +174,7 @@ in der Engine anhand handgerechneter Werte sowie die konkreten Szenarien
 `tests/test_satellit_strategy.py` prüft den Einzelaktien-Satellit
 (`BARBELL_20_60_20_SATELLIT`): Symbol-Mapping-Vollständigkeit, Ziel-Gewichte
 summieren zu 1, 80/20-Risikoprofil bleibt erhalten, End-to-End-Smoke-Test
-mit allen 17 Instrumenten.
+mit allen 17 Instrumenten. `tests/test_backfill_history.py` prüft
+`scripts/backfill_history.py` (USD/EUR-Umrechnung inkl. Forward-Fill,
+ISO-Wochen-Gruppierung, Carry-Forward fehlender Ticker) gegen ein
+Fake-`AlphaVantageSource`-Objekt.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Kurshistorie + identische Strategie ergeben immer dasselbe Ergebnis.
 | `src/boersenspiel/dashboard.py` | Rendert Simulationsergebnisse als `docs/index.html` |
 | `scripts/run_fetch.py` | Automatisierter wöchentlicher Kursabruf (GitHub Actions) |
 | `scripts/record_prices.py` | Manueller Andockpunkt für Kurse aus anderer Quelle (z. B. Cowork/Websuche) |
+| `scripts/backfill_history.py` | Einmaliger historischer Backfill von `price_history.csv` (echte Wochenkurse statt nur live gesammelter Wochen, siehe unten) |
 | `scripts/build_dashboard.py` | Baut `docs/index.html` neu aus der aktuellen Kurshistorie |
 
 ## Kursquelle wechseln
@@ -85,7 +86,40 @@ werden, ohne Code umzubauen.
    läuft über den separaten `DIGITAL_CURRENCY_DAILY`-Endpunkt. Die 10
    Einzelaktien des Satelliten-Topfs laufen bis auf SMA Solar (`S92.DEX`,
    Xetra) direkt über ihren US-Ticker in USD, inkl. der beiden ADRs BYDDY
-   (BYD) und RHHBY (Roche).
+   (BYD) und RHHBY (Roche) - eine durchgängige EUR-Notierung an der
+   Frankfurter Börse/Xetra existiert nicht für jeden Wert (z. B. nicht für
+   Coca-Cola). Deshalb rechnet `AlphaVantageSource` diese `USD_TICKERS` bei
+   jedem Abruf per aktuellem `CURRENCY_EXCHANGE_RATE` (USD→EUR) um - sonst
+   würde die (währungsblinde) Engine USD-Beträge fälschlich als EUR
+   behandeln. Schlägt der EUR/USD-Abruf fehl, werden die betroffenen Ticker
+   für diese Woche als `missing` markiert (Carry-Forward greift), statt
+   einen falsch umgerechneten Kurs zu speichern.
+
+## Historischer Backfill
+
+`data/price_history.csv` wächst im Normalbetrieb nur Woche für Woche seit
+Projektstart (`GLOBAL_QUOTE` liefert nur den aktuellen Kurs). Für
+aussagekräftige Simulationen über mehrere Marktzyklen (z. B. damit
+saisonale Szenarien wie "Sell in May" oder der 40-Wochen-SMA-Crossover
+überhaupt genug Historie zum Greifen haben) gibt es
+`scripts/backfill_history.py`: nutzt `TIME_SERIES_WEEKLY` /
+`DIGITAL_CURRENCY_WEEKLY` (liefern die komplette verfügbare Historie in
+**einem** Request pro Ticker, anders als `GLOBAL_QUOTE`) und schreibt das
+Ergebnis über `history_store.record_week()` (denselben Pfad wie der
+Live-Abruf, inkl. Wochen-Idempotenz und Carry-Forward) komplett neu in
+`price_history.csv`. USD-notierte Ticker werden dabei mit dem historischen
+`FX_WEEKLY`-Kurs der jeweils selben Woche umgerechnet (Forward-Fill, falls
+für eine Woche kein FX-Kurs vorliegt).
+
+```bash
+python scripts/backfill_history.py --years 5   # Default: 5 Jahre zurück
+```
+
+Verbraucht einmalig ca. 18 Requests (16 nicht-Krypto-Ticker + 1× `FX_WEEKLY`
++ 1× Krypto) - passt ins tägliche Free-Tier-Limit von 25, sollte aber nicht
+mehrfach am selben Tag laufen. **Ersetzt** `price_history.csv` komplett -
+kein Zusammenführen mit zuvor live gesammelten Wochen nötig, da der Backfill
+dieselben (und ältere) Wochen ohnehin mit abdeckt.
 
 ## Strategie hinzufügen
 

--- a/scripts/backfill_history.py
+++ b/scripts/backfill_history.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Einmaliger historischer Backfill von data/price_history.csv via Alpha Vantage.
+
+Ersetzt die bestehende Kurshistorie komplett durch echte historische
+Wochenschlusskurse (``TIME_SERIES_WEEKLY`` / ``DIGITAL_CURRENCY_WEEKLY`` -
+liefern die komplette verfuegbare Historie in EINEM Request pro Ticker,
+anders als das fuer den woechentlichen Live-Abruf genutzte ``GLOBAL_QUOTE``),
+statt nur die seit Projektstart live gesammelten paar Wochen zu haben.
+USD-notierte Einzelaktien (siehe ``sources.alphavantage.USD_TICKERS``) werden
+mit dem jeweils zeitgleichen woechentlichen EUR/USD-Kurs (``FX_WEEKLY``) in
+EUR umgerechnet, damit die Historie waehrungskonsistent zum Rest des
+Portfolios ist - dieselbe Umrechnung, die auch der laufende Live-Abruf
+(``run_fetch.py``) fuer diese Ticker vornimmt.
+
+Verbraucht ca. 18 Requests (16 nicht-Krypto-Ticker + 1x FX_WEEKLY + 1x
+Krypto) - passt in das taegliche Alpha-Vantage-Free-Tier-Limit von 25, sollte
+aber NICHT mehrfach am selben Tag laufen (das Limit gilt pro Tag und API-Key,
+nicht pro Skriptlauf).
+
+Nutzung:
+    python scripts/backfill_history.py --years 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+import time
+from datetime import date, timedelta
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from boersenspiel.history_store import DEFAULT_DATA_DIR, FETCH_LOG_HEADER, PRICE_HISTORY_HEADER, record_week
+from boersenspiel.instruments import TICKERS
+from boersenspiel.sources import PriceQuote
+from boersenspiel.sources.alphavantage import USD_TICKERS, AlphaVantageSource
+
+_REQUEST_INTERVAL_SECONDS = 1.1
+
+
+def _iso_week(d: date) -> tuple[int, int]:
+    iso = d.isocalendar()
+    return iso[0], iso[1]
+
+
+def _reset_data_files(data_dir: Path) -> None:
+    """Setzt price_history.csv/fetch_log.csv auf den leeren Header zurueck -
+    der Backfill baut die komplette Historie neu aus Alpha-Vantage-Daten auf."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    with (data_dir / "price_history.csv").open("w", newline="") as f:
+        csv.writer(f).writerow(PRICE_HISTORY_HEADER)
+    with (data_dir / "fetch_log.csv").open("w", newline="") as f:
+        csv.writer(f).writerow(FETCH_LOG_HEADER)
+
+
+def _nearest_fx_rate(rates: dict[date, float], sorted_dates: list[date], target: date) -> float | None:
+    """Naechstgelegener FX-Kurs an oder vor ``target`` (Forward-Fill der
+    letzten bekannten Woche), sonst der frueheste verfuegbare Kurs."""
+    if not sorted_dates:
+        return None
+    candidates = [d for d in sorted_dates if d <= target]
+    return rates[candidates[-1]] if candidates else rates[sorted_dates[0]]
+
+
+def collect_weekly_series(
+    source: AlphaVantageSource, tickers: list[str], since: date
+) -> dict[str, dict[date, float]]:
+    """Holt die woechentliche Kurshistorie (in EUR) fuer alle ``tickers`` ab
+    ``since``. Reine Datenbeschaffung + Waehrungsumrechnung, keine
+    Dateizugriffe - macht die Logik unabhaengig testbar von echten
+    Netzwerkaufrufen und von ``record_week``."""
+    per_ticker: dict[str, dict[date, float]] = {}
+    non_crypto = [t for t in tickers if t != "BTC-EUR"]
+
+    for i, ticker in enumerate(non_crypto):
+        if i > 0:
+            time.sleep(_REQUEST_INTERVAL_SECONDS)
+        print(f"  {ticker} ...", file=sys.stderr)
+        per_ticker[ticker] = source.fetch_weekly_history(ticker, since)
+
+    usd_tickers_present = [t for t in non_crypto if t in USD_TICKERS]
+    if usd_tickers_present:
+        time.sleep(_REQUEST_INTERVAL_SECONDS)
+        print("  EUR/USD-Historie (FX_WEEKLY) ...", file=sys.stderr)
+        fx_rates = source.fetch_fx_weekly_eur_per_usd(since)
+        fx_dates_sorted = sorted(fx_rates)
+        for ticker in usd_tickers_present:
+            per_ticker[ticker] = {
+                d: usd_price * rate
+                for d, usd_price in per_ticker[ticker].items()
+                if (rate := _nearest_fx_rate(fx_rates, fx_dates_sorted, d)) is not None
+            }
+
+    if "BTC-EUR" in tickers:
+        time.sleep(_REQUEST_INTERVAL_SECONDS)
+        print("  BTC-EUR ...", file=sys.stderr)
+        per_ticker["BTC-EUR"] = source.fetch_crypto_weekly_history(since)
+
+    return per_ticker
+
+
+def write_backfilled_history(per_ticker: dict[str, dict[date, float]], data_dir: Path) -> int:
+    """Schreibt die gesammelte Kurshistorie ueber ``history_store.record_week``
+    (einziger Schreibzugriff auf die CSVs) und liefert die Anzahl geschriebener
+    Wochen. Nutzt fuer fehlende Ticker/Wochen exakt denselben Carry-Forward-
+    Mechanismus wie der Live-Abruf."""
+    by_week: dict[str, dict[tuple[int, int], float]] = {
+        ticker: {_iso_week(d): price for d, price in series.items()} for ticker, series in per_ticker.items()
+    }
+
+    weeks: dict[tuple[int, int], date] = {}
+    for series in per_ticker.values():
+        for d in series:
+            key = _iso_week(d)
+            if key not in weeks or d > weeks[key]:
+                weeks[key] = d
+
+    _reset_data_files(data_dir)
+
+    for week_key, week_date in sorted(weeks.items()):
+        quotes: dict[str, PriceQuote] = {}
+        for ticker in TICKERS:
+            price = by_week.get(ticker, {}).get(week_key)
+            if price is None:
+                quotes[ticker] = PriceQuote(ticker, None, "missing", "alphavantage-backfill")
+            else:
+                quotes[ticker] = PriceQuote(ticker, price, "ok", "alphavantage-backfill")
+        record_week(week_date, quotes, data_dir=data_dir)
+
+    return len(weeks)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--years", type=int, default=5, help="Wie viele Jahre historischer Daten (Default: 5)")
+    parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR, help="Zielverzeichnis (Default: data/)")
+    args = parser.parse_args()
+
+    since = date.today() - timedelta(days=365 * args.years)
+    source = AlphaVantageSource()
+
+    print(f"Backfill ab {since.isoformat()} fuer {len(TICKERS)} Ticker ...", file=sys.stderr)
+    per_ticker = collect_weekly_series(source, TICKERS, since)
+    week_count = write_backfilled_history(per_ticker, args.data_dir)
+
+    print(f"Fertig: {week_count} Wochen zurueckgeschrieben nach {args.data_dir / 'price_history.csv'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -35,8 +35,13 @@ ALPHAVANTAGE_URL = "https://www.alphavantage.co/query"
 # eigenen Krypto-Endpunkt, siehe _fetch_crypto.
 #
 # Einzelaktien-Satellit: US-notierte Werte (inkl. ADRs wie BYDDY/RHHBY)
-# laufen direkt unter ihrem Ticker in USD, nur SMA Solar (S92) ist analog zu
-# den ETFs oben ueber die Xetra-Notierung (".DEX") angebunden.
+# laufen direkt unter ihrem Ticker in USD (liquideste Notierung - eine
+# Xetra/Frankfurt-EUR-Notierung existiert nicht fuer jeden Wert, z. B. nicht
+# fuer Coca-Cola), nur SMA Solar (S92) ist analog zu den ETFs oben ueber die
+# Xetra-Notierung (".DEX") angebunden und damit schon in EUR. Die restlichen
+# USD-Werte werden bei jedem Abruf per aktuellem EUR/USD-Kurs umgerechnet
+# (siehe USD_TICKERS/_fetch_usd_eur_rate) - die Engine kennt sonst keine
+# Waehrungen und wuerde USD-Betraege sonst faelschlich als EUR behandeln.
 ALPHAVANTAGE_SYMBOLS: dict[str, str] = {
     "EUNL": "EUNL.DEX",
     "EUNA": "EUNA.DEX",
@@ -56,6 +61,10 @@ ALPHAVANTAGE_SYMBOLS: dict[str, str] = {
     "RHHBY": "RHHBY",
 }
 
+# Ticker, deren Alpha-Vantage-Symbol in USD notiert - Kurs wird bei jedem
+# Abruf per aktuellem EUR/USD-Kurs in EUR umgerechnet.
+USD_TICKERS: frozenset[str] = frozenset({"LITE", "BYDDY", "SEDG", "TSLA", "PLTR", "MSTR", "RIVN", "KO", "RHHBY"})
+
 _REQUEST_INTERVAL_SECONDS = 1.1
 
 
@@ -73,19 +82,67 @@ class AlphaVantageSource:
 
     def fetch(self, tickers: list[str], as_of: date) -> dict[str, PriceQuote]:
         results: dict[str, PriceQuote] = {}
-        for i, ticker in enumerate(tickers):
-            if i > 0:
+        # EUR/USD-Kurs nur einmal pro fetch()-Aufruf laden (nicht pro Ticker) -
+        # gilt fuer alle USD-Ticker gemeinsam am selben Stichtag.
+        usd_eur_rate: float | None = None
+        usd_eur_rate_fetched = False
+        is_first_request = True
+
+        def pace() -> None:
+            nonlocal is_first_request
+            if not is_first_request:
                 time.sleep(_REQUEST_INTERVAL_SECONDS)
+            is_first_request = False
+
+        for ticker in tickers:
             if ticker == "BTC-EUR":
+                pace()
                 results[ticker] = self._fetch_crypto(ticker)
+            elif ticker in USD_TICKERS:
+                if not usd_eur_rate_fetched:
+                    pace()
+                    usd_eur_rate = self._fetch_usd_eur_rate()
+                    usd_eur_rate_fetched = True
+                pace()
+                results[ticker] = self._fetch_quote(ticker, fx_rate=usd_eur_rate)
             else:
+                pace()
                 results[ticker] = self._fetch_quote(ticker)
         return results
 
-    def _fetch_quote(self, ticker: str) -> PriceQuote:
+    def _fetch_usd_eur_rate(self) -> float | None:
+        try:
+            resp = requests.get(
+                ALPHAVANTAGE_URL,
+                params={
+                    "function": "CURRENCY_EXCHANGE_RATE",
+                    "from_currency": "USD",
+                    "to_currency": "EUR",
+                    "apikey": self.api_key,
+                },
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            rate_str = data.get("Realtime Currency Exchange Rate", {}).get("5. Exchange Rate")
+            if not rate_str:
+                print(f"alphavantage: kein EUR/USD-Kurs erhalten: {data!r}", file=sys.stderr)
+                return None
+            return float(rate_str)
+        except Exception as exc:
+            print(f"alphavantage: EUR/USD-Kursabruf fehlgeschlagen: {exc!r}", file=sys.stderr)
+            return None
+
+    def _fetch_quote(self, ticker: str, fx_rate: float | None = None) -> PriceQuote:
         symbol = ALPHAVANTAGE_SYMBOLS.get(ticker)
         if symbol is None:
             print(f"alphavantage: kein Symbol-Mapping fuer {ticker}", file=sys.stderr)
+            return PriceQuote(ticker, None, "missing", "alphavantage")
+        if ticker in USD_TICKERS and fx_rate is None:
+            # Ohne EUR/USD-Kurs wuerde der USD-Preis faelschlich als EUR
+            # gespeichert - lieber "missing" (carry-forward greift) als eine
+            # falsche Waehrung in die Historie schreiben.
+            print(f"alphavantage: kein EUR/USD-Kurs verfuegbar, ueberspringe {ticker}", file=sys.stderr)
             return PriceQuote(ticker, None, "missing", "alphavantage")
         try:
             resp = requests.get(
@@ -99,7 +156,10 @@ class AlphaVantageSource:
             if not price_str:
                 print(f"alphavantage: keine Kursdaten fuer {symbol}: {data!r}", file=sys.stderr)
                 return PriceQuote(ticker, None, "missing", "alphavantage")
-            return PriceQuote(ticker, float(price_str), "ok", "alphavantage")
+            price = float(price_str)
+            if fx_rate is not None:
+                price *= fx_rate
+            return PriceQuote(ticker, price, "ok", "alphavantage")
         except Exception as exc:
             print(f"alphavantage fehlgeschlagen fuer {symbol}: {exc!r}", file=sys.stderr)
             return PriceQuote(ticker, None, "missing", "alphavantage")
@@ -139,3 +199,86 @@ class AlphaVantageSource:
         except Exception as exc:
             print(f"alphavantage fehlgeschlagen fuer BTC-EUR: {exc!r}", file=sys.stderr)
             return PriceQuote(ticker, None, "missing", "alphavantage")
+
+    # --- Historische Wochenkurse (fuer den einmaligen Backfill, siehe
+    # scripts/backfill_history.py) - liefern die KOMPLETTE verfuegbare
+    # Historie in einem einzigen Request, im Gegensatz zu GLOBAL_QUOTE (nur
+    # aktueller Kurs). Werfen bewusst statt "missing" zurueckzugeben, da ein
+    # Backfill-Lauf bei einem fehlgeschlagenen Ticker abbrechen und nicht
+    # eine Luecke fuer die gesamte Historie dieses Tickers stillschweigend
+    # hinnehmen soll.
+
+    def fetch_weekly_history(self, ticker: str, since: date) -> dict[date, float]:
+        """Woechentliche Schlusskurse eines nicht-Krypto-Tickers ab ``since``,
+        in der nativen Waehrung seines Alpha-Vantage-Symbols (EUR fuer
+        .DEX/.AMS-Symbole, sonst USD - Umrechnung erfolgt separat, siehe
+        ``fetch_fx_weekly_eur_per_usd``)."""
+        symbol = ALPHAVANTAGE_SYMBOLS.get(ticker)
+        if symbol is None:
+            raise ValueError(f"kein Alpha-Vantage-Symbol-Mapping fuer {ticker!r}")
+        resp = requests.get(
+            ALPHAVANTAGE_URL,
+            params={"function": "TIME_SERIES_WEEKLY", "symbol": symbol, "apikey": self.api_key},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        series = data.get("Weekly Time Series")
+        if not series:
+            raise RuntimeError(f"keine woechentliche Historie fuer {symbol}: {data!r}")
+        return _parse_weekly_close_series(series, since)
+
+    def fetch_fx_weekly_eur_per_usd(self, since: date) -> dict[date, float]:
+        """Woechentlicher EUR-Gegenwert von 1 USD ab ``since`` (fuer die
+        Umrechnung der USD-notierten Einzelaktien beim Backfill)."""
+        resp = requests.get(
+            ALPHAVANTAGE_URL,
+            params={"function": "FX_WEEKLY", "from_symbol": "USD", "to_symbol": "EUR", "apikey": self.api_key},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        series = data.get("Weekly Time Series (FX)")
+        if not series:
+            raise RuntimeError(f"keine woechentliche FX-Historie fuer USD/EUR: {data!r}")
+        return _parse_weekly_close_series(series, since)
+
+    def fetch_crypto_weekly_history(self, since: date) -> dict[date, float]:
+        """Woechentliche BTC-EUR-Historie ab ``since``."""
+        resp = requests.get(
+            ALPHAVANTAGE_URL,
+            params={"function": "DIGITAL_CURRENCY_WEEKLY", "symbol": "BTC", "market": "EUR", "apikey": self.api_key},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        series = data.get("Time Series (Digital Currency Weekly)") or data.get(
+            "Weekly Time Series (Digital Currency Weekly)"
+        )
+        if not series:
+            raise RuntimeError(f"keine woechentliche Kryptohistorie fuer BTC-EUR: {data!r}")
+        result: dict[date, float] = {}
+        for date_str, values in series.items():
+            d = date.fromisoformat(date_str)
+            if d < since:
+                continue
+            close_key = next((k for k in values if k.startswith("4") and "EUR" in k), None) or next(
+                (k for k in values if k.startswith("4.")), None
+            )
+            if close_key is None:
+                continue
+            result[d] = float(values[close_key])
+        return result
+
+
+def _parse_weekly_close_series(series: dict, since: date) -> dict[date, float]:
+    result: dict[date, float] = {}
+    for date_str, values in series.items():
+        d = date.fromisoformat(date_str)
+        if d < since:
+            continue
+        close_str = values.get("4. close")
+        if close_str is None:
+            continue
+        result[d] = float(close_str)
+    return result

--- a/tests/test_alphavantage.py
+++ b/tests/test_alphavantage.py
@@ -108,3 +108,143 @@ def test_request_exception_yields_missing(monkeypatch: pytest.MonkeyPatch):
     result = source.fetch(["EUNL"], date(2026, 8, 24))
 
     assert result["EUNL"].status == "missing"
+
+
+# --- USD-Ticker: EUR/USD-Umrechnung (Waehrungskonsistenz-Fix) ------------------
+
+
+def _dispatch_by_function(responses: dict[str, dict]):
+    def _get(url, params, timeout):
+        return _FakeResponse(responses[params["function"]])
+
+    return _get
+
+
+def test_usd_ticker_is_converted_to_eur(monkeypatch: pytest.MonkeyPatch):
+    responses = {
+        "CURRENCY_EXCHANGE_RATE": {"Realtime Currency Exchange Rate": {"5. Exchange Rate": "0.90"}},
+        "GLOBAL_QUOTE": {"Global Quote": {"05. price": "100.00"}},
+    }
+    monkeypatch.setattr(av.requests, "get", _dispatch_by_function(responses))
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["LITE"], date(2026, 8, 24))
+
+    assert result["LITE"].status == "ok"
+    assert result["LITE"].price == pytest.approx(90.0)
+
+
+def test_usd_eur_rate_fetched_only_once_for_multiple_usd_tickers(monkeypatch: pytest.MonkeyPatch):
+    call_count = {"CURRENCY_EXCHANGE_RATE": 0, "GLOBAL_QUOTE": 0}
+
+    def _get(url, params, timeout):
+        call_count[params["function"]] += 1
+        if params["function"] == "CURRENCY_EXCHANGE_RATE":
+            return _FakeResponse({"Realtime Currency Exchange Rate": {"5. Exchange Rate": "0.90"}})
+        return _FakeResponse({"Global Quote": {"05. price": "100.00"}})
+
+    monkeypatch.setattr(av.requests, "get", _get)
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["LITE", "TSLA"], date(2026, 8, 24))
+
+    assert call_count["CURRENCY_EXCHANGE_RATE"] == 1
+    assert call_count["GLOBAL_QUOTE"] == 2
+    assert result["LITE"].price == pytest.approx(90.0)
+    assert result["TSLA"].price == pytest.approx(90.0)
+
+
+def test_eur_ticker_is_not_converted(monkeypatch: pytest.MonkeyPatch):
+    def _fail_on_fx(url, params, timeout):
+        if params["function"] == "CURRENCY_EXCHANGE_RATE":
+            raise AssertionError("EUR-Ticker sollte keinen EUR/USD-Kurs abrufen")
+        return _FakeResponse({"Global Quote": {"05. price": "82.10"}})
+
+    monkeypatch.setattr(av.requests, "get", _fail_on_fx)
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["EUNL"], date(2026, 8, 24))
+
+    assert result["EUNL"].price == 82.10
+
+
+def test_usd_ticker_yields_missing_when_fx_rate_unavailable(monkeypatch: pytest.MonkeyPatch):
+    def _get(url, params, timeout):
+        if params["function"] == "CURRENCY_EXCHANGE_RATE":
+            return _FakeResponse({"Information": "rate limit"})
+        raise AssertionError("sollte ohne EUR/USD-Kurs keinen Kurs mehr abrufen")
+
+    monkeypatch.setattr(av.requests, "get", _get)
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["LITE"], date(2026, 8, 24))
+
+    assert result["LITE"].status == "missing"
+    assert result["LITE"].price is None
+
+
+# --- Historische Wochenkurse (fuer scripts/backfill_history.py) ---------------
+
+
+def test_fetch_weekly_history_filters_by_since_date(monkeypatch: pytest.MonkeyPatch):
+    payload = {
+        "Weekly Time Series": {
+            "2026-08-14": {"4. close": "90.00"},
+            "2020-01-03": {"4. close": "50.00"},
+        }
+    }
+    monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse(payload))
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch_weekly_history("EUNL", since=date(2024, 1, 1))
+
+    assert result == {date(2026, 8, 14): 90.0}
+
+
+def test_fetch_weekly_history_raises_for_unmapped_ticker():
+    source = av.AlphaVantageSource(api_key="dummy")
+    with pytest.raises(ValueError):
+        source.fetch_weekly_history("UNKNOWN", since=date(2020, 1, 1))
+
+
+def test_fetch_weekly_history_raises_when_series_missing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse({"Information": "..."}))
+    source = av.AlphaVantageSource(api_key="dummy")
+    with pytest.raises(RuntimeError):
+        source.fetch_weekly_history("EUNL", since=date(2020, 1, 1))
+
+
+def test_fetch_fx_weekly_eur_per_usd(monkeypatch: pytest.MonkeyPatch):
+    payload = {
+        "Weekly Time Series (FX)": {
+            "2026-08-14": {"4. close": "0.9200"},
+            "2019-01-04": {"4. close": "0.8700"},
+        }
+    }
+    monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse(payload))
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch_fx_weekly_eur_per_usd(since=date(2024, 1, 1))
+
+    assert result == {date(2026, 8, 14): 0.92}
+
+
+def test_fetch_crypto_weekly_history_prefers_eur_column(monkeypatch: pytest.MonkeyPatch):
+    payload = {
+        "Time Series (Digital Currency Weekly)": {
+            "2026-08-14": {"4a. close (USD)": "70000.00", "4b. close (EUR)": "58000.00"},
+            "2015-01-04": {"4a. close (USD)": "300.00", "4b. close (EUR)": "250.00"},
+        }
+    }
+    monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse(payload))
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch_crypto_weekly_history(since=date(2024, 1, 1))
+
+    assert result == {date(2026, 8, 14): 58000.0}
+
+
+def test_fetch_crypto_weekly_history_flat_format(monkeypatch: pytest.MonkeyPatch):
+    payload = {
+        "Time Series (Digital Currency Weekly)": {
+            "2026-08-14": {"4. close": "58000.00"},
+        }
+    }
+    monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse(payload))
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch_crypto_weekly_history(since=date(2020, 1, 1))
+
+    assert result == {date(2026, 8, 14): 58000.0}

--- a/tests/test_backfill_history.py
+++ b/tests/test_backfill_history.py
@@ -1,0 +1,139 @@
+"""Tests für den einmaligen historischen Backfill (``scripts/backfill_history.py``).
+
+Reine Logik-Tests ohne echten Netzwerkzugriff: ``collect_weekly_series`` wird
+gegen ein Fake-``AlphaVantageSource``-Objekt getestet (keine HTTP-Mocks
+nötig, da die Methode nur die öffentlichen ``fetch_*``-Methoden aufruft),
+``write_backfilled_history`` gegen ``tmp_path`` als Daten-Verzeichnis.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import backfill_history as bh  # noqa: E402
+
+from boersenspiel.history_store import read_price_history  # noqa: E402
+from boersenspiel.instruments import TICKERS  # noqa: E402
+
+
+class _FakeSource:
+    def __init__(self, weekly: dict[str, dict[date, float]], fx: dict[date, float], crypto: dict[date, float]):
+        self._weekly = weekly
+        self._fx = fx
+        self._crypto = crypto
+        self.weekly_history_calls: list[str] = []
+
+    def fetch_weekly_history(self, ticker: str, since: date) -> dict[date, float]:
+        self.weekly_history_calls.append(ticker)
+        return {d: p for d, p in self._weekly.get(ticker, {}).items() if d >= since}
+
+    def fetch_fx_weekly_eur_per_usd(self, since: date) -> dict[date, float]:
+        return {d: r for d, r in self._fx.items() if d >= since}
+
+    def fetch_crypto_weekly_history(self, since: date) -> dict[date, float]:
+        return {d: p for d, p in self._crypto.items() if d >= since}
+
+
+def test_collect_weekly_series_converts_usd_tickers_to_eur():
+    source = _FakeSource(
+        weekly={
+            "EUNL": {date(2026, 8, 14): 85.0},
+            "LITE": {date(2026, 8, 14): 100.0},
+        },
+        fx={date(2026, 8, 14): 0.90},
+        crypto={date(2026, 8, 14): 58000.0},
+    )
+    result = bh.collect_weekly_series(source, ["EUNL", "LITE", "BTC-EUR"], since=date(2020, 1, 1))
+
+    assert result["EUNL"][date(2026, 8, 14)] == 85.0  # EUR-Ticker unveraendert
+    assert result["LITE"][date(2026, 8, 14)] == pytest.approx(90.0)  # 100 USD * 0.90
+    assert result["BTC-EUR"][date(2026, 8, 14)] == 58000.0
+
+
+def test_collect_weekly_series_skips_fx_fetch_when_no_usd_tickers():
+    source = _FakeSource(weekly={"EUNL": {date(2026, 8, 14): 85.0}}, fx={}, crypto={})
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("FX_WEEKLY sollte ohne USD-Ticker nicht abgerufen werden")
+
+    source.fetch_fx_weekly_eur_per_usd = _fail
+    result = bh.collect_weekly_series(source, ["EUNL"], since=date(2020, 1, 1))
+
+    assert result["EUNL"][date(2026, 8, 14)] == 85.0
+
+
+def test_collect_weekly_series_forward_fills_fx_rate_for_missing_week():
+    # FX-Kurs existiert nur fuer eine frueher Woche - die USD-Aktie hat aber
+    # auch eine spaetere Woche, fuer die es (noch) keinen neueren FX-Kurs gibt.
+    source = _FakeSource(
+        weekly={"LITE": {date(2026, 8, 14): 100.0, date(2026, 8, 21): 110.0}},
+        fx={date(2026, 8, 14): 0.90},
+        crypto={},
+    )
+    result = bh.collect_weekly_series(source, ["LITE"], since=date(2020, 1, 1))
+
+    assert result["LITE"][date(2026, 8, 14)] == pytest.approx(90.0)
+    assert result["LITE"][date(2026, 8, 21)] == pytest.approx(99.0)  # Forward-Fill des 0.90-Kurses
+
+
+def test_write_backfilled_history_writes_rows_and_carries_forward_missing_tickers(tmp_path: Path):
+    per_ticker = {
+        "EUNL": {date(2026, 8, 14): 85.0, date(2026, 8, 21): 87.0},
+        "EUNA": {date(2026, 8, 14): 5.0},  # fehlt in der zweiten Woche -> carry forward erwartet
+    }
+    week_count = bh.write_backfilled_history(per_ticker, tmp_path)
+
+    assert week_count == 2
+    rows = read_price_history(tmp_path)
+    assert len(rows) == 2
+    assert rows[0].date == date(2026, 8, 14)
+    assert rows[0].prices["EUNL"] == Decimal("85.0")
+    assert rows[0].prices["EUNA"] == Decimal("5.0")
+    assert rows[1].prices["EUNL"] == Decimal("87.0")
+    assert rows[1].prices["EUNA"] == Decimal("5.0")  # carried forward
+
+
+def test_write_backfilled_history_resets_existing_files(tmp_path: Path):
+    (tmp_path / "price_history.csv").write_text("Date,OLDTICKER\n2000-01-01,1\n")
+
+    per_ticker = {"EUNL": {date(2026, 8, 14): 85.0}}
+    bh.write_backfilled_history(per_ticker, tmp_path)
+
+    rows = read_price_history(tmp_path)
+    assert len(rows) == 1
+    assert rows[0].date == date(2026, 8, 14)
+
+
+def test_write_backfilled_history_groups_by_iso_week_using_latest_date():
+    # Zwei Ticker mit leicht unterschiedlichem "letzten Handelstag" (Donnerstag
+    # vs. Freitag) derselben ISO-Kalenderwoche sollen in DIESELBE Zeile fallen.
+    per_ticker = {
+        "EUNL": {date(2026, 8, 14): 85.0},  # Freitag, KW 33/2026
+        "EUNA": {date(2026, 8, 13): 5.0},  # Donnerstag, dieselbe ISO-Woche
+    }
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as tmp:
+        week_count = bh.write_backfilled_history(per_ticker, Path(tmp))
+        rows = read_price_history(Path(tmp))
+
+    assert week_count == 1
+    assert len(rows) == 1
+    assert rows[0].date == date(2026, 8, 14)  # spaeteres Datum der Woche gewinnt
+    assert rows[0].prices["EUNA"] == Decimal("5.0")
+
+
+def test_all_tickers_have_weekly_fetch_support():
+    """Regressionsschutz: Jeder Ticker aus instruments.py muss entweder ueber
+    fetch_weekly_history (Symbol-Mapping vorhanden) oder als BTC-EUR ueber den
+    Krypto-Pfad im Backfill abgedeckt sein."""
+    from boersenspiel.sources.alphavantage import ALPHAVANTAGE_SYMBOLS
+
+    fehlend = [t for t in TICKERS if t != "BTC-EUR" and t not in ALPHAVANTAGE_SYMBOLS]
+    assert fehlend == []


### PR DESCRIPTION
## Summary

- **Währungskonsistenz-Fix:** Die 9 USD-notierten Einzelaktien im Satelliten-Topf (alle außer S92/SMA Solar, das schon über Xetra in EUR läuft) wurden bisher unkonvertiert gespeichert — die Engine kennt keine Währungen und hätte USD-Beträge fälschlich als EUR behandelt (verzerrt Rendite/Gewichtungen). `AlphaVantageSource.fetch()` rechnet sie jetzt bei jedem Abruf per aktuellem `CURRENCY_EXCHANGE_RATE` (USD→EUR) um; schlägt der FX-Abruf fehl, werden betroffene Ticker als `missing` markiert statt falsch umgerechnet zu werden (Carry-Forward greift). Eine durchgängige EUR-Notierung an der Frankfurter Börse/Xetra existiert nicht für jeden Wert (z. B. nicht für Coca-Cola), deshalb dieser Ansatz statt Symbol-Wechsel.
- **Historischer Backfill:** `data/price_history.csv` wächst im Normalbetrieb nur Woche für Woche seit Projektstart (`GLOBAL_QUOTE` liefert nur den aktuellen Kurs). Neues `scripts/backfill_history.py` nutzt `TIME_SERIES_WEEKLY`/`DIGITAL_CURRENCY_WEEKLY` (komplette verfügbare Historie in **einem** Request pro Ticker) und schreibt über `history_store.record_week()` (derselbe Pfad wie der Live-Abruf) die komplette Historie neu — USD-Ticker werden mit dem historischen `FX_WEEKLY`-Kurs derselben Woche umgerechnet (Forward-Fill bei Lücken). Verbraucht einmalig ca. 18 Requests.

## Bekannter offener Punkt

Das Backfill-Skript ist implementiert und per Mock-Tests verifiziert, aber **noch nicht live gegen die echte Alpha-Vantage-API gelaufen** — beim Verifizieren der Satelliten-Ticker-Symbole (vorheriger PR) wurde das Tageslimit (25 Requests/Tag) aufgebraucht. Vor dem ersten echten Lauf (`python scripts/backfill_history.py`) kurz gegenprüfen, dass `TIME_SERIES_WEEKLY`/`FX_WEEKLY`/`DIGITAL_CURRENCY_WEEKLY` im Free-Tier ohne Premium-Plan verfügbar sind.

## Test plan

- [x] `pytest -q` — gesamte Testsuite (68 Tests, inkl. neuer `tests/test_backfill_history.py` und Erweiterungen in `tests/test_alphavantage.py` für FX-Umrechnung, Forward-Fill und die neuen `fetch_weekly_history`/`fetch_fx_weekly_eur_per_usd`/`fetch_crypto_weekly_history`-Methoden) grün, alles gegen gemockte HTTP-Antworten (kein echter Netzwerkzugriff in Tests).
- [x] `python -m py_compile` auf beide geänderten/neuen Skript-Dateien.
- [ ] Live-Lauf gegen echte Alpha-Vantage-API noch offen (Tageslimit erschöpft, siehe oben).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLB1ojRWESLQ6ASSoNkfLR)_