### PR TITLE
Workflow-Frequenz auf täglich + Doku-Korrektur Vergleichsübersicht

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -1,9 +1,13 @@
-name: Wöchentliches Kurs-Update & Dashboard
+name: Tägliches Kurs-Update & Dashboard
 
 on:
   schedule:
-    # Montag 06:00 UTC - nach Xetra-Vorwochenschluss, vor Xetra-Handelsbeginn.
-    - cron: "0 6 * * 1"
+    # Taeglich 06:00 UTC - vor Xetra-Handelsbeginn. record_week() ist ueber
+    # die ISO-Kalenderwoche idempotent (siehe history_store.py), ein
+    # taeglicher Lauf erzeugt also KEINE taegliche Datenpunkt-Granularitaet -
+    # er aktualisiert lediglich denselben Wochen-Datensatz mit dem jeweils
+    # aktuellsten verfuegbaren Kurs, bis die Woche vorbei ist.
+    - cron: "0 6 * * *"
   workflow_dispatch: {}
 
 permissions:
@@ -43,7 +47,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/price_history.csv data/fetch_log.csv
-          git diff --cached --quiet || git commit -m "chore: wöchentliches Kurs-Update $(date -u +%F)"
+          git diff --cached --quiet || git commit -m "chore: tägliches Kurs-Update $(date -u +%F)"
           git push
 
       - name: Pages-Artefakt hochladen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,11 @@ inkrementell fortgeschrieben).
 - `dashboard.py` + `templates/dashboard.html.j2` — reine Darstellungsschicht,
   rendert `engine.simulate()`-Ergebnisse für alle (oder eine ausgewählte)
   Strategie(n) aus `STRATEGIES` nach `docs/index.html`. Chart.js per CDN.
+  Ganz oben steht eine strategieübergreifende Vergleichsübersicht
+  ("Übersicht: Rendite im Vergleich" - Balkendiagramm + nach Rendite
+  sortierte Tabelle mit Sprunglinks zu den Detailabschnitten), Rendite und
+  URL-Slug je Strategie werden rein aus den vorhandenen
+  `engine.simulate()`-Ergebnissen abgeleitet.
 
 ### Kursquelle wechseln
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Virtuelles Portfolio-Dashboard nach einer Barbell-Strategie (siehe
 `Pflichtenheft_PortfolioProjekt_v2.md` für die ursprünglichen Anforderungen).
-Wöchentlicher Kursabruf via GitHub Actions, Kurshistorie als CSV im Repo,
+Täglicher Kursabruf via GitHub Actions, Kurshistorie als CSV im Repo,
 statisches Dashboard (Chart.js) auf GitHub Pages. Es gibt keinen PR-Workflow
 in diesem Repo — Änderungen gehen direkt auf den Default-Branch
 (`claude/pflichtenheft-umsetzung-planen-6kf05s`, fungiert als `main`, da das
@@ -156,12 +156,16 @@ Satelliten-Ticker-Symbole aufgebraucht) — vor dem ersten echten Lauf kurz
 gegenprüfen, dass `TIME_SERIES_WEEKLY`/`FX_WEEKLY`/`DIGITAL_CURRENCY_WEEKLY`
 im Free-Tier verfügbar sind.
 
-### GitHub Actions (`.github/workflows/weekly-update.yml`)
+### GitHub Actions (`.github/workflows/daily-update.yml`)
 
-Läuft wöchentlich (Montag 06:00 UTC) + `workflow_dispatch`: Tests →
+Läuft täglich (06:00 UTC) + `workflow_dispatch`: Tests →
 Kursabruf (Alpha Vantage) → Dashboard-Build → Commit von
 `data/price_history.csv`/`data/fetch_log.csv` zurück ins Repo →
-GitHub-Pages-Deploy. Braucht die Secrets/Settings: Repo-Secret
+GitHub-Pages-Deploy. `record_week()` bleibt über die ISO-Kalenderwoche
+idempotent (siehe `history_store.py`) - der tägliche Lauf erzeugt also
+keine tägliche Datenpunkt-Granularität, sondern aktualisiert bis Wochenende
+denselben Wochen-Datensatz mit dem jeweils aktuellsten Kurs. Braucht die
+Secrets/Settings: Repo-Secret
 `ALPHAVANTAGE_API_KEY`; Settings → Actions → Workflow permissions → "Read
 and write permissions"; Settings → Pages → Source → "GitHub Actions".
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Kurshistorie + identische Strategie ergeben immer dasselbe Ergebnis.
 | `src/boersenspiel/history_store.py` | Einziger Schreibzugriff auf `data/price_history.csv` / `data/fetch_log.csv` |
 | `src/boersenspiel/sources/` | Austauschbare Kursquellen (Standard: `alphavantage.py`) |
 | `src/boersenspiel/engine.py` | Reine Simulationsfunktion: (Kurshistorie, Strategie) → Portfolio-/Steuerzustand |
-| `src/boersenspiel/dashboard.py` | Rendert Simulationsergebnisse als `docs/index.html` |
+| `src/boersenspiel/dashboard.py` | Rendert Simulationsergebnisse als `docs/index.html`, inkl. strategieübergreifender Renditen-Vergleichsübersicht oben |
 | `scripts/run_fetch.py` | Automatisierter wöchentlicher Kursabruf (GitHub Actions) |
 | `scripts/record_prices.py` | Manueller Andockpunkt für Kurse aus anderer Quelle (z. B. Cowork/Websuche) |
 | `scripts/backfill_history.py` | Einmaliger historischer Backfill von `price_history.csv` (echte Wochenkurse statt nur live gesammelter Wochen, siehe unten) |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 Virtuelles Portfolio nach Barbell-Strategie, auf Basis des Pflichtenhefts
 `Pflichtenheft_PortfolioProjekt_v2.md`. Technisch wurde bewusst abweichend
 umgesetzt (siehe [Abweichungen](#abweichungen-vom-pflichtenheft) unten):
-Kursabruf wöchentlich statt täglich, Persistenz als CSV im Git-Repo statt
+Kursabruf-Zeitplan täglich (Cron), aber Kurshistorie bleibt intern
+wochenweise granular (siehe unten), Persistenz als CSV im Git-Repo statt
 Google Sheet, Ausgabe als statisches Dashboard auf GitHub Pages.
 
 ## Architektur
@@ -34,7 +35,7 @@ Kurshistorie + identische Strategie ergeben immer dasselbe Ergebnis.
 | `src/boersenspiel/sources/` | Austauschbare Kursquellen (Standard: `alphavantage.py`) |
 | `src/boersenspiel/engine.py` | Reine Simulationsfunktion: (Kurshistorie, Strategie) → Portfolio-/Steuerzustand |
 | `src/boersenspiel/dashboard.py` | Rendert Simulationsergebnisse als `docs/index.html`, inkl. strategieübergreifender Renditen-Vergleichsübersicht oben |
-| `scripts/run_fetch.py` | Automatisierter wöchentlicher Kursabruf (GitHub Actions) |
+| `scripts/run_fetch.py` | Automatisierter täglicher Kursabruf (GitHub Actions) |
 | `scripts/record_prices.py` | Manueller Andockpunkt für Kurse aus anderer Quelle (z. B. Cowork/Websuche) |
 | `scripts/backfill_history.py` | Einmaliger historischer Backfill von `price_history.csv` (echte Wochenkurse statt nur live gesammelter Wochen, siehe unten) |
 | `scripts/build_dashboard.py` | Baut `docs/index.html` neu aus der aktuellen Kurshistorie |
@@ -74,8 +75,9 @@ werden, ohne Code umzubauen.
 
 1. API-Key auf [alphavantage.co](https://www.alphavantage.co/support/#api-key)
    holen (kostenloser Plan: 25 Requests/Tag, max. 1 Request/Sekunde – bei
-   aktuell 17 Tickern einmal wöchentlich noch ausreichend, aber ohne viel
-   Spielraum für zusätzliche manuelle Abrufe am selben Tag).
+   aktuell 17 Tickern (~18 Requests/Lauf) und **täglichem** Cron praktisch
+   das gesamte Tageslimit, kaum noch Spielraum für zusätzliche manuelle
+   Abrufe am selben Tag).
 2. Als GitHub-Actions-Secret hinterlegen: Settings → Secrets and variables
    → Actions → New repository secret → Name `ALPHAVANTAGE_API_KEY`.
 3. Ticker-Symbole wurden per `SYMBOL_SEARCH` verifiziert und weichen teils
@@ -191,17 +193,25 @@ pytest -q
   Crumb/Cookie-Authentifizierung, die die gepinnte Version (0.2.43) nicht
   mehr unterstützte. Deshalb Umstieg auf Alpha Vantage als Standardquelle.
 - **Alpha Vantage Free-Tier-Limit:** 25 Requests/Tag, max. 1 Request/Sekunde.
-  Bei aktuell 17 Tickern einmal wöchentlich noch unproblematisch, aber kaum
-  noch Puffer für weitere manuelle Abrufe am selben Tag; `AlphaVantageSource`
-  hält zwischen den Requests einen Sleep ein. Schlägt ein Kurs dennoch fehl
-  (z. B. durch Rate-Limit oder eine leere Antwort), wird der letzte bekannte
-  Kurs übernommen und in `fetch_log.csv` vermerkt (nie eine Zeile mit
-  Lücke).
-- **BTC-EUR/Xetra-Zeitversatz:** Ein Montagvormittag-Lauf liefert für die
-  Xetra-ETFs den Freitagsschluss der Vorwoche, für BTC-EUR (24/7-Markt)
-  aber einen zeitlich leicht abweichenden, aktuelleren Kurs – die
-  "wöchentliche" Zeile mischt dadurch Kurse aus einem Fenster von bis zu
-  ca. 2–3 Tagen.
+  Bei aktuell 17 Tickern und **täglichem** Cron (~18 Requests/Tag) wird das
+  Limit praktisch jeden Tag ausgeschöpft, kaum noch Puffer für weitere
+  manuelle Abrufe am selben Tag; `AlphaVantageSource` hält zwischen den
+  Requests einen Sleep ein. Schlägt ein Kurs dennoch fehl (z. B. durch
+  Rate-Limit oder eine leere Antwort), wird der letzte bekannte Kurs
+  übernommen und in `fetch_log.csv` vermerkt (nie eine Zeile mit Lücke).
+- **Täglicher Cron, aber wochenweise Datengranularität:** `record_week()`
+  ist über die ISO-Kalenderwoche idempotent (siehe `history_store.py`) -
+  der tägliche Workflow-Lauf erzeugt deshalb **keine** tägliche
+  Kurshistorie, sondern aktualisiert bis zum Wochenende denselben
+  Wochen-Datensatz mit dem jeweils aktuellsten Kurs. `price_history.csv`
+  bleibt damit weiterhin eine Zeile pro Woche - der tägliche Zeitplan sorgt
+  nur dafür, dass diese Zeile öfter aktualisiert wird, bevor sie für die
+  jeweilige Woche final ist.
+- **BTC-EUR/Zeitversatz innerhalb einer Zeile:** Da BTC-EUR (24/7-Markt) und
+  die Xetra-ETFs (nur an Handelstagen) bei jedem Lauf gemeinsam abgerufen
+  werden, mischt eine Kurszeile je nach Lauftag Kurse aus leicht
+  unterschiedlichen Zeitpunkten (z. B. an einem Wochenende oder Feiertag den
+  letzten Xetra-Schlusskurs mit einem aktuelleren BTC-Kurs).
 - **Einmalige manuelle Repo-Einstellungen** (nicht per Workflow-YAML
   setzbar): Settings → Actions → General → Workflow permissions → "Read and
   write permissions"; Settings → Pages → Source → "GitHub Actions".
@@ -215,7 +225,7 @@ pytest -q
 | Pflichtenheft v2.0 | Diese Implementierung |
 |---|---|
 | Google Drive/Sheets als Kurshistorie | `data/price_history.csv` im Git-Repo |
-| Täglicher Kursabruf via Cowork Scheduled Task | Wöchentlicher Kursabruf via GitHub Actions Cron (Kursquelle austauschbar, siehe oben) |
+| Täglicher Kursabruf via Cowork Scheduled Task | Täglicher Kursabruf via GitHub Actions Cron (Kursquelle austauschbar, siehe oben) - Kurshistorie bleibt aber intern wochenweise granular (`record_week()` ist über die ISO-Kalenderwoche idempotent), der tägliche Lauf aktualisiert bis Wochenende denselben Wochen-Datensatz statt eine tägliche Zeile anzulegen |
 | Dashboard on-demand als Artefakt in einer Unterhaltung | Statische HTML-Seite (Chart.js), automatisch nach jedem Kursabruf neu gebaut, auf GitHub Pages deployed |
 | "Modell B": Kursabruf und Dashboard-Erzeugung getrennt automatisiert | Ein kombinierter Workflow (Kursabruf → Test → Dashboard-Build → Commit → Deploy) |
 | Nur die Barbell-20/80-Strategie | Mehrere austauschbare Strategien (`strategies.py`), Dashboard zeigt sie vergleichend |

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -3,10 +3,14 @@ Scraping - deutlich zuverlässiger für GitHub Actions als yfinance, das
 wiederholt an Yahoos Crumb/Cookie-Authentifizierung scheiterte (siehe README).
 
 Free-Tier-Limits: 25 Requests/Tag, max. 1 Request/Sekunde. Bei aktuell 17
-Tickern (7 Barbell-Basisinstrumente + 10 Einzelaktien-Satellit) einmal
-wöchentlich noch unproblematisch, lässt aber kaum noch Spielraum für
-zusätzliche manuelle Abrufe am selben Tag; zwischen den Requests wird ein
-kleiner Sleep eingehalten, um das Sekundenlimit nicht zu reißen.
+Tickern (7 Barbell-Basisinstrumente + 10 Einzelaktien-Satellit, davon 9 mit
+zusätzlichem EUR/USD-Kursabruf) sind das ca. 18 Requests pro Lauf - der
+tägliche GitHub-Actions-Cron (`daily-update.yml`) verbraucht damit fast das
+gesamte Tageslimit **jeden Tag**, es bleibt kaum noch Spielraum für
+zusätzliche manuelle Abrufe am selben Tag (z. B. den historischen Backfill,
+siehe unten - der sollte an einem Tag laufen, an dem der Cron pausiert oder
+noch nicht gelaufen ist); zwischen den Requests wird ein kleiner Sleep
+eingehalten, um das Sekundenlimit nicht zu reißen.
 
 Läuft in GitHub Actions gegen die reine REST-API (nicht über den
 Alpha-Vantage-MCP-Server, der nur innerhalb einer Claude-Session verfügbar


### PR DESCRIPTION
## Summary

- **Workflow-Frequenz:** `.github/workflows/weekly-update.yml` → `daily-update.yml` umbenannt, Cron von "Montag 06:00 UTC" auf "täglich 06:00 UTC" geändert.
  - **Wichtig:** `record_week()` bleibt über die ISO-Kalenderwoche idempotent (siehe `history_store.py`) — der tägliche Lauf erzeugt dadurch **keine** tägliche Datenpunkt-Granularität in `price_history.csv`, sondern aktualisiert bis Wochenende denselben Wochen-Datensatz mit dem jeweils aktuellsten Kurs. Bewusste Scope-Entscheidung (nur der Cron-Zeitplan geändert, nicht das Datenmodell) — dokumentiert in README ("Bekannte Einschränkungen"/"Abweichungen vom Pflichtenheft"), `CLAUDE.md` und dem `alphavantage.py`-Docstring.
  - Bei ~18 Requests/Lauf (17 Ticker + EUR/USD-Kurs für die USD-Satelliten-Aktien) verbraucht der jetzt tägliche Cron praktisch das gesamte 25-Requests/Tag-Freetier-Limit **jeden Tag** — entsprechend wenig Spielraum für zusätzliche manuelle Abrufe am selben Tag (z. B. den historischen Backfill aus Issue #6).
- **Doku-Korrektur** (ursprünglicher Zweck dieses PRs): Die in PR #3 hinzugefügte Renditen-Vergleichsübersicht im Dashboard ("Übersicht: Rendite im Vergleich") fehlte bislang in der `dashboard.py`-Beschreibung in `CLAUDE.md`/`README.md`.

## Test plan

- [x] `pytest -q` — gesamte Testsuite (68 Tests) grün.
- [x] `daily-update.yml` per `yaml.safe_load` auf gültige Syntax geprüft.
