### PR TITLE
Backfill per manuellem Workflow ausführbar machen (#6) + Carry-Forward-Lookahead-Fix

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1,0 +1,110 @@
+name: Historischer Backfill (manuell)
+
+# Einmaliger historischer Backfill von data/price_history.csv, siehe Issue #6.
+#
+# Bewusst ein EIGENER, ausschliesslich manuell startbarer Workflow (kein
+# Cron): der Backfill ERSETZT die Kurshistorie komplett und verbraucht ~18
+# der 25 taeglichen Alpha-Vantage-Free-Tier-Requests. Er laeuft hier statt
+# lokal, weil der API-Key als Repo-Secret vorliegt und nicht auf jeder
+# Entwicklermaschine verfuegbar ist.
+#
+# WICHTIG: nicht am selben Tag wie der woechentliche Kursabruf starten -
+# beide zusammen (18 + 18 Requests) reissen das Tageslimit.
+
+on:
+  workflow_dispatch:
+    inputs:
+      years:
+        description: "Wie viele Jahre Historie zurueck"
+        required: true
+        default: "5"
+      confirm:
+        description: "Ersetzt data/price_history.csv KOMPLETT. Zum Bestaetigen 'REPLACE' eintippen."
+        required: true
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bestaetigung pruefen
+        if: inputs.confirm != 'REPLACE'
+        run: |
+          echo "::error::Abbruch: der Backfill ersetzt data/price_history.csv komplett."
+          echo "::error::Zum Bestaetigen den Workflow erneut mit confirm='REPLACE' starten."
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Abhängigkeiten installieren
+        run: pip install -r requirements.txt
+
+      - name: Tests ausführen
+        run: pytest -q
+
+      - name: Backfill ausführen
+        env:
+          ALPHAVANTAGE_API_KEY: ${{ secrets.ALPHAVANTAGE_API_KEY }}
+        run: python scripts/backfill_history.py --years "${{ inputs.years }}"
+
+      - name: Ergebnis prüfen
+        run: |
+          echo "### Backfill-Ergebnis" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Zeilen (ohne Header): $(($(wc -l < data/price_history.csv) - 1))" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Erste Woche: $(sed -n '2p' data/price_history.csv | cut -d, -f1)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Letzte Woche: $(tail -n 1 data/price_history.csv | cut -d, -f1)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Ticker mit fehlenden Kursen (leere Zellen je Spalte):" >> "$GITHUB_STEP_SUMMARY"
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import csv
+          with open("data/price_history.csv", newline="") as f:
+              rows = list(csv.DictReader(f))
+          if not rows:
+              raise SystemExit("::error::price_history.csv enthaelt keine Datenzeilen")
+          for ticker in [c for c in rows[0] if c != "Date"]:
+              leer = sum(1 for r in rows if not r[ticker])
+              if leer:
+                  print(f"- {ticker}: {leer} von {len(rows)} Wochen ohne Kurs")
+          PY
+
+      - name: Dashboard neu bauen
+        run: python scripts/build_dashboard.py
+
+      - name: Kurshistorie committen
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/price_history.csv data/fetch_log.csv
+          git diff --cached --quiet || git commit -m "chore: historischer Backfill (${{ inputs.years }} Jahre)"
+          git push
+
+      - name: Pages-Artefakt hochladen
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    needs: backfill
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,11 @@ implementiert und per Mock-Tests verifiziert, aber noch nicht live gegen
 die echte Alpha-Vantage-API gelaufen (Tageslimit beim Verifizieren der
 Satelliten-Ticker-Symbole aufgebraucht) — vor dem ersten echten Lauf kurz
 gegenprüfen, dass `TIME_SERIES_WEEKLY`/`FX_WEEKLY`/`DIGITAL_CURRENCY_WEEKLY`
-im Free-Tier verfügbar sind.
+im Free-Tier verfügbar sind. Für den Lauf gibt es den manuell startbaren
+Workflow `.github/workflows/backfill.yml` (nutzt das Repo-Secret, verlangt
+`confirm=REPLACE`, schreibt eine Plausibilitätsprüfung in die Job-Summary) -
+nicht am selben Tag wie den wöchentlichen Kursabruf starten (18 + 18
+Requests > Tageslimit 25).
 
 ### GitHub Actions (`.github/workflows/weekly-update.yml`)
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ mehrfach am selben Tag laufen. **Ersetzt** `price_history.csv` komplett -
 kein Zusammenführen mit zuvor live gesammelten Wochen nötig, da der Backfill
 dieselben (und ältere) Wochen ohnehin mit abdeckt.
 
+Weil der API-Key als Repo-Secret vorliegt (und nicht auf jeder
+Entwicklermaschine), gibt es dafür zusätzlich den manuell startbaren
+Workflow **"Historischer Backfill (manuell)"**
+(`.github/workflows/backfill.yml`): Actions → Workflow auswählen → *Run
+workflow* → `years` setzen und zur Bestätigung `REPLACE` eintippen (der Lauf
+bricht sonst ab, da er die Kurshistorie komplett ersetzt). Der Workflow
+führt Tests, Backfill, eine Plausibilitätsprüfung (Zeilenzahl, Datumsspanne,
+Ticker mit Kurslücken landen in der Job-Summary), den Dashboard-Build, den
+Commit der Datendateien und den Pages-Deploy aus. **Nicht am selben Tag wie
+den wöchentlichen Kursabruf starten** - 18 + 18 Requests reißen das
+Tageslimit von 25.
+
 ## Strategie hinzufügen
 
 Neue Strategien werden als weiterer `Strategy`-Eintrag in

--- a/src/boersenspiel/history_store.py
+++ b/src/boersenspiel/history_store.py
@@ -99,11 +99,16 @@ def record_week(
         None,
     )
 
-    # Letzter bekannter Kurs je Ticker aus der Historie VOR dieser Schreiboperation
-    # (die evtl. ersetzte Zeile derselben Woche zählt dabei nicht als "bekannt").
+    # Letzter bekannter Kurs je Ticker aus den Wochen VOR der Zielwoche.
+    # Bewusst nur zurueckliegende Wochen: wird eine Luecke nachtraeglich
+    # gefuellt (z. B. record_prices.py mit einem alten --date oder ein
+    # Backfill, der Wochen nicht streng chronologisch schreibt), duerfte ein
+    # Carry-Forward sonst den Kurs einer SPAETEREN Woche uebernehmen und damit
+    # einen Blick in die Zukunft in die Historie schreiben. existing_rows ist
+    # aufsteigend sortiert, das letzte update() gewinnt also.
     last_known: dict[str, Decimal] = {}
-    for i, r in enumerate(existing_rows):
-        if i == same_week_index:
+    for r in existing_rows:
+        if _iso_week(r.date) >= target_week:
             continue
         last_known.update(r.prices)
 

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -62,3 +62,19 @@ def test_record_week_missing_with_no_history_logs_missing(tmp_path: Path):
 
     rows = read_price_history(tmp_path)
     assert "EUNL" not in rows[0].prices
+
+
+def test_carry_forward_uses_previous_week_not_a_later_one(tmp_path: Path):
+    """Wird eine Luecke nachtraeglich gefuellt, darf der Carry-Forward nur auf
+    zurueckliegende Wochen zurueckgreifen - sonst landet der Kurs einer
+    spaeteren Woche (Blick in die Zukunft) in der Historie."""
+    record_week(date(2024, 1, 1), _quotes(EUNL=100.0), data_dir=tmp_path)
+    record_week(date(2024, 1, 15), _quotes(EUNL=200.0), data_dir=tmp_path)
+
+    missing_quote = {"EUNL": PriceQuote("EUNL", None, "missing", "test")}
+    row = record_week(date(2024, 1, 8), missing_quote, data_dir=tmp_path)
+
+    assert row.prices["EUNL"] == Decimal("100.0")
+
+    rows = read_price_history(tmp_path)
+    assert [r.prices["EUNL"] for r in rows] == [Decimal("100.0"), Decimal("100.0"), Decimal("200.0")]


### PR DESCRIPTION
## Kontext

Zwei Dinge: der offene Issue #6 wird ausführbar gemacht, und ein beim Projekt-Audit gefundener Datenintegritätsfehler wird behoben.

### 1. Issue #6: Backfill per manuellem Workflow

Der Backfill konnte bisher nicht laufen, weil der Alpha-Vantage-API-Key ausschließlich als Repo-Secret existiert und nicht auf einer beliebigen Entwicklermaschine/in einer Agent-Session verfügbar ist. (In dieser Session war zusätzlich das Tageslimit des greifbaren Keys bereits ausgeschöpft — der Lauf war also nicht durchführbar, siehe Kommentar in #6.)

Neu: `.github/workflows/backfill.yml`, ausschließlich `workflow_dispatch` (kein Cron):

- Inputs `years` (Default 5) und `confirm` — der Lauf bricht ab, wenn `confirm` nicht exakt `REPLACE` ist, da der Backfill `data/price_history.csv` **komplett ersetzt**.
- Ablauf: Tests → Backfill → Plausibilitätsprüfung → Dashboard-Build → Commit der Datendateien → Pages-Deploy.
- Die Plausibilitätsprüfung (Punkt 4 aus Issue #6) schreibt Zeilenzahl, erste/letzte Woche und alle Ticker mit Kurslücken in die Job-Summary, statt sie manuell nachschauen zu müssen. Der Schritt wurde lokal gegen die aktuelle `price_history.csv` ausgeführt.

Damit reduziert sich #6 auf: Workflow starten, Summary prüfen. Der Hinweis aus dem Issue (nicht am selben Tag wie den wöchentlichen Kursabruf starten, 18 + 18 Requests > Tageslimit 25) steht als Kommentar im Workflow und in der README.

### 2. Bugfix: Carry-Forward konnte in die Zukunft greifen

`history_store.record_week()` bildete `last_known` über **alle** bestehenden Zeilen — auch über spätere. Wird eine Lücke nachträglich gefüllt (`record_prices.py` mit einem älteren `--date`, oder ein Backfill, der Wochen nicht streng chronologisch schreibt), übernahm der Carry-Forward damit den Kurs einer *späteren* Woche.

Reproduktion vor dem Fix:

```python
record_week(date(2024, 1, 1),  {"EUNL": 100})   # Woche 1
record_week(date(2024, 1, 15), {"EUNL": 200})   # Woche 3
record_week(date(2024, 1, 8),  {"EUNL": missing})  # Woche 2 nachtragen
# -> Woche 2 bekam 200 (Kurs aus Woche 3) statt 100
```

Das ist Lookahead-Bias direkt in den Rohdaten und verfälscht damit jede Simulation auf dieser Historie — besonders relevant für die charttechnischen Szenarien (SMA-Crossover, Momentum), die genau auf solchen Vorwochenkursen arbeiten. `record_week()` berücksichtigt jetzt nur noch Wochen **vor** der Zielwoche.

## Tests

`pytest -q`: 69 passed (68 vorher + 1 neuer Regressionstest `test_carry_forward_uses_previous_week_not_a_later_one`). Keine bestehende Erwartung musste angepasst werden — der reguläre chronologische Schreibpfad verhält sich unverändert.

## Nicht in diesem PR

Beim Audit sind weitere Befunde entstanden (u. a. Dezember-Harvest feuert im laufenden, unvollständigen Jahr; Instrumente ohne Kurs in der ersten Zeile verlieren stillschweigend ihren Kapitalanteil; Rate-Limit-Antworten sind nicht von echten Kurslücken unterscheidbar). Die sind als separate Issues erfasst, weil sie Modellierungs-/Spezifikationsentscheidungen berühren und teils die handgerechneten Erwartungswerte in `tests/test_engine.py` verändern würden.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEAtUHEqTNZfM3RiFDqyF8)_