### PR TITLE
Kurse nach Handelstag einsortieren (#15) + Prozessdokumentation in der README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,14 @@ inkrementell fortgeschrieben).
   `data/price_history.csv` / `data/fetch_log.csv`. `record_week()` ist
   Wochen-idempotent (schlüsselt über ISO-Kalenderwoche, nicht Kalenderdatum)
   und macht Carry-Forward bei fehlenden Kursen (nie eine Zeile mit Lücke,
-  sofern ein Vorwert existiert).
+  sofern ein Vorwert existiert) — dabei ausschließlich aus Wochen **vor**
+  der Zielwoche, damit ein nachträglich gefüllter Eintrag keinen Kurs aus
+  der Zukunft übernimmt. `row_date_from_quotes()` bestimmt das Zeilendatum
+  aus dem von der Quelle gemeldeten **Handelstag** (häufigster Handelstag
+  der erfolgreichen Quotes, bei Gleichstand der frühere) statt aus dem
+  Abrufdatum: ein Montagslauf vor Börsenbeginn liefert den Freitagsschluss
+  der Vorwoche, der sonst eine ISO-Woche zu spät und damit versetzt zum
+  Backfill einsortiert würde.
 - `sources/` — austauschbare `PriceSource`-Implementierungen
   (`sources/__init__.py` definiert das Protokoll). **Standard:**
   `alphavantage.py` (offizielle REST-API, braucht `ALPHAVANTAGE_API_KEY`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,12 +151,18 @@ werden mit dem historischen `FX_WEEKLY`-Kurs derselben Woche umgerechnet
 (`collect_weekly_series`) und CSV-Schreiben (`write_backfilled_history`)
 sind als separate, unabhängig testbare Funktionen im Skript
 implementiert - siehe `tests/test_backfill_history.py` (mockt
-`AlphaVantageSource`, kein echter Netzwerkzugriff). **Stand:** Skript ist
-implementiert und per Mock-Tests verifiziert, aber noch nicht live gegen
-die echte Alpha-Vantage-API gelaufen (Tageslimit beim Verifizieren der
-Satelliten-Ticker-Symbole aufgebraucht) — vor dem ersten echten Lauf kurz
-gegenprüfen, dass `TIME_SERIES_WEEKLY`/`FX_WEEKLY`/`DIGITAL_CURRENCY_WEEKLY`
-im Free-Tier verfügbar sind. Für den Lauf gibt es den manuell startbaren
+`AlphaVantageSource`, kein echter Netzwerkzugriff). **Stand:** Alle drei Endpunkte
+(`TIME_SERIES_WEEKLY`/`FX_WEEKLY`/`DIGITAL_CURRENCY_WEEKLY`) sind im
+Free-Tier verfügbar und alle 17 Symbol-Mappings lösen auf — belegt durch
+den Lauf vom 18.08.2026. Der Lauf brach dennoch ab, weil der
+Zeitreihen-Schlüssel für `FX_WEEKLY` falsch angenommen war; Alpha Vantage
+benennt ihn je Endpunkt unterschiedlich (`Weekly Time Series` /
+`Time Series FX (Weekly)` / `Time Series (Digital Currency Weekly)`).
+`_extract_time_series()` rät den Namen deshalb nicht mehr, sondern nimmt
+den einzigen Objekt-Wert der Antwort außer `Meta Data` — Fehler- und
+Rate-Limit-Antworten haben nur String-Werte und lösen damit automatisch
+eine aussagekräftige Exception aus. Der FX-Abruf läuft bewusst **vor** den
+Ticker-Abrufen, damit ein Fehlschlag einen statt 17 Requests kostet. Für den Lauf gibt es den manuell startbaren
 Workflow `.github/workflows/backfill.yml` (nutzt das Repo-Secret, verlangt
 `confirm=REPLACE`, schreibt eine Plausibilitätsprüfung in die Job-Summary) -
 nicht am selben Tag wie den wöchentlichen Kursabruf starten (18 + 18

--- a/README.md
+++ b/README.md
@@ -10,11 +10,118 @@ Google Sheet, Ausgabe als statisches Dashboard auf GitHub Pages.
 
 ## Architektur
 
+Das Projekt zerfällt in zwei Hälften, die sich ausschließlich über eine CSV-Datei
+berühren: eine **schreibende** Hälfte, die Kurse beschafft, und eine **lesende**
+Hälfte, die daraus Auswertungen rechnet.
+
+```mermaid
+flowchart TB
+    subgraph beschaffung["① Datenbeschaffung — wöchentlich, schreibend"]
+        direction TB
+        cron["GitHub Actions<br/>Mo 06:00 UTC"] --> fetch["run_fetch.py"]
+        fetch --> av["AlphaVantageSource<br/>Symbol-Mapping · USD→EUR"]
+        av --> store
+        manual["record_prices.py<br/>manuell / Cowork"] --> store
+        back["backfill_history.py<br/>einmalig, Jahre rückwirkend"] --> store
+        store["history_store.record_week()<br/><b>einziger Schreibzugriff</b><br/>Wochen-Idempotenz · Carry-Forward"]
+    end
+
+    store ==> csv[("<b>data/price_history.csv</b><br/>Datum × 17 Ticker<br/><i>nur Rohkurse, nichts Abgeleitetes</i>")]
+    store -.Protokoll.-> log[("data/fetch_log.csv")]
+
+    subgraph auswertung["② Auswertung — bei jedem Build neu, lesend"]
+        direction TB
+        sim["engine.simulate(rows, strategy)<br/><b>reine Funktion</b> — kein I/O, kein now()"]
+        sim --> dash["dashboard.py + Jinja-Template"]
+    end
+
+    csv ==> sim
+    strat["strategies.py<br/>3 Strategien<br/><i>konstante Gewichte</i>"] --> sim
+    scen["scenarios.py<br/>9 Szenarien<br/><i>gewichte_fn(rows, i)</i>"] --> sim
+    dash ==> html[("docs/index.html<br/>GitHub Pages")]
 ```
-Kursquelle (austauschbar) --> data/price_history.csv --> engine.simulate() --> docs/index.html
-                                       ^                        |
-                                data/fetch_log.csv        (pro Strategie)
-```
+
+### Prozess im Überblick
+
+**① Datenbeschaffung.** Einmal pro Woche holt der Workflow für jeden der 17 Ticker
+einen Kurs. Alles, was quellenspezifisch ist — Alpha-Vantage-Symbole, die
+USD→EUR-Umrechnung der Satelliten-Aktien, der eigene Krypto-Endpunkt — bleibt in
+`sources/`. Am Ende steht immer dasselbe: ein `PriceQuote` je Ticker. Wer die
+Kurse geliefert hat, ist ab da nicht mehr erkennbar und auch nicht mehr relevant.
+
+`history_store.record_week()` ist der einzige Weg in die CSV. Es schlüsselt über
+die **ISO-Kalenderwoche**, nicht über das Kalenderdatum: ein zweiter Lauf in
+derselben Woche aktualisiert die bestehende Zeile, statt eine Dublette anzuhängen.
+Fehlt ein Kurs, wird der letzte bekannte übernommen (Carry-Forward) und in
+`fetch_log.csv` vermerkt — die Zeile bleibt lückenlos. Eingeordnet wird die Zeile
+über den **Handelstag**, den die Quelle meldet, nicht über den Tag des Abrufs:
+ein Montagslauf vor Börsenbeginn liefert den Freitagsschluss der Vorwoche, und der
+gehört in die Freitags-Woche.
+
+**Gespeichert wird ausschließlich der Rohkurs.** Keine Positionswerte, keine
+Stückzahlen, kein Steuerstand. Das ist die zentrale Entscheidung des Projekts:
+alles Abgeleitete entsteht bei jeder Auswertung neu.
+
+**② Auswertung.** `engine.simulate(price_history, strategy)` bekommt die komplette
+Kurshistorie und eine Strategie und rechnet die gesamte Depotentwicklung von der
+ersten Woche an durch — Initialkauf, Rebalancing, Gebühren, Verlustverrechnung,
+Freibetrag, Steuer. Kein I/O, kein `datetime.now()`, kein Zustand über den Aufruf
+hinaus. Nichts wird fortgeschrieben, alles wird neu gerechnet. Daraus folgt der
+Determinismus: gleiche Kurshistorie + gleiche Strategie ⇒ garantiert gleiches
+Ergebnis.
+
+Weil die Simulation nichts kostet außer Rechenzeit, kann `build_dashboard.py`
+sie beliebig oft laufen lassen — einmal pro Strategie und Szenario, alle gegen
+dieselbe Kurshistorie, und stellt die Ergebnisse nebeneinander.
+
+### Strategien, Szenarien und was quer dazu liegt
+
+Eine **Strategie** ist eine Ziel-Gewichtung über Instrumente, gruppiert in Töpfe.
+Ein **Szenario** ist dieselbe Datenstruktur mit einem zusätzlichen Feld
+`gewichte_fn(rows, i)` — die Gewichte sind dann nicht mehr konstant, sondern
+werden je Kurszeile neu bestimmt (saisonal, charttechnisch, nach Momentum …).
+Für die Engine ist das kein Unterschied: sie ruft die Funktion auf und
+rebalanciert auf das, was zurückkommt. Sie kennt keine einzige Regel namentlich.
+
+Drei Eigenschaften, die dabei leicht übersehen werden:
+
+- **Szenarien sind vollständig unabhängig voneinander.** Jeder Lauf startet bei
+  Woche 0 mit dem vollen Startkapital und sieht nur seine eigene `gewichte_fn`.
+  Es gibt keinen gemeinsamen Zustand, keine Reihenfolge, keine Wechselwirkung —
+  die Läufe könnten in beliebiger Ordnung oder parallel stattfinden.
+- **Szenarien nutzen nur einen Teil der Daten.** Alle Szenarien in `scenarios.py`
+  bauen auf den Töpfen von `Barbell 20/80` auf und rühren damit nur **7 der 17**
+  Ticker an; die 10 Satelliten-Aktien kommen ausschließlich in
+  `Barbell 20/60/20 + Einzelaktien-Satellit` vor. Die Kurshistorie ist bewusst
+  breiter als jede einzelne Auswertung.
+- **Kein Lookahead.** Jede `gewichte_fn` darf ausschließlich `rows[:i+1]` lesen.
+  Eine Regel, die in Woche i entscheidet, darf Woche i+1 nicht kennen — sonst
+  wäre jedes Ergebnis wertlos.
+
+**Quer zu allen Strategien und Szenarien** liegen Mechanismen, die die Engine
+immer und für jeden Lauf identisch anwendet:
+
+| Mechanismus | Wirkung |
+|---|---|
+| Rebalancing | Rückführung auf die Zielgewichte bei Überschreiten der Schwelle |
+| Steueroptimierung am Jahresende | Realisierung von Verlusten bzw. Gewinnen zur Jahresgrenze |
+| Ordergebühren | 1 € je Kauf und Verkauf |
+| Besteuerung | Verlustvortrag → Freibetrag → 26,375 % |
+
+Diese Mechanismen sind heute **nicht abschaltbar**. Der Dashboard-Vergleich
+beantwortet damit nur die Frage „welche Gewichtungsregel war besser?", nicht die
+Frage „wie viel hat eigentlich die Steueroptimierung beigetragen?". Ein Vorschlag,
+sie einzeln zuschaltbar zu machen und damit ihren Beitrag als Differenz messbar zu
+machen, liegt als [#17](https://github.com/S540d/Boersenspiel/issues/17) vor.
+
+> **Hinweis zum Stand:** An zwei Stellen weicht das tatsächliche Verhalten von der
+> hier beschriebenen Absicht ab — die Jahresend-Steueroptimierung feuert auch im
+> laufenden, unvollständigen Jahr ([#9](https://github.com/S540d/Boersenspiel/issues/9)),
+> und ihre Auslösebedingung ist steuerlich nicht sinnvoll gewählt
+> ([#13](https://github.com/S540d/Boersenspiel/issues/13),
+> [#16](https://github.com/S540d/Boersenspiel/issues/16)). Instrumente ohne Kurs in
+> der ersten Zeile verlieren zudem still ihren Kapitalanteil
+> ([#10](https://github.com/S540d/Boersenspiel/issues/10)).
 
 **Leitprinzip (aus dem Pflichtenheft übernommen):** Nur Rohdaten (Kurse)
 werden dauerhaft gespeichert. Alles Abgeleitete (Positionswerte,
@@ -213,7 +320,10 @@ pytest -q
   Xetra-ETFs den Freitagsschluss der Vorwoche, für BTC-EUR (24/7-Markt)
   aber einen zeitlich leicht abweichenden, aktuelleren Kurs – die
   "wöchentliche" Zeile mischt dadurch Kurse aus einem Fenster von bis zu
-  ca. 2–3 Tagen.
+  ca. 2–3 Tagen. Welcher Woche die Zeile zugeordnet wird, entscheidet
+  dagegen der *häufigste* gemeldete Handelstag (also der gemeinsame
+  Börsen-Handelstag, nicht der abweichende BTC-Tag) – siehe
+  `history_store.row_date_from_quotes()`.
 - **Einmalige manuelle Repo-Einstellungen** (nicht per Workflow-YAML
   setzbar): Settings → Actions → General → Workflow permissions → "Read and
   write permissions"; Settings → Pages → Source → "GitHub Actions".

--- a/scripts/backfill_history.py
+++ b/scripts/backfill_history.py
@@ -73,18 +73,34 @@ def collect_weekly_series(
     Netzwerkaufrufen und von ``record_week``."""
     per_ticker: dict[str, dict[date, float]] = {}
     non_crypto = [t for t in tickers if t != "BTC-EUR"]
+    usd_tickers_present = [t for t in non_crypto if t in USD_TICKERS]
 
-    for i, ticker in enumerate(non_crypto):
-        if i > 0:
+    erste_anfrage = True
+
+    def pace() -> None:
+        nonlocal erste_anfrage
+        if not erste_anfrage:
             time.sleep(_REQUEST_INTERVAL_SECONDS)
+        erste_anfrage = False
+
+    # Der FX-Abruf laeuft BEWUSST zuerst: er ist die einzige Anfrage, die alle
+    # USD-Ticker gemeinsam braucht, und ein Fehlschlag bricht den ganzen Lauf
+    # ab. Am Ende der Reihenfolge kostet dieser Abbruch die 16 bereits
+    # verbrauchten Ticker-Requests mit - bei 25 Requests/Tag ist damit auch der
+    # zweite Versuch fuer denselben Tag verloren (so geschehen beim ersten
+    # Lauf, siehe Issue #6). Vorne kostet derselbe Fehlschlag genau 1 Request.
+    fx_rates: dict[date, float] = {}
+    if usd_tickers_present:
+        pace()
+        print("  EUR/USD-Historie (FX_WEEKLY) ...", file=sys.stderr)
+        fx_rates = source.fetch_fx_weekly_eur_per_usd(since)
+
+    for ticker in non_crypto:
+        pace()
         print(f"  {ticker} ...", file=sys.stderr)
         per_ticker[ticker] = source.fetch_weekly_history(ticker, since)
 
-    usd_tickers_present = [t for t in non_crypto if t in USD_TICKERS]
     if usd_tickers_present:
-        time.sleep(_REQUEST_INTERVAL_SECONDS)
-        print("  EUR/USD-Historie (FX_WEEKLY) ...", file=sys.stderr)
-        fx_rates = source.fetch_fx_weekly_eur_per_usd(since)
         fx_dates_sorted = sorted(fx_rates)
         for ticker in usd_tickers_present:
             per_ticker[ticker] = {
@@ -94,7 +110,7 @@ def collect_weekly_series(
             }
 
     if "BTC-EUR" in tickers:
-        time.sleep(_REQUEST_INTERVAL_SECONDS)
+        pace()
         print("  BTC-EUR ...", file=sys.stderr)
         per_ticker["BTC-EUR"] = source.fetch_crypto_weekly_history(since)
 

--- a/scripts/run_fetch.py
+++ b/scripts/run_fetch.py
@@ -19,7 +19,7 @@ from datetime import date, datetime
 
 import _bootstrap  # noqa: F401
 
-from boersenspiel.history_store import record_week
+from boersenspiel.history_store import record_week, row_date_from_quotes
 from boersenspiel.instruments import TICKERS
 from boersenspiel.sources.alphavantage import AlphaVantageSource
 
@@ -30,7 +30,16 @@ def main() -> int:
         "--date",
         type=lambda s: datetime.strptime(s, "%Y-%m-%d").date(),
         default=date.today(),
-        help="Datum, dem die abgerufenen Kurse zugeordnet werden (Default: heute)",
+        help=(
+            "Abrufdatum (Default: heute). Dient nur als Rueckfallwert - "
+            "einsortiert werden die Kurse ueber den von der Quelle gemeldeten "
+            "Handelstag, siehe --ignore-handelstag"
+        ),
+    )
+    parser.add_argument(
+        "--ignore-handelstag",
+        action="store_true",
+        help="Kurse stur unter --date ablegen, statt unter ihrem Handelstag",
     )
     args = parser.parse_args()
 
@@ -41,7 +50,14 @@ def main() -> int:
     if missing:
         print(f"WARNUNG: Kein aktueller Kurs gefunden fuer: {', '.join(missing)}", file=sys.stderr)
 
-    row = record_week(args.date, quotes)
+    # Ein Montagslauf vor Boersenbeginn liefert den Freitagsschluss der
+    # Vorwoche - unter dem Montag abgelegt landete der Kurs in der falschen
+    # ISO-Woche und damit eine Woche versetzt gegenueber dem Backfill.
+    as_of = args.date if args.ignore_handelstag else row_date_from_quotes(quotes, args.date)
+    if as_of != args.date:
+        print(f"Kurse beziehen sich auf den Handelstag {as_of.isoformat()} (Abruf: {args.date.isoformat()})")
+
+    row = record_week(as_of, quotes)
     print(f"Kurshistorie aktualisiert fuer {row.date.isoformat()}: {row.prices}")
     return 0
 

--- a/src/boersenspiel/history_store.py
+++ b/src/boersenspiel/history_store.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import csv
 import os
+from collections import Counter
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -71,6 +72,34 @@ def read_price_history(data_dir: Path = DEFAULT_DATA_DIR) -> list[PriceRow]:
 def _iso_week(d: date) -> tuple[int, int]:
     iso = d.isocalendar()
     return iso[0], iso[1]  # (ISO-Jahr, ISO-Kalenderwoche)
+
+
+def row_date_from_quotes(quotes: dict[str, PriceQuote], fallback: date) -> date:
+    """Datum, unter dem eine Abruf-Charge abgelegt wird: der Handelstag, auf
+    den sich die Kurse beziehen - nicht der Tag des Abrufs.
+
+    Ein Montagslauf vor Börsenbeginn liefert den Freitagsschluss der Vorwoche.
+    Wird der Montag als Zeilendatum genommen, landet dieser Kurs in der
+    falschen ISO-Woche - und damit eine Woche versetzt gegenüber dem
+    historischen Backfill, der dieselben Kurse über ihren Handelstag
+    einsortiert.
+
+    Da die Ticker unterschiedliche Handelskalender haben (Xetra-Freitag vs.
+    BTC-EUR als 24/7-Markt), wird der HÄUFIGSTE Handelstag der erfolgreichen
+    Quotes genommen, bei Gleichstand der frühere. Das ist robust gegen
+    einzelne Ticker mit abweichendem Feiertag und trifft bei den Börsentickern
+    zuverlässig deren gemeinsamen letzten Handelstag.
+
+    ``fallback`` (üblicherweise das Abrufdatum) greift, wenn keine einzige
+    Quote einen Handelstag mitliefert - etwa beim manuellen Weg über
+    ``record_prices.py``.
+    """
+    tage = [q.quote_date for q in quotes.values() if q.status == "ok" and q.quote_date is not None]
+    if not tage:
+        return fallback
+    haeufigkeit = Counter(tage)
+    hoechste = max(haeufigkeit.values())
+    return min(d for d, anzahl in haeufigkeit.items() if anzahl == hoechste)
 
 
 def record_week(

--- a/src/boersenspiel/sources/__init__.py
+++ b/src/boersenspiel/sources/__init__.py
@@ -30,6 +30,13 @@ class PriceQuote:
     price: float | None
     status: str  # "ok" oder "missing"
     source: str = ""
+    # Handelstag, auf den sich ``price`` bezieht - NICHT der Tag des Abrufs.
+    # Ein Montagslauf liefert vor Börsenbeginn den Freitagsschluss; ohne diese
+    # Angabe landet der Kurs in der falschen Kalenderwoche (siehe
+    # ``scripts/run_fetch.py``). Quellen, die keinen Handelstag mitliefern
+    # (z. B. der manuelle Weg über ``record_prices.py``), lassen das Feld
+    # None - dann bleibt das übergebene Abrufdatum maßgeblich.
+    quote_date: date | None = None
 
 
 class PriceSource(Protocol):

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -225,11 +225,7 @@ class AlphaVantageSource:
             timeout=30,
         )
         resp.raise_for_status()
-        data = resp.json()
-        series = data.get("Weekly Time Series")
-        if not series:
-            raise RuntimeError(f"keine woechentliche Historie fuer {symbol}: {data!r}")
-        return _parse_weekly_close_series(series, since)
+        return _parse_weekly_close_series(_extract_time_series(resp.json(), symbol), since)
 
     def fetch_fx_weekly_eur_per_usd(self, since: date) -> dict[date, float]:
         """Woechentlicher EUR-Gegenwert von 1 USD ab ``since`` (fuer die
@@ -240,11 +236,7 @@ class AlphaVantageSource:
             timeout=30,
         )
         resp.raise_for_status()
-        data = resp.json()
-        series = data.get("Weekly Time Series (FX)")
-        if not series:
-            raise RuntimeError(f"keine woechentliche FX-Historie fuer USD/EUR: {data!r}")
-        return _parse_weekly_close_series(series, since)
+        return _parse_weekly_close_series(_extract_time_series(resp.json(), "USD/EUR (FX_WEEKLY)"), since)
 
     def fetch_crypto_weekly_history(self, since: date) -> dict[date, float]:
         """Woechentliche BTC-EUR-Historie ab ``since``."""
@@ -254,12 +246,7 @@ class AlphaVantageSource:
             timeout=30,
         )
         resp.raise_for_status()
-        data = resp.json()
-        series = data.get("Time Series (Digital Currency Weekly)") or data.get(
-            "Weekly Time Series (Digital Currency Weekly)"
-        )
-        if not series:
-            raise RuntimeError(f"keine woechentliche Kryptohistorie fuer BTC-EUR: {data!r}")
+        series = _extract_time_series(resp.json(), "BTC-EUR (DIGITAL_CURRENCY_WEEKLY)")
         result: dict[date, float] = {}
         for date_str, values in series.items():
             d = date.fromisoformat(date_str)
@@ -272,6 +259,44 @@ class AlphaVantageSource:
                 continue
             result[d] = float(values[close_key])
         return result
+
+
+def _extract_time_series(data: dict, kontext: str) -> dict:
+    """Zieht die Zeitreihe aus einer Alpha-Vantage-Antwort, ohne den
+    Schluesselnamen fest zu verdrahten.
+
+    Alpha Vantage benennt den Zeitreihen-Schluessel je Endpunkt anders und
+    ohne erkennbares Muster::
+
+        TIME_SERIES_WEEKLY       -> "Weekly Time Series"
+        FX_WEEKLY                -> "Time Series FX (Weekly)"
+        DIGITAL_CURRENCY_WEEKLY  -> "Time Series (Digital Currency Weekly)"
+
+    Ein fest eingetragener Name bricht deshalb still, sobald ein Endpunkt
+    dazukommt oder anders heisst als vermutet - genau daran ist der erste
+    Backfill-Lauf gescheitert (FX_WEEKLY war als "Weekly Time Series (FX)"
+    eingetragen). Statt zu raten wird der einzige Eintrag genommen, der ein
+    Objekt ist; "Meta Data" ist ausgenommen.
+
+    Fehler- und Rate-Limit-Antworten ("Note"/"Information"/"Error Message")
+    haben ausschliesslich String-Werte und liefern damit automatisch die
+    aussagekraeftige Fehlermeldung statt einer stillen Luecke.
+    """
+    kandidaten = {k: v for k, v in data.items() if k != "Meta Data" and isinstance(v, dict)}
+    if len(kandidaten) == 1:
+        return next(iter(kandidaten.values()))
+    if not kandidaten:
+        raise RuntimeError(f"keine Zeitreihe in der Antwort fuer {kontext}: {_kurz(data)}")
+    raise RuntimeError(
+        f"mehrdeutige Antwort fuer {kontext}, Zeitreihen-Kandidaten {sorted(kandidaten)}: {_kurz(data)}"
+    )
+
+
+def _kurz(data: object, grenze: int = 500) -> str:
+    """Gekuerzte Darstellung fuer Fehlermeldungen - eine vollstaendige
+    Kurshistorie im Traceback macht das Log unlesbar."""
+    text = repr(data)
+    return text if len(text) <= grenze else text[:grenze] + " ... (gekuerzt)"
 
 
 def _parse_trading_day(raw: str | None) -> date | None:

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -152,14 +152,15 @@ class AlphaVantageSource:
             )
             resp.raise_for_status()
             data = resp.json()
-            price_str = data.get("Global Quote", {}).get("05. price")
+            quote = data.get("Global Quote", {})
+            price_str = quote.get("05. price")
             if not price_str:
                 print(f"alphavantage: keine Kursdaten fuer {symbol}: {data!r}", file=sys.stderr)
                 return PriceQuote(ticker, None, "missing", "alphavantage")
             price = float(price_str)
             if fx_rate is not None:
                 price *= fx_rate
-            return PriceQuote(ticker, price, "ok", "alphavantage")
+            return PriceQuote(ticker, price, "ok", "alphavantage", _parse_trading_day(quote.get("07. latest trading day")))
         except Exception as exc:
             print(f"alphavantage fehlgeschlagen fuer {symbol}: {exc!r}", file=sys.stderr)
             return PriceQuote(ticker, None, "missing", "alphavantage")
@@ -195,7 +196,9 @@ class AlphaVantageSource:
             if close_key is None:
                 print(f"alphavantage: unerwartetes Kryptoformat fuer BTC-EUR: {latest!r}", file=sys.stderr)
                 return PriceQuote(ticker, None, "missing", "alphavantage")
-            return PriceQuote(ticker, float(latest[close_key]), "ok", "alphavantage")
+            return PriceQuote(
+                ticker, float(latest[close_key]), "ok", "alphavantage", _parse_trading_day(latest_date)
+            )
         except Exception as exc:
             print(f"alphavantage fehlgeschlagen fuer BTC-EUR: {exc!r}", file=sys.stderr)
             return PriceQuote(ticker, None, "missing", "alphavantage")
@@ -269,6 +272,19 @@ class AlphaVantageSource:
                 continue
             result[d] = float(values[close_key])
         return result
+
+
+def _parse_trading_day(raw: str | None) -> date | None:
+    """Handelstag aus einer Alpha-Vantage-Antwort, oder None wenn das Feld
+    fehlt/unlesbar ist - ein unbrauchbares Datum darf den Kursabruf nicht
+    scheitern lassen, der Aufrufer faellt dann auf das Abrufdatum zurueck."""
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        print(f"alphavantage: unlesbarer Handelstag {raw!r}", file=sys.stderr)
+        return None
 
 
 def _parse_weekly_close_series(series: dict, since: date) -> dict[date, float]:

--- a/tests/test_alphavantage.py
+++ b/tests/test_alphavantage.py
@@ -210,11 +210,19 @@ def test_fetch_weekly_history_raises_when_series_missing(monkeypatch: pytest.Mon
 
 
 def test_fetch_fx_weekly_eur_per_usd(monkeypatch: pytest.MonkeyPatch):
+    # Schluesselname und Feldnamen exakt so, wie die echte API sie liefert
+    # (belegt durch den Backfill-Lauf vom 18.08.2026) - der erste Lauf
+    # scheiterte, weil hier "Weekly Time Series (FX)" angenommen wurde.
     payload = {
-        "Weekly Time Series (FX)": {
-            "2026-08-14": {"4. close": "0.9200"},
-            "2019-01-04": {"4. close": "0.8700"},
-        }
+        "Meta Data": {
+            "1. Information": "Forex Weekly Prices (open, high, low, close)",
+            "2. From Symbol": "USD",
+            "3. To Symbol": "EUR",
+        },
+        "Time Series FX (Weekly)": {
+            "2026-08-14": {"1. open": "0.9100", "4. close": "0.9200"},
+            "2019-01-04": {"1. open": "0.8600", "4. close": "0.8700"},
+        },
     }
     monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse(payload))
     source = av.AlphaVantageSource(api_key="dummy")
@@ -294,3 +302,72 @@ def test_unparsable_trading_day_does_not_break_the_quote(monkeypatch: pytest.Mon
     assert result["EUNL"].status == "ok"
     assert result["EUNL"].price == 82.10
     assert result["EUNL"].quote_date is None
+
+
+# --- Zeitreihen-Extraktion -----------------------------------------------------
+#
+# Alpha Vantage benennt den Zeitreihen-Schluessel je Endpunkt anders. Die
+# folgenden Payloads sind die real beobachteten Formate: TIME_SERIES_WEEKLY aus
+# dem erfolgreichen Teil des Backfill-Laufs vom 18.08.2026, FX_WEEKLY aus dessen
+# Fehlermeldung, DIGITAL_CURRENCY_WEEKLY aus einem direkten Abruf.
+
+
+def test_weekly_history_accepts_the_real_time_series_key(monkeypatch: pytest.MonkeyPatch):
+    payload = {
+        "Meta Data": {"1. Information": "Weekly Prices", "2. Symbol": "EUNL.DEX"},
+        "Weekly Time Series": {
+            "2026-08-14": {"1. open": "127.0", "4. close": "128.70"},
+            "2019-01-04": {"1. open": "70.0", "4. close": "71.00"},
+        },
+    }
+    monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse(payload))
+    source = av.AlphaVantageSource(api_key="dummy")
+
+    assert source.fetch_weekly_history("EUNL", since=date(2024, 1, 1)) == {date(2026, 8, 14): 128.70}
+
+
+def test_crypto_weekly_accepts_the_real_time_series_key(monkeypatch: pytest.MonkeyPatch):
+    payload = {
+        "Meta Data": {"1. Information": "Weekly Prices and Volumes for Digital Currency"},
+        "Time Series (Digital Currency Weekly)": {
+            "2026-08-18": {"1. open": "54293.03", "4. close": "55555.27", "5. volume": "230.17"},
+        },
+    }
+    monkeypatch.setattr(av.requests, "get", lambda url, params, timeout: _FakeResponse(payload))
+    source = av.AlphaVantageSource(api_key="dummy")
+
+    assert source.fetch_crypto_weekly_history(since=date(2024, 1, 1)) == {date(2026, 8, 18): 55555.27}
+
+
+def test_rate_limit_response_raises_instead_of_looking_like_an_empty_series():
+    """Rate-Limit-/Fehlerantworten haben nur String-Werte - sie duerfen nicht
+    als leere Zeitreihe durchgehen, sondern muessen den Backfill abbrechen."""
+    payload = {"Information": "our standard API rate limit is 25 requests per day"}
+    with pytest.raises(RuntimeError, match="keine Zeitreihe"):
+        av._extract_time_series(payload, "TESTKONTEXT")
+
+
+def test_extraction_is_independent_of_the_series_key_name():
+    """Kern des Fixes: der Schluesselname wird nicht mehr geraten."""
+    for key in ("Weekly Time Series", "Time Series FX (Weekly)", "Time Series (Digital Currency Weekly)"):
+        payload = {"Meta Data": {"1. Information": "..."}, key: {"2026-08-14": {"4. close": "1.0"}}}
+        assert av._extract_time_series(payload, "TESTKONTEXT") == {"2026-08-14": {"4. close": "1.0"}}
+
+
+def test_ambiguous_response_raises_rather_than_guessing():
+    payload = {
+        "Meta Data": {"1. Information": "..."},
+        "Weekly Time Series": {"2026-08-14": {"4. close": "1.0"}},
+        "Monthly Time Series": {"2026-08-31": {"4. close": "2.0"}},
+    }
+    with pytest.raises(RuntimeError, match="mehrdeutig"):
+        av._extract_time_series(payload, "TESTKONTEXT")
+
+
+def test_error_message_is_truncated_for_huge_payloads():
+    """Eine komplette Kurshistorie im Traceback macht das Actions-Log unlesbar."""
+    payload = {"Information": "x" * 5000}
+    with pytest.raises(RuntimeError) as exc:
+        av._extract_time_series(payload, "TESTKONTEXT")
+    assert "gekuerzt" in str(exc.value)
+    assert len(str(exc.value)) < 1000

--- a/tests/test_alphavantage.py
+++ b/tests/test_alphavantage.py
@@ -248,3 +248,49 @@ def test_fetch_crypto_weekly_history_flat_format(monkeypatch: pytest.MonkeyPatch
     result = source.fetch_crypto_weekly_history(since=date(2020, 1, 1))
 
     assert result == {date(2026, 8, 14): 58000.0}
+
+
+def test_quote_reports_trading_day_not_request_day(monkeypatch: pytest.MonkeyPatch):
+    """Ein Montagslauf liefert den Freitagsschluss - der Handelstag aus
+    "07. latest trading day" muss durchgereicht werden, sonst landet der Kurs
+    eine Woche zu spaet in der Historie (siehe row_date_from_quotes)."""
+    monkeypatch.setattr(
+        av.requests,
+        "get",
+        lambda url, params, timeout: _FakeResponse(
+            {"Global Quote": {"05. price": "82.10", "07. latest trading day": "2026-08-21"}}
+        ),
+    )
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["EUNL"], date(2026, 8, 24))  # Montag
+
+    assert result["EUNL"].quote_date == date(2026, 8, 21)  # Freitag
+
+
+def test_quote_without_trading_day_field_stays_usable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        av.requests,
+        "get",
+        lambda url, params, timeout: _FakeResponse({"Global Quote": {"05. price": "82.10"}}),
+    )
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["EUNL"], date(2026, 8, 24))
+
+    assert result["EUNL"].status == "ok"
+    assert result["EUNL"].quote_date is None
+
+
+def test_unparsable_trading_day_does_not_break_the_quote(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        av.requests,
+        "get",
+        lambda url, params, timeout: _FakeResponse(
+            {"Global Quote": {"05. price": "82.10", "07. latest trading day": "keinDatum"}}
+        ),
+    )
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["EUNL"], date(2026, 8, 24))
+
+    assert result["EUNL"].status == "ok"
+    assert result["EUNL"].price == 82.10
+    assert result["EUNL"].quote_date is None

--- a/tests/test_backfill_history.py
+++ b/tests/test_backfill_history.py
@@ -137,3 +137,49 @@ def test_all_tickers_have_weekly_fetch_support():
 
     fehlend = [t for t in TICKERS if t != "BTC-EUR" and t not in ALPHAVANTAGE_SYMBOLS]
     assert fehlend == []
+
+
+def test_fx_is_fetched_before_any_ticker_to_limit_the_cost_of_a_failure():
+    """Beim ersten echten Lauf scheiterte FX_WEEKLY erst NACH 16 Ticker-
+    Requests - bei 25 Requests/Tag war damit auch der zweite Versuch fuer
+    denselben Tag verloren. Der FX-Abruf muss deshalb zuerst laufen: dann
+    kostet derselbe Fehlschlag genau einen Request."""
+    reihenfolge: list[str] = []
+
+    class _ProtokollierendeSource(_FakeSource):
+        def fetch_weekly_history(self, ticker: str, since: date) -> dict[date, float]:
+            reihenfolge.append(f"ticker:{ticker}")
+            return super().fetch_weekly_history(ticker, since)
+
+        def fetch_fx_weekly_eur_per_usd(self, since: date) -> dict[date, float]:
+            reihenfolge.append("fx")
+            return super().fetch_fx_weekly_eur_per_usd(since)
+
+        def fetch_crypto_weekly_history(self, since: date) -> dict[date, float]:
+            reihenfolge.append("crypto")
+            return super().fetch_crypto_weekly_history(since)
+
+    source = _ProtokollierendeSource(
+        weekly={"EUNL": {date(2026, 8, 14): 85.0}, "LITE": {date(2026, 8, 14): 100.0}},
+        fx={date(2026, 8, 14): 0.90},
+        crypto={date(2026, 8, 14): 58000.0},
+    )
+    bh.collect_weekly_series(source, ["EUNL", "LITE", "BTC-EUR"], since=date(2020, 1, 1))
+
+    assert reihenfolge[0] == "fx"
+    assert reihenfolge[-1] == "crypto"
+
+
+def test_a_failing_fx_fetch_costs_no_ticker_requests():
+    source = _FakeSource(
+        weekly={"LITE": {date(2026, 8, 14): 100.0}}, fx={date(2026, 8, 14): 0.90}, crypto={}
+    )
+
+    def _rate_limit(*args, **kwargs):
+        raise RuntimeError("keine Zeitreihe in der Antwort fuer USD/EUR (FX_WEEKLY)")
+
+    source.fetch_fx_weekly_eur_per_usd = _rate_limit
+    with pytest.raises(RuntimeError):
+        bh.collect_weekly_series(source, ["LITE", "BTC-EUR"], since=date(2020, 1, 1))
+
+    assert source.weekly_history_calls == []

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 from pathlib import Path
 
-from boersenspiel.history_store import read_price_history, record_week
+from boersenspiel.history_store import read_price_history, record_week, row_date_from_quotes
 from boersenspiel.sources import PriceQuote
 
 
@@ -78,3 +78,50 @@ def test_carry_forward_uses_previous_week_not_a_later_one(tmp_path: Path):
 
     rows = read_price_history(tmp_path)
     assert [r.prices["EUNL"] for r in rows] == [Decimal("100.0"), Decimal("100.0"), Decimal("200.0")]
+
+
+def _quote(ticker: str, price: float, quote_date: date | None) -> PriceQuote:
+    return PriceQuote(ticker=ticker, price=price, status="ok", source="test", quote_date=quote_date)
+
+
+def test_row_date_uses_the_reported_trading_day_not_the_request_day():
+    """Montagslauf, Kurse vom Freitag -> die Zeile gehoert in die Freitags-Woche."""
+    quotes = {
+        "EUNL": _quote("EUNL", 80.0, date(2026, 8, 21)),
+        "EUNA": _quote("EUNA", 5.0, date(2026, 8, 21)),
+    }
+    assert row_date_from_quotes(quotes, fallback=date(2026, 8, 24)) == date(2026, 8, 21)
+
+
+def test_row_date_picks_the_most_common_trading_day():
+    """BTC-EUR handelt 24/7 und meldet einen spaeteren Tag als die Boersen -
+    ein einzelner Ausreisser darf die ganze Zeile nicht verschieben."""
+    quotes = {
+        "EUNL": _quote("EUNL", 80.0, date(2026, 8, 21)),
+        "EUNA": _quote("EUNA", 5.0, date(2026, 8, 21)),
+        "BTC-EUR": _quote("BTC-EUR", 55000.0, date(2026, 8, 23)),
+    }
+    assert row_date_from_quotes(quotes, fallback=date(2026, 8, 24)) == date(2026, 8, 21)
+
+
+def test_row_date_breaks_ties_towards_the_earlier_day():
+    quotes = {
+        "EUNL": _quote("EUNL", 80.0, date(2026, 8, 21)),
+        "BTC-EUR": _quote("BTC-EUR", 55000.0, date(2026, 8, 23)),
+    }
+    assert row_date_from_quotes(quotes, fallback=date(2026, 8, 24)) == date(2026, 8, 21)
+
+
+def test_row_date_ignores_failed_quotes():
+    quotes = {
+        "EUNL": _quote("EUNL", 80.0, date(2026, 8, 21)),
+        "EUNA": PriceQuote("EUNA", None, "missing", "test", quote_date=date(2026, 1, 1)),
+    }
+    assert row_date_from_quotes(quotes, fallback=date(2026, 8, 24)) == date(2026, 8, 21)
+
+
+def test_row_date_falls_back_when_no_source_reports_a_trading_day():
+    """Der manuelle Weg (record_prices.py) liefert keinen Handelstag -
+    dort bleibt das uebergebene Datum massgeblich."""
+    quotes = {"EUNL": _quote("EUNL", 80.0, None)}
+    assert row_date_from_quotes(quotes, fallback=date(2026, 8, 24)) == date(2026, 8, 24)


### PR DESCRIPTION
## 1. Fix für #15: Kurse landen in der Woche ihres Handelstags

Der Live-Abruf legte Kurse unter dem **Lauftag** ab statt unter dem **Handelstag**, auf den sie sich beziehen. Ein Montagslauf um 06:00 UTC liefert vor Xetra-Eröffnung den Freitagsschluss der Vorwoche — unter dem Montag abgelegt landete dieser in KW N, während der Backfill denselben Kurs über seinen Handelstag in KW N−1 einsortiert.

Folgen: die Live-Historie war systematisch eine Woche versetzt, und an der Nahtstelle nach einem Backfill (#6) wäre derselbe Freitagsschluss in zwei aufeinanderfolgenden Zeilen gelandet — eine Woche Kursbewegung hätte gefehlt.

Die Information war die ganze Zeit da und wurde verworfen: `GLOBAL_QUOTE` liefert `"07. latest trading day"` im selben Objekt wie den Kurs, `_fetch_quote()` las nur `"05. price"`.

**Änderungen:**

- `PriceQuote` bekommt ein optionales `quote_date`.
- `AlphaVantageSource` füllt es aus `"07. latest trading day"` bzw. beim Krypto-Endpunkt aus dem Datum der jüngsten Zeitreihen-Zeile. Ein fehlendes oder unlesbares Datum lässt den Kursabruf nicht scheitern — die Quote bleibt gültig, `quote_date` bleibt `None`.
- `history_store.row_date_from_quotes()` leitet daraus das Zeilendatum ab: **häufigster** Handelstag der erfolgreichen Quotes, bei Gleichstand der frühere. Robust gegen einzelne Ticker mit abweichendem Handelskalender — BTC-EUR handelt 24/7 und meldet regelmäßig einen späteren Tag als die Börsen, darf die Zeile aber nicht verschieben.
- Quellen ohne Handelstag (`record_prices.py`) bleiben unverändert: dort ist `--date` weiterhin maßgeblich. `run_fetch.py` bekommt `--ignore-handelstag`, um das alte Verhalten notfalls erzwingen zu können.

Verifikation der Nahtstelle — Backfill schreibt den Freitagsschluss der KW 34, danach der Live-Lauf am Montag mit demselben gemeldeten Handelstag:

```
Zeilen: [('2026-08-21', (2026, 34))]
-> kein Duplikat, gleiche ISO-Woche: True
```

## 2. Prozessdokumentation in der README

Der bisherige ASCII-Block ist durch ein Mermaid-Diagramm plus Fließtext ersetzt, das den Gesamtprozess beschreibt:

- die Trennung in eine **schreibende** Hälfte (Datenbeschaffung, wöchentlich) und eine **lesende** Hälfte (Auswertung, bei jedem Build neu), die sich nur über `price_history.csv` berühren;
- dass Szenarien **vollständig unabhängig** voneinander sind — jeder Lauf startet bei Woche 0, kein gemeinsamer Zustand, keine Reihenfolge;
- dass Szenarien nur **7 der 17** Ticker anfassen (alle bauen auf den Töpfen von Barbell 20/80 auf; die 10 Satelliten-Aktien kommen nur in einer Strategie vor);
- die **quer zu allen Läufen liegenden Mechanismen** (Rebalancing, Steueroptimierung, Ordergebühren, Besteuerung) und dass sie heute nicht abschaltbar sind — mit Verweis auf #17.

Ein kurzer Hinweiskasten verlinkt die Stellen, an denen das tatsächliche Verhalten von der beschriebenen Absicht abweicht (#9, #10, #13, #16), damit die README nicht mehr verspricht als der Code hält.

## Tests

`pytest -q`: **77 passed** (69 vorher, 8 neue). Abgedeckt: Handelstag wird durchgereicht; fehlendes Feld und unlesbares Datum brechen den Abruf nicht; Zeilendatum folgt dem gemeldeten Handelstag, ignoriert fehlgeschlagene Quotes, wählt bei Mehrheit den häufigsten und bei Gleichstand den früheren Tag, und fällt ohne jeden Handelstag auf das Abrufdatum zurück.

## Hinweis zur Historie

Dieser Branch wurde nach dem Merge von #8 auf den Default-Branch zurückgesetzt; die Commits aus #8 sind hier nicht erneut enthalten.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEAtUHEqTNZfM3RiFDqyF8)_