### PR TITLE
Fixe die mit Bug markierten Issues (#9, #10, #11)

### DIFF
--- a/scripts/run_fetch.py
+++ b/scripts/run_fetch.py
@@ -50,6 +50,21 @@ def main() -> int:
     if missing:
         print(f"WARNUNG: Kein aktueller Kurs gefunden fuer: {', '.join(missing)}", file=sys.stderr)
 
+    # Ein von Alpha Vantage erreichtes Tageslimit liefert HTTP 200 mit
+    # "Note"/"Information" statt Kursdaten und sieht damit fuer jeden Ticker
+    # wie eine ganz normale Kurslücke aus (siehe AlphaVantageSource, Status
+    # "rate_limited"). Schlaegt der Abruf fuer ALLE Ticker fehl, ist das kein
+    # plausibler gleichzeitiger Ausfall aller Instrumente, sondern fast immer
+    # genau dieser Fall - abbrechen, BEVOR record_week() eine Carry-Forward-
+    # Zeile schreibt, die wie ein echtes Update aussaehe.
+    if missing and len(missing) == len(quotes):
+        print(
+            "FEHLER: Kursabruf fuer ALLE Ticker fehlgeschlagen (vermutlich Rate-Limit "
+            "der Quelle) - breche ab, ohne die Kurshistorie zu veraendern.",
+            file=sys.stderr,
+        )
+        return 1
+
     # Ein Montagslauf vor Boersenbeginn liefert den Freitagsschluss der
     # Vorwoche - unter dem Montag abgelegt landete der Kurs in der falschen
     # ISO-Woche und damit eine Woche versetzt gegenueber dem Backfill.

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -16,12 +16,22 @@ Modellierungsentscheidungen (siehe README für Details):
   (kein FIFO/LIFO mit einzelnen Lots).
 - Rebalancing bringt bei Auslösung ALLE Instrumente auf ihr Zielgewicht
   zurück (nicht nur den auslösenden Topf).
-- Dezember-Harvest: an der letzten Kurszeile jedes Kalenderjahres werden
-  verlustbehaftete Positionen (größter Verlust zuerst, bei Gleichstand nach
-  Ticker sortiert) vollständig verkauft und sofort zum selben Kurs neu
-  gekauft, bis der noch nicht genutzte Sparerpauschbetrag des laufenden
-  Jahres durch realisierte Verluste gedeckt ist (oder keine Verlustpositionen
-  mehr vorhanden sind).
+- Dezember-Harvest: an der letzten Kurszeile eines ABGESCHLOSSENEN
+  Kalenderjahres (ein späteres Jahr ist in der Historie bereits vertreten,
+  oder die Zeile liegt selbst im Dezember) werden verlustbehaftete Positionen
+  (größter Verlust zuerst, bei Gleichstand nach Ticker sortiert) vollständig
+  verkauft und sofort zum selben Kurs neu gekauft, bis der noch nicht
+  genutzte Sparerpauschbetrag des jeweiligen Jahres durch realisierte
+  Verluste gedeckt ist (oder keine Verlustpositionen mehr vorhanden sind).
+  Das laufende, noch unvollständige Jahr löst keinen Harvest aus, auch wenn
+  seine bislang letzte Zeile zufällig die neueste der gesamten Historie ist.
+- Fehlt einem Instrument in der ersten Kurszeile der Kurs (z. B. ein Titel,
+  der erst später an die Börse ging), bleibt sein Kapitalanteil als
+  unverzinste Cash-Position geparkt, statt verlorenzugehen - sobald die
+  erste Kurszeile mit diesem Instrument erscheint, wird die Cash-Position
+  vollständig investiert. Fehlt der Kurs in einer SPÄTEREN Zeile für ein
+  bereits gehaltenes Instrument, wird die Position mit dem letzten bekannten
+  Kurs bewertet statt aus der Summe zu fallen.
 """
 
 from __future__ import annotations
@@ -43,7 +53,7 @@ class Trade:
     price: Decimal
     fee: Decimal
     realized_gain: Decimal | None
-    reason: str  # "initial_buy" | "rebalance" | "december_harvest" | "december_harvest_rebuy"
+    reason: str  # "initial_buy" | "delayed_initial_buy" | "rebalance" | "december_harvest" | "december_harvest_rebuy"
 
 
 @dataclass
@@ -104,6 +114,12 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
         return base_weights
 
     positions: dict[str, _Position] = {t: _Position() for t in tickers}
+    # Kapitalanteil eines Instruments ohne Kurs in der ersten Zeile (z. B. vor
+    # dessen Börsengang) - wird investiert, sobald erstmals ein Kurs vorliegt.
+    pending_cash: dict[str, Decimal] = {t: Decimal(0) for t in tickers}
+    # Letzter bekannter Kurs je Instrument - haelt eine Position bewertbar,
+    # wenn eine spaetere Zeile fuer dieses Instrument keinen Kurs liefert.
+    last_price: dict[str, Decimal] = {}
     trades: list[Trade] = []
     last_rebalance_date: date | None = None
     last_harvest_date: date | None = None
@@ -133,14 +149,23 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
             current_tax_year = year
             freibetrag_verbleibend = SPARERPAUSCHBETRAG_PRO_JAHR
 
+    def total_cash() -> Decimal:
+        return sum(pending_cash.values(), Decimal(0))
+
     def current_values(prices: dict[str, Decimal]) -> dict[str, Decimal]:
-        return {t: positions[t].units * prices[t] for t in tickers if t in prices}
+        values: dict[str, Decimal] = {}
+        for t in tickers:
+            price = prices.get(t, last_price.get(t))
+            if price is None:
+                continue
+            values[t] = positions[t].units * price
+        return values
 
     def rebalance_to_targets(
         prices: dict[str, Decimal], trade_date: date, reason: str, weights: dict[str, Decimal]
     ) -> bool:
         values = current_values(prices)
-        total_value = sum(values.values(), Decimal(0))
+        total_value = sum(values.values(), Decimal(0)) + total_cash()
         if total_value <= 0:
             return False
         diffs = {
@@ -223,10 +248,17 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
         return executed
 
     def year_last_row_dates(all_rows: list[PriceRow]) -> set[date]:
+        """Harvest-Zeitpunkte: die letzte Kurszeile eines ABGESCHLOSSENEN
+        Kalenderjahres - also eines Jahres, dem in der Historie ein späteres
+        Jahr folgt, oder dessen letzte Zeile selbst im Dezember liegt. Ohne
+        diese Einschränkung wäre die jeweils neueste Zeile der Historie immer
+        eine Harvest-Zeile, egal welcher Monat gerade ist, weil sie zwangsläufig
+        die letzte ihres (noch laufenden) Jahres ist."""
         last_by_year: dict[int, date] = {}
         for r in all_rows:
             last_by_year[r.date.year] = r.date
-        return set(last_by_year.values())
+        max_year = max(last_by_year)
+        return {d for y, d in last_by_year.items() if y < max_year or d.month == 12}
 
     harvest_dates = year_last_row_dates(rows)
 
@@ -235,6 +267,9 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
     for i, row in enumerate(rows):
         prices = row.prices
         reset_year_if_needed(row.date.year)
+        for t in tickers:
+            if t in prices:
+                last_price[t] = prices[t]
 
         if i == 0:
             initial_weights = weights_at(0)
@@ -243,16 +278,31 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
             investable = strategy.startkapital - total_fees
             for t in tickers:
                 price = prices.get(t)
-                if price is None:
-                    continue
                 buy_value = investable * initial_weights.get(t, Decimal(0))
+                if price is None:
+                    # Instrument noch ohne Kurs (z. B. vor seinem Börsengang) -
+                    # Kapitalanteil bleibt als Cash geparkt, statt zu verfallen.
+                    pending_cash[t] = buy_value
+                    continue
                 units = buy_value / price
                 positions[t].units = units
                 positions[t].cost_total = buy_value
                 trades.append(Trade(row.date, t, "buy", units, price, ORDERGEBUEHR, None, "initial_buy"))
         else:
+            for t in tickers:
+                if pending_cash[t] > 0 and t in prices:
+                    price = prices[t]
+                    buy_value = pending_cash[t]
+                    units = buy_value / price
+                    positions[t].units += units
+                    positions[t].cost_total += buy_value
+                    trades.append(
+                        Trade(row.date, t, "buy", units, price, Decimal(0), None, "delayed_initial_buy")
+                    )
+                    pending_cash[t] = Decimal(0)
+
             values = current_values(prices)
-            total_value = sum(values.values(), Decimal(0))
+            total_value = sum(values.values(), Decimal(0)) + total_cash()
             if total_value > 0:
                 ziel_topf = next(t for t in strategy.toepfe if t.name == strategy.ziel_topf)
                 if strategy.gewichte_fn is not None:
@@ -277,7 +327,7 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                 last_harvest_date = row.date
 
         values = current_values(prices)
-        total_value = sum(values.values(), Decimal(0))
+        total_value = sum(values.values(), Decimal(0)) + total_cash()
         ticker_weights = {
             t: (values.get(t, Decimal(0)) / total_value if total_value > 0 else Decimal(0)) for t in tickers
         }

--- a/src/boersenspiel/history_store.py
+++ b/src/boersenspiel/history_store.py
@@ -150,27 +150,22 @@ def record_week(
             continue
 
         source = quote.source if quote else ""
+        rate_limited = quote is not None and quote.status == "rate_limited"
         if ticker in last_known:
             new_prices[ticker] = last_known[ticker]
-            log_entries.append(
-                [
-                    as_of.isoformat(),
-                    ticker,
-                    "carried_forward",
-                    source,
-                    "Kein aktueller Kurs verfuegbar, letzter bekannter Kurs uebernommen",
-                ]
+            note = (
+                "Rate-Limit der Quelle erreicht, letzter bekannter Kurs uebernommen"
+                if rate_limited
+                else "Kein aktueller Kurs verfuegbar, letzter bekannter Kurs uebernommen"
             )
+            log_entries.append([as_of.isoformat(), ticker, "carried_forward", source, note])
         else:
-            log_entries.append(
-                [
-                    as_of.isoformat(),
-                    ticker,
-                    "missing",
-                    source,
-                    "Kein aktueller und kein historischer Kurs verfuegbar",
-                ]
+            note = (
+                "Rate-Limit der Quelle erreicht, kein historischer Kurs verfuegbar"
+                if rate_limited
+                else "Kein aktueller und kein historischer Kurs verfuegbar"
             )
+            log_entries.append([as_of.isoformat(), ticker, "missing", source, note])
 
     if same_week_index is not None:
         existing_rows[same_week_index] = PriceRow(date=as_of, prices=new_prices)

--- a/src/boersenspiel/sources/__init__.py
+++ b/src/boersenspiel/sources/__init__.py
@@ -5,7 +5,10 @@ Liste der Ticker (aus ``instruments.py``) sowie ein "as_of"-Datum und liefert
 für jeden Ticker entweder einen Kurs (Status ``ok``) oder signalisiert, dass
 kein Kurs gefunden wurde (Status ``missing``) - Letzteres lässt
 ``history_store.record_week`` dann automatisch auf den letzten bekannten Kurs
-zurückfallen ("carry forward").
+zurückfallen ("carry forward"). Status ``rate_limited`` ist ein Sonderfall von
+``missing``: die Quelle hat erkennbar ein Rate-Limit erreicht statt keinen
+Kurs für dieses Instrument zu haben - ``record_week`` behandelt beide gleich
+(carry forward), vermerkt den Unterschied aber im ``fetch_log.csv``.
 
 Die konkrete Quelle ist bewusst austauschbar: der GitHub-Actions-Workflow
 nutzt standardmäßig ``yfinance_stooq.YfinanceStooqSource``, aber der Kursabruf
@@ -28,7 +31,7 @@ class PriceQuote:
 
     ticker: str
     price: float | None
-    status: str  # "ok" oder "missing"
+    status: str  # "ok" | "missing" | "rate_limited"
     source: str = ""
     # Handelstag, auf den sich ``price`` bezieht - NICHT der Tag des Abrufs.
     # Ein Montagslauf liefert vor Börsenbeginn den Freitagsschluss; ohne diese

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -126,7 +126,11 @@ class AlphaVantageSource:
             data = resp.json()
             rate_str = data.get("Realtime Currency Exchange Rate", {}).get("5. Exchange Rate")
             if not rate_str:
-                print(f"alphavantage: kein EUR/USD-Kurs erhalten: {data!r}", file=sys.stderr)
+                note = _rate_limit_note(data)
+                if note:
+                    print(f"alphavantage: Rate-Limit erkannt fuer EUR/USD-Kurs: {note}", file=sys.stderr)
+                else:
+                    print(f"alphavantage: kein EUR/USD-Kurs erhalten: {data!r}", file=sys.stderr)
                 return None
             return float(rate_str)
         except Exception as exc:
@@ -155,6 +159,10 @@ class AlphaVantageSource:
             quote = data.get("Global Quote", {})
             price_str = quote.get("05. price")
             if not price_str:
+                note = _rate_limit_note(data)
+                if note:
+                    print(f"alphavantage: Rate-Limit erkannt fuer {symbol}: {note}", file=sys.stderr)
+                    return PriceQuote(ticker, None, "rate_limited", "alphavantage")
                 print(f"alphavantage: keine Kursdaten fuer {symbol}: {data!r}", file=sys.stderr)
                 return PriceQuote(ticker, None, "missing", "alphavantage")
             price = float(price_str)
@@ -181,6 +189,10 @@ class AlphaVantageSource:
             data = resp.json()
             series = data.get("Time Series (Digital Currency Daily)")
             if not series:
+                note = _rate_limit_note(data)
+                if note:
+                    print(f"alphavantage: Rate-Limit erkannt fuer BTC-EUR: {note}", file=sys.stderr)
+                    return PriceQuote(ticker, None, "rate_limited", "alphavantage")
                 print(f"alphavantage: keine Kryptodaten fuer BTC-EUR: {data!r}", file=sys.stderr)
                 return PriceQuote(ticker, None, "missing", "alphavantage")
             latest_date = max(series.keys())
@@ -297,6 +309,19 @@ def _kurz(data: object, grenze: int = 500) -> str:
     Kurshistorie im Traceback macht das Log unlesbar."""
     text = repr(data)
     return text if len(text) <= grenze else text[:grenze] + " ... (gekuerzt)"
+
+
+def _rate_limit_note(data: dict) -> str | None:
+    """Erkennt Alpha Vantages Rate-Limit-/Fehlerantworten, die bei erreichtem
+    Tageslimit statt der erwarteten Kursdaten mit HTTP 200 zurueckkommen (kein
+    "Global Quote" o.ae., stattdessen "Note"/"Information"/"Error Message").
+    Ohne diese Erkennung ist ein erschoepftes Tageslimit von einer echten
+    Kurslücke nicht unterscheidbar - beide liefern denselben Status "missing"."""
+    for key in ("Note", "Information", "Error Message"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 def _parse_trading_day(raw: str | None) -> date | None:

--- a/tests/test_alphavantage.py
+++ b/tests/test_alphavantage.py
@@ -42,6 +42,21 @@ def test_quote_missing_data_yields_missing_status(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(
         av.requests,
         "get",
+        lambda url, params, timeout: _FakeResponse({"Global Quote": {}}),
+    )
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["EUNL"], date(2026, 8, 24))
+
+    assert result["EUNL"].status == "missing"
+    assert result["EUNL"].price is None
+
+
+def test_quote_rate_limit_response_yields_rate_limited_status(monkeypatch: pytest.MonkeyPatch):
+    """Ein erreichtes Tageslimit liefert HTTP 200 mit "Information" statt
+    Kursdaten - das darf nicht wie eine echte Kurslücke aussehen (Issue #11)."""
+    monkeypatch.setattr(
+        av.requests,
+        "get",
         lambda url, params, timeout: _FakeResponse(
             {"Information": "Please consider optimizing your API request frequency."}
         ),
@@ -49,8 +64,20 @@ def test_quote_missing_data_yields_missing_status(monkeypatch: pytest.MonkeyPatc
     source = av.AlphaVantageSource(api_key="dummy")
     result = source.fetch(["EUNL"], date(2026, 8, 24))
 
-    assert result["EUNL"].status == "missing"
+    assert result["EUNL"].status == "rate_limited"
     assert result["EUNL"].price is None
+
+
+def test_quote_note_response_yields_rate_limited_status(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        av.requests,
+        "get",
+        lambda url, params, timeout: _FakeResponse({"Note": "our standard API rate limit is 25 requests per day"}),
+    )
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["EUNL"], date(2026, 8, 24))
+
+    assert result["EUNL"].status == "rate_limited"
 
 
 def test_unmapped_ticker_yields_missing_without_request(monkeypatch: pytest.MonkeyPatch):
@@ -97,6 +124,18 @@ def test_crypto_flat_format(monkeypatch: pytest.MonkeyPatch):
 
     assert result["BTC-EUR"].status == "ok"
     assert result["BTC-EUR"].price == 58000.0
+
+
+def test_crypto_rate_limit_response_yields_rate_limited_status(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        av.requests,
+        "get",
+        lambda url, params, timeout: _FakeResponse({"Note": "our standard API rate limit is 25 requests per day"}),
+    )
+    source = av.AlphaVantageSource(api_key="dummy")
+    result = source.fetch(["BTC-EUR"], date(2026, 8, 24))
+
+    assert result["BTC-EUR"].status == "rate_limited"
 
 
 def test_request_exception_yields_missing(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -40,13 +40,15 @@ def _rows() -> list[PriceRow]:
         PriceRow(date(2024, 1, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
         # T1 verdoppelt sich (200), T2 faellt auf 50 -> TopfX-Gewicht springt
         # auf 1000/1250=80% -> Abweichung 30pp > 10pp -> Rebalancing.
-        # Zugleich letzte Zeile des Jahres 2024 -> Dezember-Harvest greift
+        # Zugleich letzte Zeile des Jahres 2024 UND das Jahr 2024 ist in der
+        # Historie abgeschlossen (2025 folgt noch) -> Dezember-Harvest greift
         # danach zusaetzlich auf den unrealisierten Verlust von T2 (Kurs 50
         # liegt unter der durch den Rebalancing-Kauf erhoehten Kostenbasis).
         PriceRow(date(2024, 1, 8), {"T1": Decimal("200"), "T2": Decimal("50")}),
         # Neues Jahr (2025) -> Freibetrag-Reset. T1 steigt weiter auf 500,
-        # T2 bleibt bei 50 -> erneutes Rebalancing + Dezember-Harvest (da
-        # einzige Zeile in 2025).
+        # T2 bleibt bei 50 -> erneutes Rebalancing. Kein Dezember-Harvest hier:
+        # 2025 ist das laufende (nicht abgeschlossene) Jahr und die Zeile liegt
+        # nicht im Dezember, auch wenn es die einzige Zeile in 2025 ist.
         PriceRow(date(2025, 1, 6), {"T1": Decimal("500"), "T2": Decimal("50")}),
     ]
 
@@ -55,20 +57,32 @@ def test_simple_strategy_end_to_end_exact_values():
     result = simulate(_rows(), SIMPLE_STRATEGY)
 
     # Von Hand hergeleitete Endwerte (siehe Modul-Docstring-Herleitung im PR).
+    # holdings sind vom Zeitpunkt des Harvests unabhaengig - der Harvest kauft
+    # zum selben Kurs sofort zurueck.
     assert result.holdings["T1"] == Decimal("2.1875")
     assert result.holdings["T2"] == Decimal("21.875")
 
+    # Steuerherleitung:
+    # 2024-01-08 Rebalance-Verkauf T1: Gewinn 186,50 -> voll gegen den frischen
+    #   Freibetrag verrechnet (freibetrag_verbleibend 1000 -> 813,50).
+    # 2024-01-08 Harvest-Verkauf T2 (Jahr 2024 abgeschlossen, da 2025 folgt):
+    #   Verlust 252 -> verlustvortrag 0 -> 252.
+    # 2025-01-06 Freibetrag-Reset auf 1000 (neues Jahr). Rebalance-Verkauf T1:
+    #   Gewinn 374 -> zunaechst voll gegen verlustvortrag verrechnet (252),
+    #   Rest 122 gegen den (neuen) Freibetrag -> freibetrag_verbleibend 878,
+    #   verlustvortrag 0. Kein Harvest 2025 (laufendes, unvollstaendiges Jahr).
     assert result.tax_status.year == 2025
     assert result.tax_status.freibetrag_verbleibend == Decimal("878")
     assert result.tax_status.freibetrag_verbraucht == Decimal("122")
-    assert result.tax_status.verlustvortrag == Decimal("3")
+    assert result.tax_status.verlustvortrag == Decimal("0.00")
     assert result.tax_status.kumulierte_steuer == Decimal("0")
 
     assert result.last_rebalance_date == date(2025, 1, 6)
-    assert result.last_harvest_date == date(2025, 1, 6)
+    assert result.last_harvest_date == date(2024, 1, 8)
 
-    # 2 Initialkauf-Trades + je (2 Rebalance + 2 Harvest) fuer beide Jahre
-    assert len(result.trades) == 10
+    # 2 Initialkauf-Trades + 2024-01-08 (2 Rebalance + 2 Harvest) + 2025-01-06
+    # (2 Rebalance, kein Harvest im laufenden Jahr)
+    assert len(result.trades) == 8
 
 
 def test_initial_buy_deducts_fees_before_allocation():
@@ -138,3 +152,54 @@ def test_barbell_strategy_runs_and_keeps_weights_consistent():
     total_weight = sum(last_point.ticker_weights.values())
     assert abs(total_weight - Decimal("1")) < Decimal("0.0001")
     assert all(units >= 0 for units in result.holdings.values())
+
+
+# Regressionstests fuer Issue #10: Instrumente ohne Kurs verlieren nicht mehr
+# stillschweigend ihren Kapitalanteil.
+
+MISSING_PRICE_STRATEGY = Strategy(
+    name="Test-Zwei-Toepfe-Missing",
+    startkapital=Decimal("1000"),
+    toepfe=[
+        Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T1": Decimal("1")}),
+        Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T2": Decimal("1")}),
+    ],
+    ziel_topf="TopfX",
+    ziel_gewicht=Decimal("0.5"),
+    rebalancing_schwelle_pp=Decimal("100"),  # kein Rebalancing in diesen Tests
+)
+
+
+def test_missing_price_in_first_row_parks_capital_as_cash_and_invests_later():
+    # T2 hat in der ersten Zeile noch keinen Kurs (z. B. vor seinem IPO). Der
+    # dafuer vorgesehene Kapitalanteil bleibt als Cash geparkt statt zu
+    # verfallen und wird investiert, sobald T2 erstmals einen Kurs hat.
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("100"), "T2": Decimal("50")}),
+    ]
+    result = simulate(rows, MISSING_PRICE_STRATEGY)
+
+    # Startkapital 1000 - 2*1 Gebuehr = 998 investierbar, je 499 -> T1 sofort,
+    # T2 verzoegert zum Kurs 50 der zweiten Zeile.
+    assert result.holdings["T1"] == Decimal("4.99")
+    assert result.holdings["T2"] == Decimal("9.98")
+    assert result.value_history[0].total_value == Decimal("998")
+    assert result.value_history[1].total_value == Decimal("998")
+    delayed_buys = [t for t in result.trades if t.reason == "delayed_initial_buy"]
+    assert len(delayed_buys) == 1
+    assert delayed_buys[0].ticker == "T2"
+
+
+def test_missing_price_in_later_row_values_with_last_known_price():
+    # T2 fehlt in der mittleren Zeile - die Position darf nicht aus der Summe
+    # herausfallen, sondern wird mit dem letzten bekannten Kurs bewertet.
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 15), {"T1": Decimal("100"), "T2": Decimal("100")}),
+    ]
+    result = simulate(rows, MISSING_PRICE_STRATEGY)
+
+    values = [vp.total_value for vp in result.value_history]
+    assert values == [Decimal("998"), Decimal("998"), Decimal("998")]


### PR DESCRIPTION
## Zusammenfassung

Fixt die drei noch offenen, mit "Bug:" markierten Issues (#15 war bereits durch einen früheren Commit gefixt):

- **#9 — Dezember-Harvest feuert auch im laufenden, unvollständigen Jahr.** `year_last_row_dates()` markierte bisher die letzte Zeile *jedes* Kalenderjahres als Harvest-Zeitpunkt, auch das laufende Jahr — dadurch löste jeder Dashboard-Build einen "Dezember"-Harvest an der neuesten Kurszeile aus, egal welcher Monat gerade ist. Harvest greift jetzt nur noch an der letzten Zeile eines in der Historie bereits **abgeschlossenen** Jahres (ein späteres Jahr folgt) oder wenn die Zeile selbst im Dezember liegt.
- **#10 — Instrumente ohne Kurs verlieren stillschweigend ihren Kapitalanteil.**
  - Fehlt der Kurs in der **ersten** Zeile (z. B. ein Titel vor seinem Börsengang, relevant für den Backfill aus #6), bleibt der dafür vorgesehene Kapitalanteil als unverzinste Cash-Position geparkt statt zu verfallen, und wird investiert, sobald erstmals ein Kurs vorliegt.
  - Fehlt der Kurs in einer **späteren** Zeile für ein bereits gehaltenes Instrument, wird die Position mit dem letzten bekannten Kurs bewertet statt komplett aus der Summe zu fallen (verhinderte den künstlichen Depotwert-Einbruch/-Wiederauferstehung aus der Issue-Reproduktion).
- **#11 — Alpha-Vantage-Rate-Limit ist nicht von einer echten Kurslücke unterscheidbar.** Rate-Limit-Antworten (`Note`/`Information`/`Error Message` bei HTTP 200) werden jetzt erkannt und als eigener `PriceQuote`-Status `rate_limited` von `missing` unterschieden. `history_store.record_week()` vermerkt den Unterschied im `fetch_log.csv`. `scripts/run_fetch.py` bricht mit Exit-Code 1 ab, **bevor** irgendetwas geschrieben wird, wenn der Abruf für **alle** Ticker fehlschlägt — verhindert, dass eine reine Carry-Forward-Woche als "echtes" Kurs-Update committet und deployt wird.

## Hinweis zu den Testwerten in `test_engine.py`

Die #9-Fixture kodierte das alte (fehlerhafte) Verhalten bewusst mit — der Harvest an `2025-01-06` war laut Kommentar erwartet, "da einzige Zeile in 2025". Die handgerechneten Erwartungswerte (Steuerstatus, `last_harvest_date`, Trade-Anzahl) wurden neu hergeleitet und die Herleitung als Kommentar dokumentiert; die Endbestände (`holdings`) ändern sich nicht, da der Harvest zum selben Kurs zurückkauft.

## Test plan

- [x] `pytest -q` — alle 90 Tests grün (inkl. neuer Regressionstests für #10 in `test_engine.py` und für #11 in `test_alphavantage.py`)
- [x] `scripts/build_dashboard.py` manuell gegen die echte Kurshistorie ausgeführt, läuft ohne Fehler

---
_Generated by [Claude Code](https://claude.ai/code/session_019rqhJkKpJeqbw25ky8J4Dv)_