### PR TITLE
Dezember-Harvest durch korrekte Steueroptimierung ersetzen (#13, #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,13 +325,24 @@ pytest -q
 - **Rebalancing** bringt bei Auslösung (>Schwelle Abweichung vom
   Ziel-Topf-Gewicht) **alle** Instrumente auf ihr Zielgewicht zurück, nicht
   nur den auslösenden Topf.
-- **Dezember-Harvest:** An der letzten Kurszeile jedes Kalenderjahres
-  werden verlustbehaftete Positionen (größter Verlust zuerst) vollständig
-  verkauft und sofort zum selben Kurs neu gekauft, bis der noch nicht
-  genutzte Sparerpauschbetrag des laufenden Jahres durch realisierte
-  Verluste gedeckt ist (oder keine Verlustpositionen mehr vorhanden sind).
-  Das Pflichtenheft spezifizierte hier keinen exakten Algorithmus – diese
-  Variante wurde im Planungsgespräch bestätigt.
+- **Dezember-Harvest:** An der letzten Kurszeile eines abgeschlossenen
+  Kalenderjahres greift genau eine von zwei sich gegenseitig ausschließenden
+  Maßnahmen, je nachdem wie das Steuerjahr bis dahin gelaufen ist (siehe
+  [#13](https://github.com/S540d/Boersenspiel/issues/13)/[#16](https://github.com/S540d/Boersenspiel/issues/16)):
+  (A) **Freibetrag-Gewinnmitnahme**, solange der Sparerpauschbetrag des
+  Jahres noch nicht ausgeschöpft ist: Gewinnpositionen (größter
+  unrealisierter Gewinn zuerst) werden **anteilig** verkauft und sofort zum
+  selben Kurs zurückgekauft, bis der realisierte Gewinn den verbleibenden
+  Freibetrag genau ausschöpft (nicht überschreitet) — der Gewinn bleibt
+  steuerfrei, die Kostenbasis wird steuerfrei angehoben. (B) **Echtes
+  Tax-Loss-Harvesting**, sobald im Jahr bereits ein steuerpflichtiger Gewinn
+  realisiert wurde (der Freibetrag also schon bei 0 steht): Verlustpositionen
+  (größter unrealisierter Verlust zuerst) werden anteilig verkauft und sofort
+  zurückgekauft, bis die realisierten Verluste den steuerpflichtigen Teil der
+  Jahresgewinne decken — das verschiebt die schon versteuerte Gewinnsumme
+  nicht rückwirkend, sondern baut einen Verlustvortrag auf, der künftige
+  Gewinne mindert. Das Pflichtenheft spezifizierte hier keinen exakten
+  Algorithmus – diese Variante wurde im Planungsgespräch bestätigt.
 - **Steuerlogik** unverändert aus dem Pflichtenheft: Verlustverrechnung vor
   Freibetrag vor Steuer (26,375 %), Sparerpauschbetrag 1.000 €/Jahr mit
   Reset zum Kalenderjahreswechsel, ein gemeinsamer Verlust-/Freibetrag-Topf,

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -18,13 +18,25 @@ Modellierungsentscheidungen (siehe README für Details):
   zurück (nicht nur den auslösenden Topf).
 - Dezember-Harvest: an der letzten Kurszeile eines ABGESCHLOSSENEN
   Kalenderjahres (ein späteres Jahr ist in der Historie bereits vertreten,
-  oder die Zeile liegt selbst im Dezember) werden verlustbehaftete Positionen
-  (größter Verlust zuerst, bei Gleichstand nach Ticker sortiert) vollständig
-  verkauft und sofort zum selben Kurs neu gekauft, bis der noch nicht
-  genutzte Sparerpauschbetrag des jeweiligen Jahres durch realisierte
-  Verluste gedeckt ist (oder keine Verlustpositionen mehr vorhanden sind).
-  Das laufende, noch unvollständige Jahr löst keinen Harvest aus, auch wenn
-  seine bislang letzte Zeile zufällig die neueste der gesamten Historie ist.
+  oder die Zeile liegt selbst im Dezember) greift genau eine von zwei sich
+  gegenseitig ausschließenden Maßnahmen, je nachdem wie das Steuerjahr bis
+  dahin gelaufen ist (siehe #13/#16):
+  (A) Freibetrag-Gewinnmitnahme, wenn der Sparerpauschbetrag des Jahres noch
+      nicht ausgeschöpft ist (`freibetrag_verbleibend > 0`): Gewinnpositionen
+      (größter unrealisierter Gewinn zuerst) werden anteilig verkauft und
+      sofort zum selben Kurs zurückgekauft, bis der realisierte Gewinn den
+      verbleibenden Freibetrag genau ausschöpft, nicht überschreitet. Der
+      Gewinn bleibt steuerfrei, die Kostenbasis wird steuerfrei angehoben.
+  (B) Echtes Tax-Loss-Harvesting, wenn im Jahr bereits ein steuerpflichtiger
+      Gewinn realisiert wurde (Freibetrag ist folglich bereits 0):
+      Verlustpositionen (größter unrealisierter Verlust zuerst) werden
+      anteilig verkauft und sofort zurückgekauft, bis die realisierten
+      Verluste den steuerpflichtigen Teil der Jahresgewinne decken. Das
+      verschiebt die bereits versteuerte Gewinnsumme nicht rückwirkend,
+      sondern baut einen Verlustvortrag auf, der künftige Gewinne mindert.
+  Bei Gleichstand wird nach Ticker sortiert. Das laufende, noch
+  unvollständige Jahr löst keinen Harvest aus, auch wenn seine bislang
+  letzte Zeile zufällig die neueste der gesamten Historie ist.
 - Fehlt einem Instrument in der ersten Kurszeile der Kurs (z. B. ein Titel,
   der erst später an die Börse ging), bleibt sein Kapitalanteil als
   unverzinste Cash-Position geparkt, statt verlorenzugehen - sobald die
@@ -53,7 +65,7 @@ class Trade:
     price: Decimal
     fee: Decimal
     realized_gain: Decimal | None
-    reason: str  # "initial_buy" | "delayed_initial_buy" | "rebalance" | "december_harvest" | "december_harvest_rebuy"
+    reason: str  # "initial_buy" | "delayed_initial_buy" | "rebalance" | "freibetrag_gewinnmitnahme" | "freibetrag_gewinnmitnahme_rebuy" | "tax_loss_harvest" | "tax_loss_harvest_rebuy"
 
 
 @dataclass
@@ -129,9 +141,13 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
     freibetrag_verbleibend = SPARERPAUSCHBETRAG_PRO_JAHR
     verlustvortrag = Decimal(0)
     kumulierte_steuer = Decimal(0)
+    # Steuerpflichtiger (bereits versteuerter) Anteil der im laufenden Jahr
+    # realisierten Gewinne - Trigger und Zielgröße für den Tax-Loss-Harvest
+    # (Maßnahme B), unabhängig von freibetrag_verbleibend.
+    steuerpflichtige_gewinne_jahr = Decimal(0)
 
     def process_realized_gain(gain: Decimal) -> None:
-        nonlocal freibetrag_verbleibend, verlustvortrag, kumulierte_steuer
+        nonlocal freibetrag_verbleibend, verlustvortrag, kumulierte_steuer, steuerpflichtige_gewinne_jahr
         if gain <= 0:
             verlustvortrag += -gain
             return
@@ -142,12 +158,14 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
         freibetrag_verbleibend -= offset_freibetrag
         steuerpflichtig = rest - offset_freibetrag
         kumulierte_steuer += steuerpflichtig * STEUERSATZ
+        steuerpflichtige_gewinne_jahr += steuerpflichtig
 
     def reset_year_if_needed(year: int) -> None:
-        nonlocal current_tax_year, freibetrag_verbleibend
+        nonlocal current_tax_year, freibetrag_verbleibend, steuerpflichtige_gewinne_jahr
         if year != current_tax_year:
             current_tax_year = year
             freibetrag_verbleibend = SPARERPAUSCHBETRAG_PRO_JAHR
+            steuerpflichtige_gewinne_jahr = Decimal(0)
 
     def total_cash() -> Decimal:
         return sum(pending_cash.values(), Decimal(0))
@@ -204,7 +222,61 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                 executed = True
         return executed
 
-    def december_harvest(prices: dict[str, Decimal], trade_date: date) -> bool:
+    def december_gewinnmitnahme(prices: dict[str, Decimal], trade_date: date) -> bool:
+        """Maßnahme A: Gewinnpositionen anteilig verkaufen und sofort
+        zurückkaufen, bis der realisierte Gewinn den verbleibenden
+        Freibetrag genau ausschöpft (nicht überschreitet)."""
+        winners: list[tuple[str, Decimal]] = []
+        for t in tickers:
+            price = prices.get(t)
+            pos = positions[t]
+            if price is None or pos.units <= 0:
+                continue
+            unrealized = pos.units * price - pos.cost_total
+            if unrealized > 0:
+                winners.append((t, unrealized))
+        if not winners:
+            return False
+
+        winners.sort(key=lambda kv: (-kv[1], kv[0]))
+        executed = False
+        for t, _ in winners:
+            ziel_gewinn = freibetrag_verbleibend
+            if ziel_gewinn <= 0:
+                break
+            price = prices[t]
+            pos = positions[t]
+            avg_cost = pos.avg_cost()
+            gewinn_je_stueck = price - avg_cost
+            if gewinn_je_stueck <= 0:
+                continue
+            units_to_sell = min((ziel_gewinn + ORDERGEBUEHR) / gewinn_je_stueck, pos.units)
+            if units_to_sell <= 0:
+                continue
+            proceeds = units_to_sell * price
+            cost_removed = avg_cost * units_to_sell
+            realized_gain = proceeds - cost_removed - ORDERGEBUEHR
+            pos.units -= units_to_sell
+            pos.cost_total -= cost_removed
+            trades.append(
+                Trade(trade_date, t, "sell", units_to_sell, price, ORDERGEBUEHR, realized_gain, "freibetrag_gewinnmitnahme")
+            )
+            process_realized_gain(realized_gain)
+            executed = True
+
+            # sofortiger Rückkauf zum selben Kurs, um die Marktexponierung zu
+            # erhalten - hebt die Kostenbasis steuerfrei an.
+            pos.units += units_to_sell
+            pos.cost_total += proceeds + ORDERGEBUEHR
+            trades.append(
+                Trade(trade_date, t, "buy", units_to_sell, price, ORDERGEBUEHR, None, "freibetrag_gewinnmitnahme_rebuy")
+            )
+        return executed
+
+    def december_tax_loss_harvest(prices: dict[str, Decimal], trade_date: date) -> bool:
+        """Maßnahme B: Verlustpositionen anteilig verkaufen und sofort
+        zurückkaufen, bis die realisierten Verluste den bereits
+        steuerpflichtig gewordenen Teil der Jahresgewinne decken."""
         losers: list[tuple[str, Decimal]] = []
         for t in tickers:
             price = prices.get(t)
@@ -219,31 +291,42 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
 
         losers.sort(key=lambda kv: (-kv[1], kv[0]))
         harvested = Decimal(0)
-        target_harvest = freibetrag_verbleibend
+        ziel_verlust = steuerpflichtige_gewinne_jahr
         executed = False
-        for t, loss in losers:
-            if harvested >= target_harvest:
+        for t, _ in losers:
+            restziel = ziel_verlust - harvested
+            if restziel <= 0:
                 break
             price = prices[t]
             pos = positions[t]
-            units_to_sell = pos.units
+            avg_cost = pos.avg_cost()
+            verlust_je_stueck = avg_cost - price
+            if verlust_je_stueck <= 0:
+                continue
+            units_needed = max(restziel - ORDERGEBUEHR, Decimal(0)) / verlust_je_stueck
+            if units_needed <= 0:
+                # Restziel liegt unter der Gebühr allein - jeder Verkauf
+                # würde das Ziel überschießen, also hier abbrechen statt
+                # überzuharvesten.
+                break
+            units_to_sell = min(units_needed, pos.units)
             proceeds = units_to_sell * price
-            cost_removed = pos.cost_total
+            cost_removed = avg_cost * units_to_sell
             realized_gain = proceeds - cost_removed - ORDERGEBUEHR
-            pos.units = Decimal(0)
-            pos.cost_total = Decimal(0)
+            pos.units -= units_to_sell
+            pos.cost_total -= cost_removed
             trades.append(
-                Trade(trade_date, t, "sell", units_to_sell, price, ORDERGEBUEHR, realized_gain, "december_harvest")
+                Trade(trade_date, t, "sell", units_to_sell, price, ORDERGEBUEHR, realized_gain, "tax_loss_harvest")
             )
             process_realized_gain(realized_gain)
-            harvested += loss
+            harvested += -realized_gain
             executed = True
 
             # sofortiger Rückkauf zum selben Kurs, um die Marktexponierung zu erhalten
-            pos.units = units_to_sell
-            pos.cost_total = proceeds + ORDERGEBUEHR
+            pos.units += units_to_sell
+            pos.cost_total += proceeds + ORDERGEBUEHR
             trades.append(
-                Trade(trade_date, t, "buy", units_to_sell, price, ORDERGEBUEHR, None, "december_harvest_rebuy")
+                Trade(trade_date, t, "buy", units_to_sell, price, ORDERGEBUEHR, None, "tax_loss_harvest_rebuy")
             )
         return executed
 
@@ -323,8 +406,12 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                         last_rebalance_date = row.date
 
         if row.date in harvest_dates:
-            if december_harvest(prices, row.date):
-                last_harvest_date = row.date
+            if freibetrag_verbleibend > 0:
+                if december_gewinnmitnahme(prices, row.date):
+                    last_harvest_date = row.date
+            elif steuerpflichtige_gewinne_jahr > 0:
+                if december_tax_loss_harvest(prices, row.date):
+                    last_harvest_date = row.date
 
         values = current_values(prices)
         total_value = sum(values.values(), Decimal(0)) + total_cash()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -42,8 +42,11 @@ def _rows() -> list[PriceRow]:
         # auf 1000/1250=80% -> Abweichung 30pp > 10pp -> Rebalancing.
         # Zugleich letzte Zeile des Jahres 2024 UND das Jahr 2024 ist in der
         # Historie abgeschlossen (2025 folgt noch) -> Dezember-Harvest greift
-        # danach zusaetzlich auf den unrealisierten Verlust von T2 (Kurs 50
-        # liegt unter der durch den Rebalancing-Kauf erhoehten Kostenbasis).
+        # danach zusaetzlich: Freibetrag ist nach dem Rebalancing-Gewinn noch
+        # nicht ausgeschoepft (Massnahme A) -> die verbliebene T1-Position
+        # (einziger Gewinnwert, T2 liegt im Verlust) wird vollstaendig
+        # verkauft und sofort zurueckgekauft, um den Freibetrag weiter zu
+        # fuellen.
         PriceRow(date(2024, 1, 8), {"T1": Decimal("200"), "T2": Decimal("50")}),
         # Neues Jahr (2025) -> Freibetrag-Reset. T1 steigt weiter auf 500,
         # T2 bleibt bei 50 -> erneutes Rebalancing. Kein Dezember-Harvest hier:
@@ -63,18 +66,26 @@ def test_simple_strategy_end_to_end_exact_values():
     assert result.holdings["T2"] == Decimal("21.875")
 
     # Steuerherleitung:
-    # 2024-01-08 Rebalance-Verkauf T1: Gewinn 186,50 -> voll gegen den frischen
-    #   Freibetrag verrechnet (freibetrag_verbleibend 1000 -> 813,50).
-    # 2024-01-08 Harvest-Verkauf T2 (Jahr 2024 abgeschlossen, da 2025 folgt):
-    #   Verlust 252 -> verlustvortrag 0 -> 252.
-    # 2025-01-06 Freibetrag-Reset auf 1000 (neues Jahr). Rebalance-Verkauf T1:
-    #   Gewinn 374 -> zunaechst voll gegen verlustvortrag verrechnet (252),
-    #   Rest 122 gegen den (neuen) Freibetrag -> freibetrag_verbleibend 878,
-    #   verlustvortrag 0. Kein Harvest 2025 (laufendes, unvollstaendiges Jahr).
+    # 2024-01-08 Rebalance-Verkauf T1 (1,875 Stueck zu 200, Kostenbasis 100/Stk):
+    #   Gewinn 375-187,50-1=186,50 -> voll gegen den frischen Freibetrag
+    #   verrechnet (freibetrag_verbleibend 1000 -> 813,50).
+    # 2024-01-08 Harvest (Jahr 2024 abgeschlossen, da 2025 folgt): Freibetrag
+    #   ist noch nicht ausgeschoepft (813,50 > 0) -> Massnahme A
+    #   (Gewinnmitnahme). Einziger Gewinnwert ist die verbliebene T1-Position
+    #   (3,125 Stueck zu 200, Kostenbasis 100/Stk, unrealisiert +312,50); die
+    #   Zielgroesse (813,50 + 1 Gebuehr)/100=8,135 Stueck uebersteigt den
+    #   Bestand -> komplette Position verkauft: Gewinn 625-312,50-1=311,50 ->
+    #   voll gegen den Freibetrag verrechnet -> freibetrag_verbleibend 502.
+    #   T2 liegt im Verlust und wird bei Massnahme A nicht angefasst.
+    # 2025-01-06 Freibetrag-Reset auf 1000 (neues Jahr). Rebalance-Verkauf T1
+    #   (0,9375 Stueck zu 500, Kostenbasis 200,32/Stk): Gewinn
+    #   468,75-187,80-1=279,95 -> voll gegen den (neuen) Freibetrag verrechnet
+    #   -> freibetrag_verbleibend 720,05. Kein Harvest 2025 (laufendes,
+    #   unvollstaendiges Jahr).
     assert result.tax_status.year == 2025
-    assert result.tax_status.freibetrag_verbleibend == Decimal("878")
-    assert result.tax_status.freibetrag_verbraucht == Decimal("122")
-    assert result.tax_status.verlustvortrag == Decimal("0.00")
+    assert result.tax_status.freibetrag_verbleibend == Decimal("720.05")
+    assert result.tax_status.freibetrag_verbraucht == Decimal("279.95")
+    assert result.tax_status.verlustvortrag == Decimal("0")
     assert result.tax_status.kumulierte_steuer == Decimal("0")
 
     assert result.last_rebalance_date == date(2025, 1, 6)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -166,7 +166,13 @@ def test_buy_and_hold_never_rebalances():
     result = simulate(_sample_rows(), BUY_AND_HOLD)
     assert result.last_rebalance_date is None
     reasons = {t.reason for t in result.trades}
-    assert reasons <= {"initial_buy", "december_harvest", "december_harvest_rebuy"}
+    assert reasons <= {
+        "initial_buy",
+        "freibetrag_gewinnmitnahme",
+        "freibetrag_gewinnmitnahme_rebuy",
+        "tax_loss_harvest",
+        "tax_loss_harvest_rebuy",
+    }
 
 
 def test_chart_sma_crossover_defaults_to_normal_weights_without_enough_history():


### PR DESCRIPTION
## Summary

Löst #13 (Modellierungsfrage) und setzt #16 (Umsetzung) um.

Der bisherige `december_harvest()` maß Verlustrealisierung am
`freibetrag_verbleibend` — steuerlich wirkungslos, da der Sparerpauschbetrag
nur Gewinne freistellt und von Verlusten nie berührt wird (die laufen
ausschließlich in `verlustvortrag`).

Ersetzt durch zwei sich gegenseitig ausschließende, korrekte Maßnahmen an
der Dezember-Harvest-Zeile:

- **(A) Freibetrag-Gewinnmitnahme** — solange der Sparerpauschbetrag des
  Jahres noch nicht ausgeschöpft ist: Gewinnpositionen (größter
  unrealisierter Gewinn zuerst) werden **anteilig** verkauft und sofort
  zurückgekauft, bis der realisierte Gewinn den verbleibenden Freibetrag
  genau ausschöpft, nicht überschreitet. Gewinn bleibt steuerfrei,
  Kostenbasis wird steuerfrei angehoben.
- **(B) Echtes Tax-Loss-Harvesting** — sobald im Jahr bereits ein
  steuerpflichtiger Gewinn realisiert wurde (Freibetrag also bei 0):
  Verlustpositionen (größter unrealisierter Verlust zuerst) werden anteilig
  verkauft und sofort zurückgekauft, bis die realisierten Verluste den
  steuerpflichtigen Teil der Jahresgewinne decken.

Dafür führt die Engine neu mit, welcher Anteil der im laufenden Jahr
realisierten Gewinne bereits versteuert wurde
(`steuerpflichtige_gewinne_jahr`, Reset beim Jahreswechsel) — das ist
zugleich der Trigger und die Zielgröße für Maßnahme B, unabhängig von
`freibetrag_verbleibend`.

Abhängigkeit **#9** (Harvest darf nicht im laufenden, unvollständigen Jahr
feuern) war zum Zeitpunkt dieser Änderung bereits geschlossen — die
bestehende `year_last_row_dates()`-Beschränkung bleibt unverändert.

`Trade.reason` hat neue Werte: `freibetrag_gewinnmitnahme` /
`freibetrag_gewinnmitnahme_rebuy` / `tax_loss_harvest` /
`tax_loss_harvest_rebuy` (ersetzen `december_harvest` /
`december_harvest_rebuy`).

## Änderungen

- `src/boersenspiel/engine.py`: `december_harvest()` durch
  `december_gewinnmitnahme()` (A) und `december_tax_loss_harvest()` (B)
  ersetzt, inkl. neuem `steuerpflichtige_gewinne_jahr`-Tracker in
  `process_realized_gain()`/`reset_year_if_needed()`; Modul-Docstring
  aktualisiert.
- `tests/test_engine.py`: Handgerechnete Erwartungswerte für die
  End-to-End-Fixture neu hergeleitet (der Harvest trifft jetzt Maßnahme A
  statt der alten Verlust-Logik).
- `tests/test_scenarios.py`: Erwartete `reason`-Werte für `BUY_AND_HOLD` an
  die neuen Trade-Reasons angepasst.
- `README.md`: Modellierungsentscheidung zum Dezember-Harvest aktualisiert.

## Test plan

- [x] `pytest -q` — 90 passed
- [x] Handgerechnete Werte für `test_simple_strategy_end_to_end_exact_values`
  neu hergeleitet und gegen den Code verifiziert (Maßnahme A greift, da
  `freibetrag_verbleibend` nach dem Rebalancing-Gewinn noch > 0 ist)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTssvBHpKBfnAB6QNLt4tr)_