### PR TITLE
Szenario "Börsenweisheiten": alle fünf kombiniert + Effekt je Spruch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,11 @@ inkrementell fortgeschrieben).
   Optionales Feld `Strategy.gewichte_fn` macht die Ziel-Gewichte zeitabhängig
   statt konstant (Signatur `(rows, i) -> dict[ticker, Decimal]`, darf nur auf
   `rows[:i+1]` zugreifen, kein Lookahead-Bias) — Basis für `scenarios.py`.
+  Optionales Feld `Strategy.beitraege` (Liste von `Beitrag(name, ohne)`)
+  markiert eine Strategie als *zusammengesetzt*: `ohne` ist dieselbe Strategie
+  ohne genau diese eine Teilregel, das Dashboard weist deren Einzeleffekt per
+  Leave-one-out aus (Rendite voll − Rendite ohne). Die `ohne`-Varianten haben
+  selbst keine `beitraege`, sonst würde die Auswertung rekursiv.
   `BARBELL_20_60_20_SATELLIT` erweitert Barbell 20/80 um einen dritten Topf
   "Einzelaktien-Satellit" (10 gleichgewichtete Einzelaktien statt breiter
   ETFs): Topf A (Sicherheit) bleibt bei 20%, Topf B (breite ETFs/BTC) sinkt
@@ -77,7 +82,17 @@ inkrementell fortgeschrieben).
   95%), "Antizyklisch kaufen" (Wachstumsquote auf 95% nach >10% Rückgang vom
   Rolling-Hoch) und "Verluste begrenzen" (Trailing-Stop je Wachstums-
   Instrument, >15% Rückgang vom eigenen Rolling-Hoch schaltet nur dieses
-  Instrument auf 0%); (2) Charttechnik — SMA-Crossover (Golden/Death Cross,
+  Instrument auf 0%) sowie "Börsenweisheiten (alle fünf kombiniert)", das die
+  fünf zu einer Strategie zusammenfasst: jede Weisheit ist ein `Weisheit`-
+  Baustein, der in Phase 1 eine Wachstumsquote votiert (oder sich enthält,
+  wenn seine Bedingung diese Woche nicht greift) und/oder in Phase 2 als
+  Instrument-Overlay wirkt. Ziel-Quote ist das **arithmetische Mittel der
+  abgegebenen Voten** — widersprüchliche Signale (Mai-Ausstieg vs. Dip-Kauf)
+  heben sich damit teilweise auf, statt dass eine Regel die anderen
+  überstimmt; "Buy & Hold" votiert als einzige immer (für die normale Quote)
+  und wirkt so als dämpfender Anker. "Verluste begrenzen" ist die einzige
+  Overlay-Regel und läuft nach Phase 1. Der Einzeleffekt jedes Spruchs kommt
+  über `Strategy.beitraege` (Leave-one-out) ins Dashboard; (2) Charttechnik — SMA-Crossover (Golden/Death Cross,
   10/40 Wochen) auf dem MSCI-World-ETF; (3) weitere Ansätze — Momentum-/
   Relative-Stärke-Rotation (Top-2 der Wachstums-Instrumente nach
   12-Wochen-Trailing-Rendite), volatilitätsbasierte Aktienquote (50–90%
@@ -132,7 +147,12 @@ inkrementell fortgeschrieben).
   ("Übersicht: Rendite im Vergleich" - Balkendiagramm + nach Rendite
   sortierte Tabelle mit Sprunglinks zu den Detailabschnitten), Rendite und
   URL-Slug je Strategie werden rein aus den vorhandenen
-  `engine.simulate()`-Ergebnissen abgeleitet.
+  `engine.simulate()`-Ergebnissen abgeleitet. Strategien mit gesetztem
+  `beitraege` bekommen zusätzlich einen Abschnitt "Effekt der einzelnen
+  Börsenweisheiten" (Balkendiagramm + Tabelle): je Teilregel die
+  Leave-one-out-Differenz in Prozentpunkten. Dafür simuliert die
+  Darstellungsschicht die `ohne`-Varianten zusätzlich — auch das bleibt reine
+  Anwendung von `engine.simulate()`, keine eigene Berechnungslogik.
 
 ### Kursquelle wechseln
 
@@ -193,7 +213,12 @@ Strategien plus Determinismus (zweifacher Lauf → identisches Ergebnis).
 Provider-API vollständig (kein echter Netzwerkzugriff in Tests).
 `tests/test_scenarios.py` verifiziert die generische `gewichte_fn`-Mechanik
 in der Engine anhand handgerechneter Werte sowie die konkreten Szenarien
-(Sell in May, Buy & Hold, SMA-Crossover) als End-to-End-Smoke-Tests.
+(Sell in May, Buy & Hold, SMA-Crossover) als End-to-End-Smoke-Tests. Für das
+kombinierte Börsenweisheiten-Szenario sind die gemittelten Quoten handgerechnet
+(Mai → 40%, Dezember → 87,5%) sowie geprüft, dass die Gewichte in jeder Woche zu
+1 summieren und jede Leave-one-out-Variante genau eine Weisheit weglässt.
+`tests/test_dashboard.py` prüft zusätzlich, dass der Beitrags-Abschnitt nur bei
+gesetztem `beitraege` gerendert wird.
 `tests/test_satellit_strategy.py` prüft den Einzelaktien-Satellit
 (`BARBELL_20_60_20_SATELLIT`): Symbol-Mapping-Vollständigkeit, Ziel-Gewichte
 summieren zu 1, 80/20-Risikoprofil bleibt erhalten, End-to-End-Smoke-Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,18 @@ inkrementell fortgeschrieben).
   Leave-one-out-Differenz in Prozentpunkten. Dafür simuliert die
   Darstellungsschicht die `ohne`-Varianten zusätzlich — auch das bleibt reine
   Anwendung von `engine.simulate()`, keine eigene Berechnungslogik.
+- `learnings.py` — leitet die Sektion "Key Learnings" (ganz oben im Dashboard)
+  bei jedem Build neu aus den Strategie-Views ab. **Keine hinterlegten
+  Erkenntnis-Texte:** fest ist nur die Fragestellung je Regel (reine Funktion
+  `(views) -> Learning | None`), alle Zahlen *und* Superlative ("größter
+  Bremsklotz", "einziger Rückhalt") kommen aus den aktuellen Ergebnissen.
+  Liefert eine Regel `None`, ist ihre Frage aus den Daten nicht beantwortbar
+  (z. B. Vergleichsaussagen bei nur einer Strategie) — das Learning fällt dann
+  still weg, statt eine Aussage zu erfinden; bei leerer Liste rendert das
+  Template die Sektion gar nicht. Beim Ergänzen einer Regel: nichts in den
+  Fließtext schreiben, was nicht aus `views` belegt ist, und die
+  Deutsch-Formatierung über `_zahl()/_pp()/_pct()/_eur()` laufen lassen (ein
+  `.replace(".", ",")` auf dem ganzen Satz erwischt sonst den Satzpunkt).
 
 ### Kursquelle wechseln
 
@@ -218,7 +230,10 @@ kombinierte Börsenweisheiten-Szenario sind die gemittelten Quoten handgerechnet
 (Mai → 40%, Dezember → 87,5%) sowie geprüft, dass die Gewichte in jeder Woche zu
 1 summieren und jede Leave-one-out-Variante genau eine Weisheit weglässt.
 `tests/test_dashboard.py` prüft zusätzlich, dass der Beitrags-Abschnitt nur bei
-gesetztem `beitraege` gerendert wird.
+gesetztem `beitraege` gerendert wird. `tests/test_learnings.py` fährt jede
+Learning-Regel gegen konstruierte Views mit bekannten Zahlen und prüft, dass die
+Aussagen den Daten folgen statt fest zu sein (inkl. Gegenprobe mit umgedrehter
+Rangfolge) sowie dass nicht beantwortbare Regeln still wegfallen.
 `tests/test_satellit_strategy.py` prüft den Einzelaktien-Satellit
 (`BARBELL_20_60_20_SATELLIT`): Symbol-Mapping-Vollständigkeit, Ziel-Gewichte
 summieren zu 1, 80/20-Risikoprofil bleibt erhalten, End-to-End-Smoke-Test

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ flowchart TB
         direction TB
         sim["engine.simulate(rows, strategy)<br/><b>reine Funktion</b> — kein I/O, kein now()"]
         sim --> dash["dashboard.py + Jinja-Template"]
+        dash --> learn["learnings.py<br/><i>Key Learnings aus den Ergebnissen</i>"]
+        learn --> dash
     end
 
     csv ==> sim
     strat["strategies.py<br/>3 Strategien<br/><i>konstante Gewichte</i>"] --> sim
-    scen["scenarios.py<br/>9 Szenarien<br/><i>gewichte_fn(rows, i)</i>"] --> sim
+    scen["scenarios.py<br/>10 Szenarien<br/><i>gewichte_fn(rows, i)</i>"] --> sim
     dash ==> html[("docs/index.html<br/>GitHub Pages")]
 ```
 
@@ -74,6 +76,19 @@ Ergebnis.
 Weil die Simulation nichts kostet außer Rechenzeit, kann `build_dashboard.py`
 sie beliebig oft laufen lassen — einmal pro Strategie und Szenario, alle gegen
 dieselbe Kurshistorie, und stellt die Ergebnisse nebeneinander.
+
+**③ Key Learnings.** Ganz oben im Dashboard steht eine Sektion, die die
+auffälligsten Befunde aus dem Vergleich in Worte fasst. Auch sie ist
+**abgeleitet, nicht hinterlegt**: `learnings.py` enthält je Learning nur die
+*Fragestellung* als reine Funktion `(views) -> Learning | None` — wie groß ist
+die Spannweite zwischen bester und schlechtester Regel, wo landet die
+handelsintensivste Regel im Ranking, was kosten Gebühren und Steuer, wie viele
+Teilregeln einer zusammengesetzten Strategie liefern einen negativen Beitrag.
+Alle Zahlen *und* alle Superlative („größter Bremsklotz", „einziger Rückhalt")
+kommen aus den aktuellen Ergebnissen. Ändert sich die Kurshistorie, ändern sich
+die Aussagen mit; lässt sich eine Frage aus den vorliegenden Daten nicht
+beantworten (z. B. weil nur eine Strategie gerendert wird), liefert die Regel
+`None` und das Learning fällt still weg, statt eine Aussage zu erfinden.
 
 ### Strategien, Szenarien und was quer dazu liegt
 
@@ -132,7 +147,8 @@ Kurshistorie + identische Strategie ergeben immer dasselbe Ergebnis.
 | `src/boersenspiel/history_store.py` | Einziger Schreibzugriff auf `data/price_history.csv` / `data/fetch_log.csv` |
 | `src/boersenspiel/sources/` | Austauschbare Kursquellen (Standard: `alphavantage.py`) |
 | `src/boersenspiel/engine.py` | Reine Simulationsfunktion: (Kurshistorie, Strategie) → Portfolio-/Steuerzustand |
-| `src/boersenspiel/dashboard.py` | Rendert Simulationsergebnisse als `docs/index.html`, inkl. strategieübergreifender Renditen-Vergleichsübersicht oben |
+| `src/boersenspiel/dashboard.py` | Rendert Simulationsergebnisse als `docs/index.html`, inkl. Key Learnings und strategieübergreifender Renditen-Vergleichsübersicht oben |
+| `src/boersenspiel/learnings.py` | Leitet die Key-Learnings-Texte bei jedem Build neu aus den Simulationsergebnissen ab (keine hinterlegten Erkenntnisse) |
 | `scripts/run_fetch.py` | Automatisierter wöchentlicher Kursabruf (GitHub Actions) |
 | `scripts/record_prices.py` | Manueller Andockpunkt für Kurse aus anderer Quelle (z. B. Cowork/Websuche) |
 | `scripts/backfill_history.py` | Einmaliger historischer Backfill von `price_history.csv` (echte Wochenkurse statt nur live gesammelter Wochen, siehe unten) |
@@ -266,6 +282,31 @@ Parameter sind nicht optimiert oder gebacktestet. Startkapital jeweils
 | Jahresendrallye | Dezember/Januar Wachstumsquote auf 95% ("Santa Claus Rally"), sonst normale Verteilung |
 | Antizyklisch kaufen | Wachstumsquote auf 95%, sobald der MSCI-World-ETF (EUNL) mehr als 10% unter seinem 20-Wochen-Hoch notiert ("Buy the Dip") |
 | Verluste begrenzen | Trailing-Stop je Wachstums-Instrument: fällt eines mehr als 15% unter sein eigenes 20-Wochen-Hoch, wird nur dieses auf 0% gesetzt (Rest des Depots unverändert) |
+| Börsenweisheiten (alle fünf kombiniert) | Fasst die fünf Weisheiten oben zu **einer** Strategie zusammen (siehe unten) und weist den Einzeleffekt jedes Spruchs per Leave-one-out aus |
+
+**Wie die fünf Weisheiten kombiniert werden.** Die Regeln widersprechen sich
+teilweise — im Mai will „Sell in May" raus, ein gleichzeitiger Kurseinbruch will
+laut „antizyklisch kaufen" rein. Statt sie hart nacheinander anzuwenden, laufen
+sie deshalb in zwei Phasen:
+
+1. **Quoten-Votum.** Jede Weisheit schlägt eine Wachstumsquote vor oder *enthält
+   sich*, wenn ihre Bedingung diese Woche nicht greift. Ziel ist das
+   **arithmetische Mittel der abgegebenen Voten** — widersprüchliche Signale
+   heben sich damit teilweise auf, statt dass eine Regel die anderen
+   überstimmt. „Buy & Hold" (= „nichts umschichten") votiert als einzige immer
+   für die normale 80%-Quote und wirkt so als dämpfender Anker; damit gibt es
+   stets mindestens ein Votum.
+2. **Instrument-Overlay.** „Verluste begrenzen" wirkt nicht auf die Gesamtquote,
+   sondern je Instrument, und wird deshalb anschließend auf das Ergebnis aus
+   Phase 1 angewendet.
+
+**Effekt je Spruch.** Im Detailabschnitt der Strategie steht ein Balkendiagramm
+„Effekt der einzelnen Börsenweisheiten": je Spruch die **Leave-one-out**-Differenz
+in Prozentpunkten, also Rendite der vollen Strategie minus Rendite derselben
+Strategie *ohne* genau diesen Spruch. Positiv heißt: der Spruch hat Rendite
+gebracht. Weil sich die Regeln gegenseitig beeinflussen, summieren sich die
+Einzelbeiträge nicht exakt zur Gesamtrendite — es ist eine marginale, keine
+additive Zerlegung.
 
 **Charttechnik**
 

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -36,6 +36,13 @@ def _slug(name: str) -> str:
     return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", normalisiert)).strip("-")
 
 
+def _rendite_pct(result: SimulationResult, strategy: Strategy) -> Decimal:
+    if strategy.startkapital <= 0:
+        return Decimal(0)
+    endwert = result.value_history[-1].total_value
+    return ((endwert - strategy.startkapital) / strategy.startkapital) * 100
+
+
 def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: list[PriceRow]) -> dict:
     points = result.value_history
     labels = [vp.date.isoformat() for vp in points]
@@ -73,7 +80,21 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         )
 
     gewinn = last.total_value - strategy.startkapital
-    rendite_pct = (gewinn / strategy.startkapital) * 100 if strategy.startkapital > 0 else Decimal(0)
+    rendite_pct = _rendite_pct(result, strategy)
+
+    # Leave-one-out: Einzeleffekt jeder Teilregel als Differenz zur Variante ohne sie.
+    beitraege = []
+    for beitrag in strategy.beitraege:
+        ohne_rendite_pct = _rendite_pct(simulate(rows, beitrag.ohne), beitrag.ohne)
+        delta_pp = rendite_pct - ohne_rendite_pct
+        beitraege.append(
+            {
+                "name": beitrag.name,
+                "delta_pp": _f(delta_pp),
+                "delta_label": f"{delta_pp:+.2f}",
+                "ohne_rendite_label": f"{ohne_rendite_pct:+.2f}",
+            }
+        )
 
     return {
         "name": result.strategy_name,
@@ -100,6 +121,7 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         },
         "last_rebalance_date": result.last_rebalance_date.isoformat() if result.last_rebalance_date else "-",
         "last_harvest_date": result.last_harvest_date.isoformat() if result.last_harvest_date else "-",
+        "beitraege": beitraege,
     }
 
 

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -18,6 +18,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from .engine import SimulationResult, simulate
 from .history_store import PriceRow
+from .learnings import derive_learnings
 from .strategies import STRATEGIES, Strategy
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
@@ -108,6 +109,10 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         "topf_targets": topf_targets,
         "topf_series_last": {name: series[-1] if series else 0.0 for name, series in topf_series.items()},
         "rebalancing_schwelle_pp": f"{strategy.rebalancing_schwelle_pp}",
+        # Numerische Zweitfassungen fuer die Learnings-Ableitung (die uebrigen
+        # Felder sind bereits fuer die Anzeige formatierte Strings).
+        "startkapital_num": _f(strategy.startkapital),
+        "steuer_num": _f(result.tax_status.kumulierte_steuer),
         "holdings_table": holdings_table,
         "total_value": f"{last.total_value:.2f}",
         "startkapital": f"{strategy.startkapital:.2f}",
@@ -137,6 +142,7 @@ def build_dashboard(
 
     views = [_build_strategy_view(s, simulate(rows, s), rows) for s in strategies]
     summary = sorted(views, key=lambda v: v["rendite_pct"], reverse=True)
+    learnings = derive_learnings(views)
 
     env = Environment(
         loader=FileSystemLoader(str(TEMPLATE_DIR)),
@@ -146,6 +152,7 @@ def build_dashboard(
     html = template.render(
         strategies=views,
         summary=summary,
+        learnings=learnings,
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
         row_count=len(price_history),
         last_date=price_history[-1].date.isoformat(),

--- a/src/boersenspiel/learnings.py
+++ b/src/boersenspiel/learnings.py
@@ -1,0 +1,191 @@
+"""Leitet "Key Learnings" aus den Simulationsergebnissen ab.
+
+Bewusst **keine** fest hinterlegten Erkenntnis-Texte: jede Aussage entsteht bei
+jedem Dashboard-Build neu aus den Zahlen, die ``engine.simulate()`` gerade
+geliefert hat. Ändert sich die Kurshistorie, ändern sich die Learnings mit -
+genau wie jede andere abgeleitete Größe im Projekt (siehe Leitprinzip in der
+README). Fest ist nur die *Fragestellung* je Regel, nicht ihr Ergebnis.
+
+Jede Regel ist eine reine Funktion ``(views) -> Learning | None`` über den
+bereits gerenderten Strategie-Views aus ``dashboard.py``. Liefert sie ``None``,
+lässt sich die Frage aus den vorhandenen Daten nicht beantworten (z. B. weil zu
+wenige Strategien vorliegen) - dann fällt das Learning still weg, statt eine
+Aussage zu erfinden.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .strategies import ORDERGEBUEHR
+
+
+@dataclass(frozen=True)
+class Learning:
+    titel: str
+    kernaussage: str  # eine Zeile, die Zahl im Vordergrund
+    detail: str  # Einordnung/Begründung
+
+
+def _nach_rendite(views: list[dict]) -> list[dict]:
+    return sorted(views, key=lambda v: v["rendite_pct"], reverse=True)
+
+
+def _zahl(wert: float, nachkommastellen: int) -> str:
+    """Deutsches Dezimalkomma - bewusst nur auf der Zahl, nicht auf dem Satz."""
+    return f"{wert:.{nachkommastellen}f}".replace(".", ",")
+
+
+def _pp(wert: float) -> str:
+    return f"{_zahl(wert, 2)} pp" if wert < 0 else f"+{_zahl(wert, 2)} pp"
+
+
+def _pct(wert: float) -> str:
+    return f"{_zahl(wert, 2)} %" if wert < 0 else f"+{_zahl(wert, 2)} %"
+
+
+def _eur(wert: float) -> str:
+    return f"{wert:,.0f} €".replace(",", ".")
+
+
+def _spannweite(views: list[dict]) -> Learning | None:
+    """Wie viel hängt überhaupt an der Regel - bei identischer Kurshistorie?"""
+    if len(views) < 2:
+        return None
+    rangliste = _nach_rendite(views)
+    bester, schlechtester = rangliste[0], rangliste[-1]
+    spread = bester["rendite_pct"] - schlechtester["rendite_pct"]
+    return Learning(
+        titel="Die Regel entscheidet, nicht der Markt",
+        kernaussage=(
+            f"{_pp(spread)} Unterschied zwischen bester und schlechtester Regel - "
+            f"bei exakt derselben Kurshistorie."
+        ),
+        detail=(
+            f"„{bester['name']}\" kommt auf {_pct(bester['rendite_pct'])}, "
+            f"„{schlechtester['name']}\" auf {_pct(schlechtester['rendite_pct'])}. "
+            f"Alle {len(views)} Läufe sehen dieselben Kurse, dasselbe Startkapital und "
+            f"dieselbe Steuer-/Gebührenlogik. Der gesamte Unterschied entsteht allein "
+            f"daraus, wann umgeschichtet wird."
+        ),
+    )
+
+
+def _aktivitaet(views: list[dict]) -> Learning | None:
+    """Zahlt sich häufiges Umschichten aus?"""
+    if len(views) < 3:
+        return None
+    rangliste = _nach_rendite(views)
+    platz = {v["name"]: i + 1 for i, v in enumerate(rangliste)}
+    aktivste = max(views, key=lambda v: v["trade_count"])
+    ruhigste = min(views, key=lambda v: v["trade_count"])
+    if aktivste["name"] == ruhigste["name"]:
+        return None
+    return Learning(
+        titel="Mehr Handeln ist nicht mehr Rendite",
+        kernaussage=(
+            f"Die handelsintensivste Regel ({aktivste['trade_count']} Trades) landet auf "
+            f"Platz {platz[aktivste['name']]} von {len(views)}, die ruhigste "
+            f"({ruhigste['trade_count']} Trades) auf Platz {platz[ruhigste['name']]}."
+        ),
+        detail=(
+            f"„{aktivste['name']}\" handelt am meisten und erreicht "
+            f"{_pct(aktivste['rendite_pct'])}; „{ruhigste['name']}\" handelt am wenigsten "
+            f"und erreicht {_pct(ruhigste['rendite_pct'])}. Jeder Trade kostet "
+            f"{ORDERGEBUEHR} € Gebühr und kann zusätzlich Gewinne steuerpflichtig "
+            f"realisieren - Aktivität muss diesen Aufschlag erst wieder verdienen."
+        ),
+    )
+
+
+def _reibungskosten(views: list[dict]) -> Learning | None:
+    """Was kosten Gebühren und Steuer die aktivste Regel?"""
+    # "die aktivste" ist nur im Vergleich eine Aussage.
+    if len(views) < 2:
+        return None
+    aktivste = max(views, key=lambda v: v["trade_count"])
+    gebuehren = aktivste["trade_count"] * float(ORDERGEBUEHR)
+    steuer = aktivste["steuer_num"]
+    gesamt = gebuehren + steuer
+    if gesamt <= 0 or aktivste["startkapital_num"] <= 0:
+        return None
+    anteil = gesamt / aktivste["startkapital_num"] * 100
+    return Learning(
+        titel="Reibung ist sichtbar, aber selten entscheidend",
+        kernaussage=(
+            f"{_eur(gesamt)} Gebühren und Steuer bei „{aktivste['name']}\" - "
+            f"{_zahl(anteil, 1)} % des Startkapitals."
+        ),
+        detail=(
+            f"Davon {_eur(gebuehren)} Ordergebühren ({aktivste['trade_count']} Trades × "
+            f"{ORDERGEBUEHR} €) und {_eur(steuer)} kumulierte Steuer. Das erklärt einen "
+            f"Teil des Rückstands aktiver Regeln, aber nicht die großen Abstände in der "
+            f"Übersicht - die entstehen dadurch, zu welchen Kursen umgeschichtet wird, "
+            f"nicht durch die Transaktionskosten."
+        ),
+    )
+
+
+def _kombinationseffekt(views: list[dict]) -> Learning | None:
+    """Was passiert, wenn man widersprüchliche Regeln zusammenwirft?"""
+    zusammengesetzt = [v for v in views if v["beitraege"]]
+    if not zusammengesetzt:
+        return None
+    kombi = min(zusammengesetzt, key=lambda v: v["rendite_pct"])
+    beitraege = kombi["beitraege"]
+    negativ = [b for b in beitraege if b["delta_pp"] < 0]
+    bester = max(beitraege, key=lambda b: b["delta_pp"])
+    schlechtester = min(beitraege, key=lambda b: b["delta_pp"])
+    return Learning(
+        titel="Regeln zusammenwerfen macht sie nicht besser",
+        kernaussage=(
+            f"„{kombi['name']}\" kommt auf {_pct(kombi['rendite_pct'])}; "
+            f"{len(negativ)} von {len(beitraege)} Teilregeln liefern einen negativen "
+            f"Beitrag."
+        ),
+        detail=(
+            f"Größter Bremsklotz ist „{schlechtester['name']}\" mit "
+            f"{_pp(schlechtester['delta_pp'])}, "
+            f"{'einziger Rückhalt' if len(negativ) == len(beitraege) - 1 else 'stärkster Rückhalt'} "
+            f"„{bester['name']}\" mit {_pp(bester['delta_pp'])}. Sich widersprechende "
+            f"Signale erzeugen Hin- und Her-Umschichtungen (Whipsaw): erst nach einem "
+            f"Rückgang verkaufen, dann nach der Erholung zurückkaufen. Die Einzeleffekte "
+            f"stehen im Detailabschnitt der Strategie."
+        ),
+    )
+
+
+def _extremwerte_streuung(views: list[dict]) -> Learning | None:
+    """Wie viele Regeln liegen überhaupt im Plus?"""
+    if len(views) < 3:
+        return None
+    positiv = [v for v in views if v["rendite_pct"] > 0]
+    anteil = len(positiv) / len(views) * 100
+    return Learning(
+        titel="Ein Zeitfenster ist kein Beweis",
+        kernaussage=(
+            f"{len(positiv)} von {len(views)} Regeln stehen im Plus "
+            f"({_zahl(anteil, 0)} %) - über genau einen historischen Zeitraum."
+        ),
+        detail=(
+            "Die Auswertung läuft über einen einzigen historischen Zeitraum und über "
+            "Regeln, deren Parameter bewusst nicht optimiert wurden. Sie zeigt, wie sich "
+            "diese Regeln in genau diesem Fenster verhalten hätten - kein Beleg dafür, "
+            "wie sie sich künftig verhalten, und keine Anlageempfehlung."
+        ),
+    )
+
+
+REGELN = (
+    _spannweite,
+    _kombinationseffekt,
+    _aktivitaet,
+    _reibungskosten,
+    _extremwerte_streuung,
+)
+
+
+def derive_learnings(views: list[dict]) -> list[Learning]:
+    """Wendet alle Regeln an und liefert die Learnings, die sich beantworten lassen."""
+    ergebnisse = (regel(views) for regel in REGELN)
+    return [learning for learning in ergebnisse if learning is not None]

--- a/src/boersenspiel/scenarios.py
+++ b/src/boersenspiel/scenarios.py
@@ -14,7 +14,10 @@ Parameter) für drei Kategorien:
 
 1. Börsenweisheiten: "Sell in May and Go Away", "Buy & Hold" (Gegenbeispiel: gar keine
    taktische Umschichtung), "Jahresendrallye" (Santa-Claus-Rally), "Antizyklisch kaufen"
-   (Buy the Dip) und "Verluste begrenzen" (Trailing-Stop je Wachstums-Instrument).
+   (Buy the Dip) und "Verluste begrenzen" (Trailing-Stop je Wachstums-Instrument) -
+   jeweils einzeln, plus "Börsenweisheiten (alle fünf kombiniert)", das die fünf in
+   einer Strategie zusammenführt und den Einzeleffekt jedes Spruchs per Leave-one-out
+   ausweist.
 2. Charttechnik: gleitender-Durchschnitt-Crossover (Golden Cross / Death Cross) auf dem
    MSCI-World-ETF als Trendindikator fürs Gesamtdepot.
 3. Weitere Ansätze: Momentum-/Relative-Stärke-Rotation zwischen den Wachstums-
@@ -24,33 +27,43 @@ Parameter) für drei Kategorien:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal
+from typing import Callable
 
 from .history_store import PriceRow
-from .strategies import BARBELL_20_80, Strategy, Topf
+from .strategies import BARBELL_20_80, Beitrag, Strategy, Topf
 
 TOPF_SICHERHEIT: Topf = BARBELL_20_80.toepfe[0]
 TOPF_WACHSTUM: Topf = BARBELL_20_80.toepfe[1]
 GROWTH_TICKER: list[str] = list(TOPF_WACHSTUM.sub_gewichte.keys())
 TREND_TICKER = "EUNL"  # MSCI-World-ETF als Proxy fuer den breiten Markttrend
 
-_NORMAL_GEWICHTE: dict[str, Decimal] = BARBELL_20_80.alle_ticker_gewichte()
+# Wachstumsquote der unveraenderten Barbell-Verteilung (Topf B am Gesamtdepot).
+NORMALE_WACHSTUMSQUOTE: Decimal = TOPF_WACHSTUM.gewicht_gesamt
+
+
+def gewichte_fuer_wachstumsquote(quote: Decimal) -> dict[str, Decimal]:
+    """Ziel-Gewichte am Gesamtdepot fuer eine gegebene Wachstumsquote (Anteil
+    Topf B). Der Rest geht in Topf A; die Sub-Gewichte innerhalb beider Töpfe
+    bleiben unveraendert. Quote 0 = voll defensiv, 1 = voll investiert."""
+    sicherheitsquote = Decimal(1) - quote
+    gewichte = {t: sub * sicherheitsquote for t, sub in TOPF_SICHERHEIT.sub_gewichte.items()}
+    gewichte.update({t: sub * quote for t, sub in TOPF_WACHSTUM.sub_gewichte.items()})
+    return gewichte
+
+
+_NORMAL_GEWICHTE: dict[str, Decimal] = gewichte_fuer_wachstumsquote(NORMALE_WACHSTUMSQUOTE)
 
 # Ziel-Gewichte, wenn eine Regel "defensiv" auslöst: 100% Topf A (Sicherheit),
 # Topf B (Wachstum) komplett auf 0 - keine neuen Töpfe/Instrumente, nur eine
 # andere Verteilung der bestehenden.
-_DEFENSIV_GEWICHTE: dict[str, Decimal] = {
-    **TOPF_SICHERHEIT.sub_gewichte,
-    **{t: Decimal(0) for t in TOPF_WACHSTUM.sub_gewichte},
-}
+_DEFENSIV_GEWICHTE: dict[str, Decimal] = gewichte_fuer_wachstumsquote(Decimal(0))
 
 # Ziel-Gewichte, wenn eine Regel "aggressiv" auslöst: Wachstum auf 95% hochgefahren,
 # Sicherheit auf 5% reduziert (Sub-Gewichte innerhalb der Töpfe bleiben unverändert).
 _AGGRESSIVE_WACHSTUMSQUOTE = Decimal("0.95")
-_AGGRESSIV_GEWICHTE: dict[str, Decimal] = {
-    **{t: g * (Decimal(1) - _AGGRESSIVE_WACHSTUMSQUOTE) for t, g in TOPF_SICHERHEIT.sub_gewichte.items()},
-    **{t: g * _AGGRESSIVE_WACHSTUMSQUOTE for t, g in TOPF_WACHSTUM.sub_gewichte.items()},
-}
+_AGGRESSIV_GEWICHTE: dict[str, Decimal] = gewichte_fuer_wachstumsquote(_AGGRESSIVE_WACHSTUMSQUOTE)
 
 
 def _rolling_prices(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> list[Decimal] | None:
@@ -85,11 +98,15 @@ def _sma(rows: list[PriceRow], i: int, ticker: str, fenster_wochen: int) -> Deci
 _SELL_IN_MAY_MONATE = {5, 6, 7, 8, 9}
 
 
+def votum_sell_in_may(rows: list[PriceRow], i: int) -> Decimal | None:
+    if rows[i].date.month in _SELL_IN_MAY_MONATE:
+        return Decimal(0)  # voll defensiv
+    return None  # ausserhalb des Sommerhalbjahrs hat diese Weisheit nichts zu sagen
+
+
 def sell_in_may_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
-    monat = rows[i].date.month
-    if monat in _SELL_IN_MAY_MONATE:
-        return _DEFENSIV_GEWICHTE
-    return _NORMAL_GEWICHTE
+    quote = votum_sell_in_may(rows, i)
+    return _NORMAL_GEWICHTE if quote is None else gewichte_fuer_wachstumsquote(quote)
 
 
 SELL_IN_MAY = Strategy(
@@ -113,6 +130,16 @@ SELL_IN_MAY = Strategy(
 # Dezember-Verlustverrechnungs-Mechanismus (steuerliche Optimierung, keine
 # Umschichtung der Zielgewichte) bleibt wie bei den anderen Strategien aktiv.
 
+def votum_buy_and_hold(rows: list[PriceRow], i: int) -> Decimal | None:
+    """"Hin und her macht Taschen leer": stimmt immer fuer die unveraenderte
+    Ausgangsverteilung. Als Einzelszenario heisst das "gar nicht rebalancieren"
+    (siehe ``BUY_AND_HOLD``); im Verbund mit anderen Weisheiten ist die
+    entsprechende Aussage "nichts umschichten", also ein Dauervotum fuer die
+    normale Wachstumsquote - das die Ausschlaege der uebrigen Weisheiten
+    daempft, statt sie zu unterdruecken."""
+    return NORMALE_WACHSTUMSQUOTE
+
+
 BUY_AND_HOLD = Strategy(
     name="Börsenweisheit: Buy & Hold",
     startkapital=Decimal("10000"),
@@ -134,11 +161,15 @@ BUY_AND_HOLD = Strategy(
 _JAHRESENDRALLYE_MONATE = {12, 1}
 
 
+def votum_jahresendrallye(rows: list[PriceRow], i: int) -> Decimal | None:
+    if rows[i].date.month in _JAHRESENDRALLYE_MONATE:
+        return _AGGRESSIVE_WACHSTUMSQUOTE
+    return None  # ausserhalb des Jahreswechsels kein Votum
+
+
 def santa_claus_rally_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
-    monat = rows[i].date.month
-    if monat in _JAHRESENDRALLYE_MONATE:
-        return _AGGRESSIV_GEWICHTE
-    return _NORMAL_GEWICHTE
+    quote = votum_jahresendrallye(rows, i)
+    return _NORMAL_GEWICHTE if quote is None else gewichte_fuer_wachstumsquote(quote)
 
 
 SANTA_CLAUS_RALLY = Strategy(
@@ -164,18 +195,23 @@ BUY_THE_DIP_FENSTER_WOCHEN = 20
 BUY_THE_DIP_SCHWELLE = Decimal("0.10")  # 10% Rückgang vom Rolling-Hoch
 
 
-def buy_the_dip_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+def votum_antizyklisch_kaufen(rows: list[PriceRow], i: int) -> Decimal | None:
     kurse = _rolling_prices(rows, i, TREND_TICKER, BUY_THE_DIP_FENSTER_WOCHEN)
     if kurse is None:
-        return _NORMAL_GEWICHTE
+        return None
     rolling_hoch = max(kurse)
     aktueller_kurs = kurse[-1]
     if rolling_hoch <= 0:
-        return _NORMAL_GEWICHTE
+        return None
     ruckgang = (rolling_hoch - aktueller_kurs) / rolling_hoch
     if ruckgang > BUY_THE_DIP_SCHWELLE:
-        return _AGGRESSIV_GEWICHTE
-    return _NORMAL_GEWICHTE
+        return _AGGRESSIVE_WACHSTUMSQUOTE
+    return None  # ohne nennenswerten Rueckgang kein Votum
+
+
+def buy_the_dip_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    quote = votum_antizyklisch_kaufen(rows, i)
+    return _NORMAL_GEWICHTE if quote is None else gewichte_fuer_wachstumsquote(quote)
 
 
 BUY_THE_DIP = Strategy(
@@ -202,8 +238,14 @@ CUT_LOSSES_FENSTER_WOCHEN = 20
 CUT_LOSSES_SCHWELLE = Decimal("0.15")  # 15% Rückgang vom eigenen Rolling-Hoch
 
 
-def cut_losses_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
-    gewichte = dict(_NORMAL_GEWICHTE)
+def overlay_verluste_begrenzen(
+    rows: list[PriceRow], i: int, gewichte: dict[str, Decimal]
+) -> dict[str, Decimal]:
+    """Setzt jedes Wachstums-Instrument mit zu grossem Rueckgang auf 0% und
+    verteilt dessen Gewicht in den Sicherheits-Topf um. Arbeitet auf beliebigen
+    Ausgangsgewichten (nicht nur der Normalverteilung), damit die Regel sich mit
+    anderen Weisheiten kombinieren laesst."""
+    gewichte = dict(gewichte)
     freigewordenes_gewicht = Decimal(0)
     for ticker in GROWTH_TICKER:
         kurse = _rolling_prices(rows, i, ticker, CUT_LOSSES_FENSTER_WOCHEN)
@@ -223,6 +265,10 @@ def cut_losses_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
     return gewichte
 
 
+def cut_losses_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    return overlay_verluste_begrenzen(rows, i, _NORMAL_GEWICHTE)
+
+
 CUT_LOSSES = Strategy(
     name="Börsenweisheit: Verluste begrenzen",
     startkapital=Decimal("10000"),
@@ -231,6 +277,105 @@ CUT_LOSSES = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=cut_losses_gewichte,
+)
+
+
+# --- 1f: "Börsenweisheiten" (alle fünf kombiniert) --------------------------------------
+#
+# Fasst die fünf Weisheiten oben zu EINER Strategie zusammen, statt sie nur
+# nebeneinander zu stellen. Die Regeln widersprechen sich teilweise (im Mai will
+# "Sell in May" raus, ein gleichzeitiger Kurseinbruch will laut "antizyklisch
+# kaufen" rein), deshalb werden sie nicht hart nacheinander angewendet, sondern
+# in zwei Phasen zusammengeführt:
+#
+#   Phase 1 - Quoten-Votum: jede Weisheit darf eine Wachstumsquote vorschlagen
+#     oder sich enthalten (``None``), wenn ihre Bedingung diese Woche nicht
+#     zutrifft. Die Ziel-Wachstumsquote ist das arithmetische Mittel der
+#     abgegebenen Voten - widersprüchliche Signale heben sich damit teilweise
+#     auf, statt dass eine Regel die anderen überstimmt. "Buy & Hold" votiert
+#     als einzige immer (für die normale Quote) und wirkt so als dämpfender
+#     Anker; damit gibt es auch stets mindestens ein Votum.
+#   Phase 2 - Instrument-Overlay: "Verluste begrenzen" wirkt nicht auf die
+#     Gesamtquote, sondern je Instrument, und wird deshalb anschließend auf das
+#     Ergebnis aus Phase 1 angewendet.
+#
+# Der Einzeleffekt jeder Weisheit wird über ``Strategy.beitraege`` per
+# Leave-one-out ausgewiesen (siehe ``strategies.Beitrag``): dieselbe Strategie
+# noch einmal, nur ohne genau diese eine Weisheit.
+
+
+@dataclass(frozen=True)
+class Weisheit:
+    """Eine Börsenweisheit als kombinierbarer Baustein.
+
+    Implementiert mindestens eine der beiden Phasen: ``quote_fn`` votiert für
+    eine Wachstumsquote (oder ``None`` = Enthaltung), ``overlay_fn`` passt die
+    fertigen Ziel-Gewichte je Instrument an.
+    """
+
+    spruch: str
+    quote_fn: Callable[[list[PriceRow], int], Decimal | None] | None = None
+    overlay_fn: Callable[[list[PriceRow], int, dict[str, Decimal]], dict[str, Decimal]] | None = None
+
+
+WEISHEITEN: tuple[Weisheit, ...] = (
+    Weisheit(spruch="Sell in May and go away", quote_fn=votum_sell_in_may),
+    Weisheit(spruch="Hin und her macht Taschen leer", quote_fn=votum_buy_and_hold),
+    Weisheit(spruch="Jahresendrallye (Santa-Claus-Rally)", quote_fn=votum_jahresendrallye),
+    Weisheit(spruch="Kaufen, wenn die Kanonen donnern", quote_fn=votum_antizyklisch_kaufen),
+    Weisheit(spruch="Verluste begrenzen, Gewinne laufen lassen", overlay_fn=overlay_verluste_begrenzen),
+)
+
+
+def kombinierte_weisheiten_gewichte(
+    weisheiten: tuple[Weisheit, ...],
+) -> Callable[[list[PriceRow], int], dict[str, Decimal]]:
+    """Baut ein ``gewichte_fn`` aus den übergebenen Weisheiten (zwei Phasen, s. o.)."""
+
+    def gewichte_fn(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+        voten = [w.quote_fn(rows, i) for w in weisheiten if w.quote_fn is not None]
+        abgegeben = [q for q in voten if q is not None]
+        if abgegeben:
+            quote = sum(abgegeben, Decimal(0)) / Decimal(len(abgegeben))
+            gewichte = gewichte_fuer_wachstumsquote(quote)
+        else:
+            # Enthalten sich alle (moeglich, sobald "Buy & Hold" weggelassen wird),
+            # bleibt es bei der unveraenderten Barbell-Verteilung.
+            gewichte = dict(_NORMAL_GEWICHTE)
+        for weisheit in weisheiten:
+            if weisheit.overlay_fn is not None:
+                gewichte = weisheit.overlay_fn(rows, i, gewichte)
+        return gewichte
+
+    return gewichte_fn
+
+
+def _weisheiten_strategy(name: str, weisheiten: tuple[Weisheit, ...], **kwargs) -> Strategy:
+    return Strategy(
+        name=name,
+        startkapital=Decimal("10000"),
+        toepfe=BARBELL_20_80.toepfe,
+        ziel_topf=BARBELL_20_80.ziel_topf,
+        ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+        rebalancing_schwelle_pp=Decimal("5"),
+        gewichte_fn=kombinierte_weisheiten_gewichte(weisheiten),
+        **kwargs,
+    )
+
+
+BOERSENWEISHEITEN = _weisheiten_strategy(
+    "Börsenweisheiten (alle fünf kombiniert)",
+    WEISHEITEN,
+    beitraege=tuple(
+        Beitrag(
+            name=weisheit.spruch,
+            ohne=_weisheiten_strategy(
+                f"ohne „{weisheit.spruch}“",
+                tuple(w for w in WEISHEITEN if w is not weisheit),
+            ),
+        )
+        for weisheit in WEISHEITEN
+    ),
 )
 
 
@@ -429,6 +574,7 @@ SCENARIOS: list[Strategy] = [
     SANTA_CLAUS_RALLY,
     BUY_THE_DIP,
     CUT_LOSSES,
+    BOERSENWEISHEITEN,
     CHART_SMA_CROSSOVER,
     MOMENTUM_ROTATION,
     VOLATILITY_TARGET,

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -33,6 +33,24 @@ class Topf:
 
 
 @dataclass(frozen=True)
+class Beitrag:
+    """Eine Teilregel einer zusammengesetzten Strategie, deren Effekt einzeln
+    ausgewiesen werden soll.
+
+    ``ohne`` ist dieselbe Strategie mit genau dieser einen Teilregel entfernt.
+    Die Darstellungsschicht misst den Effekt der Teilregel per
+    "Leave-one-out": Rendite(voll) - Rendite(ohne diese Teilregel), also der
+    Renditebeitrag in Prozentpunkten, den das Weglassen dieser Regel kosten
+    (positiv) oder sparen (negativ) würde. Das ist bewusst nur eine
+    *marginale* Betrachtung - die Beiträge summieren sich bei sich gegenseitig
+    beeinflussenden Regeln nicht exakt zur Gesamtrendite auf.
+    """
+
+    name: str  # Anzeigename der Teilregel (z. B. die Börsenweisheit selbst)
+    ohne: "Strategy"
+
+
+@dataclass(frozen=True)
 class Strategy:
     name: str
     startkapital: Decimal
@@ -48,6 +66,12 @@ class Strategy:
     # einzubauen. None bedeutet: konstante Gewichte aus den toepfe/sub_gewichte (Barbell-
     # Rebalancing-Verhalten, wie bisher).
     gewichte_fn: Callable[[list["PriceRow"], int], dict[str, Decimal]] | None = None
+    # Optional: Teilregeln einer zusammengesetzten Strategie, deren Einzeleffekt das
+    # Dashboard per Leave-one-out ausweist (siehe ``Beitrag``). Leer bedeutet: die
+    # Strategie wird nur als Ganzes betrachtet. Die in ``Beitrag.ohne`` hinterlegten
+    # Varianten haben ihrerseits keine ``beitraege`` - sonst würde die Auswertung
+    # rekursiv.
+    beitraege: tuple[Beitrag, ...] = ()
 
     def alle_ticker_gewichte(self) -> dict[str, Decimal]:
         """Ziel-Gewicht jedes Instruments am Gesamtdepot."""

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -95,6 +95,35 @@
   .overflow-x { overflow-x: auto; }
   footer { max-width: 1100px; margin: 24px auto 0; color: var(--text-muted); font-size: 0.8rem; }
   .summary-chart-box { position: relative; height: 340px; margin-bottom: 20px; }
+  .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 16px; max-width: 68ch; }
+  ol.learnings { list-style: none; counter-reset: learning; margin: 0; padding: 0; display: grid; gap: 14px; }
+  ol.learnings li {
+    counter-increment: learning;
+    position: relative;
+    background: var(--page);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 18px 14px 52px;
+  }
+  ol.learnings li::before {
+    content: counter(learning);
+    position: absolute;
+    left: 16px;
+    top: 14px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--series-1);
+    color: #fff;
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  ol.learnings h3 { font-size: 0.98rem; margin: 0 0 4px; }
+  ol.learnings .kernaussage { margin: 0 0 6px; font-size: 0.95rem; }
+  ol.learnings .detail { margin: 0; color: var(--text-secondary); font-size: 0.85rem; max-width: 78ch; }
   .beitraege { margin-bottom: 20px; }
   .beitraege h3 { font-size: 1rem; margin: 0 0 4px; }
   .beitraege .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 12px; max-width: 68ch; }
@@ -110,6 +139,24 @@
   <div class="meta">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
 </header>
 <main>
+{% if learnings %}
+  <section class="strategy" id="key-learnings">
+    <h2>Key Learnings</h2>
+    <p class="hint">
+      Bei jedem Build neu aus den Simulationsergebnissen abgeleitet – nicht
+      hinterlegter Text. Ändert sich die Kurshistorie, ändern sich diese Aussagen mit.
+    </p>
+    <ol class="learnings">
+    {% for l in learnings %}
+      <li>
+        <h3>{{ l.titel }}</h3>
+        <p class="kernaussage">{{ l.kernaussage }}</p>
+        <p class="detail">{{ l.detail }}</p>
+      </li>
+    {% endfor %}
+    </ol>
+  </section>
+{% endif %}
   <section class="strategy" id="uebersicht">
     <h2>Übersicht: Rendite im Vergleich</h2>
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -95,6 +95,10 @@
   .overflow-x { overflow-x: auto; }
   footer { max-width: 1100px; margin: 24px auto 0; color: var(--text-muted); font-size: 0.8rem; }
   .summary-chart-box { position: relative; height: 340px; margin-bottom: 20px; }
+  .beitraege { margin-bottom: 20px; }
+  .beitraege h3 { font-size: 1rem; margin: 0 0 4px; }
+  .beitraege .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 12px; max-width: 68ch; }
+  .beitraege .chart-box { height: 220px; margin-bottom: 12px; }
   table.summary-table a { color: inherit; text-decoration: underline; text-decoration-color: var(--border); }
   .positive { color: var(--good); }
   .negative { color: var(--series-2); }
@@ -145,6 +149,32 @@
       <div class="chart-box"><canvas id="value-chart-{{ loop.index }}"></canvas></div>
       <div class="chart-box"><canvas id="topf-chart-{{ loop.index }}"></canvas></div>
     </div>
+    {% if s.beitraege %}
+    <div class="beitraege">
+      <h3>Effekt der einzelnen Börsenweisheiten</h3>
+      <p class="hint">
+        Leave-one-out: Rendite dieser Strategie minus Rendite derselben Strategie
+        <em>ohne</em> den jeweiligen Spruch. Positiv = der Spruch hat Rendite gebracht,
+        negativ = er hat gekostet. Die Regeln beeinflussen sich gegenseitig, die
+        Einzelbeiträge summieren sich deshalb nicht exakt zur Gesamtrendite.
+      </p>
+      <div class="chart-box"><canvas id="beitrag-chart-{{ loop.index }}"></canvas></div>
+      <div class="overflow-x">
+        <table>
+          <thead><tr><th>Börsenweisheit</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Spruch %</th></tr></thead>
+          <tbody>
+          {% for b in s.beitraege %}
+            <tr>
+              <td>{{ b.name }}</td>
+              <td class="{{ 'positive' if b.delta_pp >= 0 else 'negative' }}">{{ b.delta_label }}</td>
+              <td>{{ b.ohne_rendite_label }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    {% endif %}
     <div class="overflow-x">
       <table>
         <thead><tr><th>Instrument</th><th>Einheiten</th><th>Kurs</th><th>Wert</th><th>Ist-Gewicht %</th><th>Ziel-Gewicht %</th></tr></thead>
@@ -229,6 +259,29 @@
       scales: commonScales,
     },
   });
+
+  {% if s.beitraege %}
+  new Chart(document.getElementById('beitrag-chart-{{ loop.index }}'), {
+    type: 'bar',
+    data: {
+      labels: {{ s.beitraege | map(attribute='name') | list | tojson }},
+      datasets: [{
+        label: 'Effekt (Prozentpunkte)',
+        data: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }},
+        backgroundColor: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+      }],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Börsenweisheit (Prozentpunkte)', color: colors.text } },
+      scales: {
+        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+      },
+    },
+  });
+  {% endif %}
 
   new Chart(document.getElementById('topf-chart-{{ loop.index }}'), {
     type: 'line',

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from boersenspiel.dashboard import _slug, build_dashboard
 from boersenspiel.history_store import PriceRow
-from boersenspiel.strategies import Strategy, Topf
+from boersenspiel.strategies import Beitrag, Strategy, Topf
 
 ZWEI_STRATEGIEN = [
     Strategy(
@@ -69,3 +69,61 @@ def test_build_dashboard_summary_matches_detail_total_value(tmp_path: Path):
     html = output.read_text(encoding="utf-8")
     # Endwert taucht sowohl in der Uebersichtstabelle als auch im Detail-Stat-Tile auf.
     assert html.count("1498.50") >= 2
+
+
+# --- Leave-one-out-Beitraege zusammengesetzter Strategien ------------------------------
+
+
+def _strategy_mit_beitraegen() -> Strategy:
+    """Zwei Varianten mit unterschiedlicher Rebalancing-Schwelle, damit sich die
+    Renditen (und damit die Leave-one-out-Differenzen) messbar unterscheiden."""
+    basis = dict(
+        startkapital=Decimal("1000"),
+        toepfe=[
+            Topf(
+                name="Topf",
+                gewicht_gesamt=Decimal("1"),
+                sub_gewichte={"T1": Decimal("0.5"), "T2": Decimal("0.5")},
+            )
+        ],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+    return Strategy(
+        name="Kombiniert",
+        **basis,
+        beitraege=(
+            Beitrag(name="Regel A", ohne=Strategy(name="ohne Regel A", **basis)),
+            Beitrag(name="Regel B", ohne=Strategy(name="ohne Regel B", **basis)),
+        ),
+    )
+
+
+def _zwei_ticker_rows() -> list[PriceRow]:
+    return [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("150"), "T2": Decimal("120")}),
+    ]
+
+
+def test_build_dashboard_renders_beitrag_chart_and_table(tmp_path: Path):
+    output = build_dashboard(
+        _zwei_ticker_rows(), [_strategy_mit_beitraegen()], output_path=tmp_path / "index.html"
+    )
+    html = output.read_text(encoding="utf-8")
+
+    assert "Effekt der einzelnen Börsenweisheiten" in html
+    assert 'id="beitrag-chart-1"' in html
+    assert "Regel A" in html
+    assert "Regel B" in html
+    # Identische Varianten -> Leave-one-out-Differenz exakt 0.
+    assert html.count("+0.00") >= 2
+
+
+def test_build_dashboard_omits_beitrag_section_without_beitraege(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    assert "Effekt der einzelnen Börsenweisheiten" not in html
+    assert "beitrag-chart-" not in html

--- a/tests/test_learnings.py
+++ b/tests/test_learnings.py
@@ -9,14 +9,32 @@ nicht beantwortbar ist.
 
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 from pathlib import Path
 
 from boersenspiel.dashboard import build_dashboard
+from boersenspiel.history_store import PriceRow
 from boersenspiel.learnings import derive_learnings
 from boersenspiel.strategies import Strategy, Topf
 
-from tests.test_dashboard import _rows, ZWEI_STRATEGIEN
+
+def _einfache_strategie(name: str) -> Strategy:
+    return Strategy(
+        name=name,
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T1": Decimal("1")})],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+
+
+def _rows() -> list[PriceRow]:
+    return [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("150")}),
+    ]
 
 
 def _view(
@@ -129,7 +147,8 @@ def test_derive_learnings_mit_leerer_liste():
 
 
 def test_build_dashboard_rendert_learnings_sektion(tmp_path: Path):
-    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    zwei = [_einfache_strategie("A: Verdoppler"), _einfache_strategie("B: Zwilling")]
+    output = build_dashboard(_rows(), zwei, output_path=tmp_path / "index.html")
     html = output.read_text(encoding="utf-8")
 
     assert 'id="key-learnings"' in html
@@ -140,17 +159,9 @@ def test_build_dashboard_rendert_learnings_sektion(tmp_path: Path):
 
 def test_build_dashboard_ohne_learnings_rendert_keine_leere_sektion(tmp_path: Path):
     """Eine einzelne, handelsfreie Strategie erzeugt kein einziges Learning."""
-    eine_strategie = [
-        Strategy(
-            name="Nur eine",
-            startkapital=Decimal("1000"),
-            toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T1": Decimal("1")})],
-            ziel_topf="Topf",
-            ziel_gewicht=Decimal("1"),
-            rebalancing_schwelle_pp=Decimal("1000"),
-        )
-    ]
-    output = build_dashboard(_rows(), eine_strategie, output_path=tmp_path / "index.html")
+    output = build_dashboard(
+        _rows(), [_einfache_strategie("Nur eine")], output_path=tmp_path / "index.html"
+    )
     html = output.read_text(encoding="utf-8")
 
     assert 'id="key-learnings"' not in html

--- a/tests/test_learnings.py
+++ b/tests/test_learnings.py
@@ -1,0 +1,156 @@
+"""Tests für die abgeleiteten Key Learnings (``learnings.py``).
+
+Kernpunkt der Prüfung: die Aussagen sind **nicht** hinterlegt, sondern folgen
+den übergebenen Zahlen. Deshalb wird jede Regel gegen konstruierte Views mit
+bekannten Werten gefahren und geprüft, dass die genannten Zahlen und Namen
+mitwandern - und dass eine Regel still wegfällt, wenn ihre Frage aus den Daten
+nicht beantwortbar ist.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from boersenspiel.dashboard import build_dashboard
+from boersenspiel.learnings import derive_learnings
+from boersenspiel.strategies import Strategy, Topf
+
+from tests.test_dashboard import _rows, ZWEI_STRATEGIEN
+
+
+def _view(
+    name: str,
+    rendite_pct: float,
+    trade_count: int = 10,
+    steuer: float = 0.0,
+    beitraege: list[dict] | None = None,
+) -> dict:
+    return {
+        "name": name,
+        "rendite_pct": rendite_pct,
+        "trade_count": trade_count,
+        "steuer_num": steuer,
+        "startkapital_num": 10000.0,
+        "beitraege": beitraege or [],
+    }
+
+
+def _titel(learnings) -> list[str]:
+    return [l.titel for l in learnings]
+
+
+def test_spannweite_nennt_beste_und_schlechteste_regel():
+    views = [_view("Gut", 50.0), _view("Mittel", 10.0), _view("Schlecht", -20.0)]
+    learning = next(l for l in derive_learnings(views) if l.titel == "Die Regel entscheidet, nicht der Markt")
+
+    # Spread 50 - (-20) = 70 pp
+    assert "+70,00 pp" in learning.kernaussage
+    assert "Gut" in learning.detail and "+50,00 %" in learning.detail
+    assert "Schlecht" in learning.detail and "-20,00 %" in learning.detail
+
+
+def test_aktivitaet_nennt_platzierung_der_handelsintensivsten_regel():
+    views = [
+        _view("Vielhandel", -5.0, trade_count=400),
+        _view("Mittel", 20.0, trade_count=100),
+        _view("Ruhig", 80.0, trade_count=5),
+    ]
+    learning = next(l for l in derive_learnings(views) if l.titel == "Mehr Handeln ist nicht mehr Rendite")
+
+    assert "400 Trades" in learning.kernaussage
+    assert "Platz 3 von 3" in learning.kernaussage
+    assert "5 Trades" in learning.kernaussage
+    assert "Platz 1" in learning.kernaussage
+
+
+def test_aktivitaet_dreht_sich_mit_den_daten():
+    """Gegenprobe: handelt die BESTE Regel am meisten, wandert die Platzierung mit."""
+    views = [
+        _view("Vielhandel", 80.0, trade_count=400),
+        _view("Mittel", 20.0, trade_count=100),
+        _view("Ruhig", -5.0, trade_count=5),
+    ]
+    learning = next(l for l in derive_learnings(views) if l.titel == "Mehr Handeln ist nicht mehr Rendite")
+    assert "Platz 1 von 3" in learning.kernaussage
+
+
+def test_reibungskosten_rechnet_gebuehren_aus_trade_count():
+    views = [_view("A", 10.0, trade_count=250, steuer=150.0), _view("B", 5.0, trade_count=3)]
+    learning = next(l for l in derive_learnings(views) if l.titel.startswith("Reibung"))
+
+    # 250 Trades * 1 EUR + 150 EUR Steuer = 400 EUR = 4,0 % von 10.000 EUR
+    assert "400 €" in learning.kernaussage
+    assert "4,0 %" in learning.kernaussage
+    assert "250 €" in learning.detail and "150 €" in learning.detail
+
+
+def test_kombinationseffekt_zaehlt_negative_beitraege():
+    beitraege = [
+        {"name": "Regel A", "delta_pp": -30.0},
+        {"name": "Regel B", "delta_pp": +12.0},
+        {"name": "Regel C", "delta_pp": -4.0},
+        {"name": "Regel D", "delta_pp": +3.0},
+    ]
+    views = [_view("Solo", 40.0), _view("Kombi", -10.0, beitraege=beitraege)]
+    learning = next(l for l in derive_learnings(views) if l.titel.startswith("Regeln zusammenwerfen"))
+
+    assert "2 von 4" in learning.kernaussage
+    assert "Regel A" in learning.detail and "-30,00 pp" in learning.detail
+    assert "Regel B" in learning.detail and "+12,00 pp" in learning.detail
+    # Zwei positive Beitraege -> "einziger Rückhalt" waere falsch
+    assert "stärkster Rückhalt" in learning.detail
+
+
+def test_kombinationseffekt_formuliert_einzigen_rueckhalt():
+    beitraege = [
+        {"name": "Regel A", "delta_pp": -30.0},
+        {"name": "Regel B", "delta_pp": +12.0},
+    ]
+    views = [_view("Solo", 40.0), _view("Kombi", -10.0, beitraege=beitraege)]
+    learning = next(l for l in derive_learnings(views) if l.titel.startswith("Regeln zusammenwerfen"))
+    assert "einziger Rückhalt" in learning.detail
+
+
+def test_kombinationseffekt_faellt_ohne_zusammengesetzte_strategie_weg():
+    views = [_view("A", 10.0), _view("B", 20.0), _view("C", 30.0)]
+    assert not any(t.startswith("Regeln zusammenwerfen") for t in _titel(derive_learnings(views)))
+
+
+def test_learnings_fallen_bei_zu_wenigen_strategien_still_weg():
+    """Eine einzelne Strategie beantwortet keine der Vergleichsfragen."""
+    learnings = derive_learnings([_view("Einzeln", 10.0, trade_count=5)])
+    assert "Die Regel entscheidet, nicht der Markt" not in _titel(learnings)
+    assert "Mehr Handeln ist nicht mehr Rendite" not in _titel(learnings)
+
+
+def test_derive_learnings_mit_leerer_liste():
+    assert derive_learnings([]) == []
+
+
+def test_build_dashboard_rendert_learnings_sektion(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    assert 'id="key-learnings"' in html
+    assert "Key Learnings" in html
+    # Beide Test-Strategien sind identisch -> Spannweite 0, aber die Sektion steht.
+    assert "Die Regel entscheidet, nicht der Markt" in html
+
+
+def test_build_dashboard_ohne_learnings_rendert_keine_leere_sektion(tmp_path: Path):
+    """Eine einzelne, handelsfreie Strategie erzeugt kein einziges Learning."""
+    eine_strategie = [
+        Strategy(
+            name="Nur eine",
+            startkapital=Decimal("1000"),
+            toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T1": Decimal("1")})],
+            ziel_topf="Topf",
+            ziel_gewicht=Decimal("1"),
+            rebalancing_schwelle_pp=Decimal("1000"),
+        )
+    ]
+    output = build_dashboard(_rows(), eine_strategie, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    assert 'id="key-learnings"' not in html

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -18,20 +18,26 @@ from decimal import Decimal
 from boersenspiel.engine import simulate
 from boersenspiel.history_store import PriceRow
 from boersenspiel.scenarios import (
+    BOERSENWEISHEITEN,
     BUY_AND_HOLD,
     BUY_THE_DIP,
     CHART_SMA_CROSSOVER,
     COST_AVERAGE_ENTRY,
     CUT_LOSSES,
+    CUT_LOSSES_FENSTER_WOCHEN,
     MOMENTUM_ROTATION,
     SANTA_CLAUS_RALLY,
     SELL_IN_MAY,
+    TOPF_WACHSTUM,
     VOLATILITY_TARGET,
+    WEISHEITEN,
     buy_the_dip_gewichte,
     chart_sma_crossover_gewichte,
     cost_average_gewichte,
     cut_losses_gewichte,
+    gewichte_fuer_wachstumsquote,
     momentum_rotation_gewichte,
+    overlay_verluste_begrenzen,
     santa_claus_rally_gewichte,
     sell_in_may_gewichte,
     volatility_target_gewichte,
@@ -414,3 +420,98 @@ def test_cost_average_entry_scenario_runs_end_to_end():
     result = simulate(_sample_rows(), COST_AVERAGE_ENTRY)
     last_point = result.value_history[-1]
     assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")
+
+
+# --- Börsenweisheiten (alle fünf kombiniert) ------------------------------------------
+
+
+def test_kombinierte_weisheiten_mitteln_widerspruechliche_voten():
+    """Mai + "Buy & Hold": Voten 0% und 80% -> Mittel 40% Wachstumsquote.
+
+    Die uebrigen drei Weisheiten enthalten sich hier: Jahresendrallye (nicht
+    Dez/Jan), antizyklisch kaufen und Verluste begrenzen (beide brauchen 20
+    Wochen Historie, die es an dieser Stelle noch nicht gibt).
+    """
+    rows = _sample_rows()
+    i = next(idx for idx, r in enumerate(rows) if r.date.month == 5)
+    assert i < CUT_LOSSES_FENSTER_WOCHEN  # sonst greifen die Rolling-Window-Regeln mit
+
+    gewichte = BOERSENWEISHEITEN.gewichte_fn(rows, i)
+
+    # Sicherheitsquote 60%, aufgeteilt nach den Sub-Gewichten von Topf A
+    assert gewichte["EUNL"] == Decimal("0.50") * Decimal("0.60")
+    assert gewichte["EUNA"] == Decimal("0.35") * Decimal("0.60")
+    assert gewichte["4GLD"] == Decimal("0.15") * Decimal("0.60")
+    # Wachstumsquote 40%, aufgeteilt nach den Sub-Gewichten von Topf B
+    assert gewichte["LYMS"] == Decimal("0.40") * Decimal("0.40")
+    assert gewichte["BTC-EUR"] == Decimal("0.10") * Decimal("0.40")
+    assert sum(gewichte.values()) == Decimal("1")
+
+
+def test_kombinierte_weisheiten_mitteln_jahresendrallye_mit_buy_and_hold():
+    """Dezember: Voten 80% (Buy & Hold) und 95% (Jahresendrallye) -> Mittel 87,5%."""
+    rows = _sample_rows()
+    i = next(idx for idx, r in enumerate(rows) if r.date.month == 12)
+
+    gewichte = BOERSENWEISHEITEN.gewichte_fn(rows, i)
+    wachstumsquote = sum(gewichte[t] for t in TOPF_WACHSTUM.sub_gewichte)
+    assert wachstumsquote == Decimal("0.875")
+
+
+def test_kombinierte_weisheiten_gewichte_summieren_immer_zu_eins():
+    rows = _sample_rows()
+    for i in range(len(rows)):
+        gewichte = BOERSENWEISHEITEN.gewichte_fn(rows, i)
+        assert abs(sum(gewichte.values()) - Decimal("1")) < Decimal("0.0000001")
+
+
+def test_ohne_buy_and_hold_enthalten_sich_alle_und_es_bleibt_normal():
+    """Fallback-Pfad: ohne das Dauervotum von "Buy & Hold" gibt es in einer
+    ruhigen Woche gar kein Votum -> unveraenderte Barbell-Verteilung."""
+    ohne_buy_and_hold = next(
+        b.ohne for b in BOERSENWEISHEITEN.beitraege if b.name == "Hin und her macht Taschen leer"
+    )
+    rows = _sample_rows()
+    # Februar, zu wenig Historie fuer die beiden Rolling-Window-Regeln
+    i = next(idx for idx, r in enumerate(rows) if r.date.month == 2)
+
+    gewichte = ohne_buy_and_hold.gewichte_fn(rows, i)
+    assert gewichte == BARBELL_20_80.alle_ticker_gewichte()
+
+
+def test_beitraege_lassen_je_genau_eine_weisheit_weg():
+    assert len(BOERSENWEISHEITEN.beitraege) == len(WEISHEITEN) == 5
+    assert [b.name for b in BOERSENWEISHEITEN.beitraege] == [w.spruch for w in WEISHEITEN]
+    # Die Leave-one-out-Varianten haben selbst keine beitraege - sonst wuerde die
+    # Auswertung im Dashboard rekursiv.
+    assert all(b.ohne.beitraege == () for b in BOERSENWEISHEITEN.beitraege)
+
+    rows = _sample_rows()
+    i = next(idx for idx, r in enumerate(rows) if r.date.month == 5)
+    ohne_sell_in_may = next(
+        b.ohne for b in BOERSENWEISHEITEN.beitraege if b.name == "Sell in May and go away"
+    )
+    # Ohne "Sell in May" faellt im Mai das 0%-Votum weg -> nur noch Buy & Hold -> 80%.
+    wachstumsquote = sum(ohne_sell_in_may.gewichte_fn(rows, i)[t] for t in TOPF_WACHSTUM.sub_gewichte)
+    assert wachstumsquote == Decimal("0.80")
+
+
+def test_boersenweisheiten_scenario_runs_end_to_end():
+    result = simulate(_sample_rows(), BOERSENWEISHEITEN)
+    last_point = result.value_history[-1]
+    assert abs(sum(last_point.ticker_weights.values()) - Decimal("1")) < Decimal("0.0001")
+
+
+def test_verluste_begrenzen_overlay_wirkt_auf_beliebige_ausgangsgewichte():
+    """Das Overlay muss auch auf einer bereits reduzierten Wachstumsquote sauber
+    umschichten (Gewichtssumme bleibt 1), nicht nur auf der Normalverteilung."""
+    rows = _rows_with_single_loser()
+    i = 20
+    ausgangs_gewichte = gewichte_fuer_wachstumsquote(Decimal("0.40"))
+
+    gewichte = overlay_verluste_begrenzen(rows, i, ausgangs_gewichte)
+
+    assert gewichte["LYMS"] == Decimal("0")  # abgestuerztes Instrument komplett raus
+    assert gewichte["EUNL"] > ausgangs_gewichte["EUNL"]  # Gewicht in den Sicherheits-Topf
+    assert abs(sum(gewichte.values()) - Decimal("1")) < Decimal("0.0000001")
+    assert ausgangs_gewichte["LYMS"] == Decimal("0.40") * Decimal("0.40")  # Eingabe unveraendert


### PR DESCRIPTION
## Was

Neues Szenario **"Börsenweisheiten (alle fünf kombiniert)"**, das die bisher nur nebeneinander stehenden fünf Börsenweisheiten zu *einer* Strategie zusammenfasst — plus ein Balkendiagramm, das den Effekt jedes einzelnen Spruchs innerhalb dieser Kombination ausweist.

## Wie kombiniert

Die Regeln widersprechen sich teilweise (im Mai will "Sell in May" raus, ein gleichzeitiger Kurseinbruch will laut "antizyklisch kaufen" rein). Statt sie hart nacheinander anzuwenden, laufen sie in zwei Phasen:

- **Phase 1 – Quoten-Votum:** Jede Weisheit schlägt eine Wachstumsquote vor oder enthält sich (`None`), wenn ihre Bedingung diese Woche nicht greift. Ziel ist das **arithmetische Mittel der abgegebenen Voten** — widersprüchliche Signale heben sich damit teilweise auf, statt dass eine Regel die anderen überstimmt. "Buy & Hold" votiert als einzige immer (für die normale 80%-Quote) und wirkt so als dämpfender Anker; damit gibt es stets mindestens ein Votum.
- **Phase 2 – Instrument-Overlay:** "Verluste begrenzen" wirkt nicht auf die Gesamtquote, sondern je Instrument, und wird deshalb anschließend auf das Ergebnis aus Phase 1 angewendet.

## Effekt je Spruch (Leave-one-out)

Neues optionales Feld `Strategy.beitraege` (`Beitrag(name, ohne)`) markiert eine Strategie als zusammengesetzt: `ohne` ist dieselbe Strategie ohne genau diese eine Teilregel. Das Dashboard simuliert die `ohne`-Varianten zusätzlich und zeigt die Renditedifferenz in Prozentpunkten als Balkendiagramm plus Tabelle.

Der Mechanismus ist bewusst generisch — Engine und Darstellungsschicht kennen keine Börsenweisheiten-Details, jede künftige zusammengesetzte Strategie kann `beitraege` setzen. Die `ohne`-Varianten haben selbst keine `beitraege`, sonst würde die Auswertung rekursiv.

## Ergebnis auf der aktuellen 5-Jahres-Historie

| | Rendite |
|---|---|
| Börsenweisheiten (alle fünf kombiniert) | **−11,77 %** |

| Spruch | Effekt | Rendite ohne diesen Spruch |
|---|---|---|
| Sell in May and go away | −75,04 pp | +63,27 % |
| Hin und her macht Taschen leer | +83,61 pp | −95,38 % |
| Jahresendrallye (Santa-Claus-Rally) | −6,74 pp | −5,03 % |
| Kaufen, wenn die Kanonen donnern | −5,56 pp | −6,21 % |
| Verluste begrenzen, Gewinne laufen lassen | −28,45 pp | +16,68 % |

Die Kombination schneidet deutlich schlechter ab als jede Einzelregel (+21,97 % bis +128,98 %) — 380 Trades statt 27–273, der Einbruch liegt in 2022. Das ist kein Rechenfehler, sondern Whipsaw: "Verluste begrenzen" verkauft nach Rückgängen (realisiert den Verlust), während die saisonale Regel unabhängig davon wieder einsteigt, sodass wiederholt tief verkauft und teuer zurückgekauft wird. Der Engine-Rebalancing-Trigger vergleicht dabei korrekt gegen das *effektive* Ziel aus `gewichte_fn`. Das dämpfende Dauervotum von "Buy & Hold" ist mit +83,61 pp der einzige positive Beitrag.

## Refactoring

Die fünf Einzelregeln sind in wiederverwendbare Bausteine zerlegt (`votum_*` / `overlay_verluste_begrenzen`), außerdem gibt es `gewichte_fuer_wachstumsquote()` als gemeinsamen Helfer für die vorher dreifach ausgeschriebene Quoten→Gewichte-Umrechnung. Die bestehenden Einzelszenarien leiten sich unverändert daraus ab — ihre Ergebnisse bleiben identisch (durch die bestehenden Tests abgedeckt).

## Tests

99 statt 90 Tests, alle grün (`python3 -m pytest -q`). Neu:

- gemittelte Quoten handgerechnet (Mai → 40 %, Dezember → 87,5 %)
- Gewichte summieren in *jeder* Woche zu 1
- jede Leave-one-out-Variante lässt genau eine Weisheit weg und hat selbst keine `beitraege`
- Fallback-Pfad ohne jedes Votum (sobald "Buy & Hold" fehlt)
- Overlay wirkt korrekt auf beliebigen Ausgangsgewichten, ohne die Eingabe zu mutieren
- Beitrags-Abschnitt wird nur bei gesetztem `beitraege` gerendert

Determinismus verifiziert (zwei Läufe → identisches Ergebnis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RyQMKVtwPVXc9vRgcUZe1


---
_Generated by [Claude Code](https://claude.ai/code/session_011RyQMKVtwPVXc9vRgcUZe1)_