### PR TITLE
Einheitliche Chart-Skalierung, Optimierungs-Schalter und Szenario-Beschreibungen

### DIFF
--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -23,6 +24,14 @@ from .strategies import STRATEGIES, Strategy
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 DEFAULT_OUTPUT = Path(__file__).resolve().parents[2] / "docs" / "index.html"
+
+# Anzeigenamen der vier Optimierungs-Schalter (siehe strategies.Optimierungen / #17).
+_OPTIMIERUNGS_LABELS: dict[str, str] = {
+    "steueroptimierung": "Steueroptimierung (Dezember-Harvest)",
+    "rebalancing": "Rebalancing",
+    "ordergebuehren": "Ordergebühren",
+    "besteuerung": "Besteuerung",
+}
 
 
 def _f(value: Decimal) -> float:
@@ -42,6 +51,26 @@ def _rendite_pct(result: SimulationResult, strategy: Strategy) -> Decimal:
         return Decimal(0)
     endwert = result.value_history[-1].total_value
     return ((endwert - strategy.startkapital) / strategy.startkapital) * 100
+
+
+def _optimierungs_effekte(strategy: Strategy, rows: list[PriceRow], basis_rendite_pct: Decimal) -> list[dict]:
+    """Effekt jedes der vier Optimierungs-Schalter (#17) als Leave-one-out-Differenz:
+    Rendite mit allen Schaltern wie konfiguriert minus Rendite mit genau diesem einen
+    Schalter aus."""
+    effekte = []
+    for feld, label in _OPTIMIERUNGS_LABELS.items():
+        variante = replace(strategy.optimierungen, **{feld: False})
+        ohne_rendite_pct = _rendite_pct(simulate(rows, strategy, variante), strategy)
+        delta_pp = basis_rendite_pct - ohne_rendite_pct
+        effekte.append(
+            {
+                "name": label,
+                "delta_pp": _f(delta_pp),
+                "delta_label": f"{delta_pp:+.2f}",
+                "ohne_rendite_label": f"{ohne_rendite_pct:+.2f}",
+            }
+        )
+    return effekte
 
 
 def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: list[PriceRow]) -> dict:
@@ -100,10 +129,12 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
     return {
         "name": result.strategy_name,
         "id": _slug(result.strategy_name),
+        "beschreibung": strategy.beschreibung,
         "rendite_pct": _f(rendite_pct),
         "rendite_pct_label": f"{rendite_pct:+.2f}",
         "gewinn_label": f"{gewinn:+.2f}",
         "labels_json": json.dumps(labels),
+        "total_values": total_values,
         "total_values_json": json.dumps(total_values),
         "topf_series_json": json.dumps(topf_series),
         "topf_targets": topf_targets,
@@ -127,6 +158,7 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         "last_rebalance_date": result.last_rebalance_date.isoformat() if result.last_rebalance_date else "-",
         "last_harvest_date": result.last_harvest_date.isoformat() if result.last_harvest_date else "-",
         "beitraege": beitraege,
+        "optimierungs_effekte": _optimierungs_effekte(strategy, rows, rendite_pct),
     }
 
 
@@ -144,6 +176,12 @@ def build_dashboard(
     summary = sorted(views, key=lambda v: v["rendite_pct"], reverse=True)
     learnings = derive_learnings(views)
 
+    # Gemeinsames Y-Achsen-Maximum ueber alle Wertverlauf-Charts (#24): ohne das skaliert
+    # jeder Chart unabhaengig, wodurch unterschiedliche Strategien optisch nicht mehr
+    # vergleichbar sind.
+    alle_werte = [wert for view in views for wert in view["total_values"]]
+    wert_chart_max = max(alle_werte) if alle_werte else 0.0
+
     env = Environment(
         loader=FileSystemLoader(str(TEMPLATE_DIR)),
         autoescape=select_autoescape(["html"]),
@@ -156,6 +194,7 @@ def build_dashboard(
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
         row_count=len(price_history),
         last_date=price_history[-1].date.isoformat(),
+        wert_chart_max=wert_chart_max,
     )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -53,7 +53,7 @@ from datetime import date
 from decimal import Decimal
 
 from .history_store import PriceRow
-from .strategies import ORDERGEBUEHR, SPARERPAUSCHBETRAG_PRO_JAHR, STEUERSATZ, Strategy
+from .strategies import ORDERGEBUEHR, SPARERPAUSCHBETRAG_PRO_JAHR, STEUERSATZ, Optimierungen, Strategy
 
 
 @dataclass
@@ -109,9 +109,16 @@ class _Position:
         return self.cost_total / self.units
 
 
-def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationResult:
+def simulate(
+    price_history: list[PriceRow],
+    strategy: Strategy,
+    optimierungen: Optimierungen | None = None,
+) -> SimulationResult:
     if not price_history:
         raise ValueError("Kurshistorie ist leer - Simulation benötigt mindestens eine Zeile")
+
+    opt = optimierungen if optimierungen is not None else strategy.optimierungen
+    gebuehr = ORDERGEBUEHR if opt.ordergebuehren else Decimal(0)
 
     rows = sorted(price_history, key=lambda r: r.date)
     base_weights = strategy.alle_ticker_gewichte()
@@ -148,6 +155,8 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
 
     def process_realized_gain(gain: Decimal) -> None:
         nonlocal freibetrag_verbleibend, verlustvortrag, kumulierte_steuer, steuerpflichtige_gewinne_jahr
+        if not opt.besteuerung:
+            return
         if gain <= 0:
             verlustvortrag += -gain
             return
@@ -203,11 +212,11 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                     continue
                 proceeds = units_to_sell * price
                 cost_removed = pos.avg_cost() * units_to_sell
-                realized_gain = proceeds - cost_removed - ORDERGEBUEHR
+                realized_gain = proceeds - cost_removed - gebuehr
                 pos.units -= units_to_sell
                 pos.cost_total -= cost_removed
                 trades.append(
-                    Trade(trade_date, t, "sell", units_to_sell, price, ORDERGEBUEHR, realized_gain, reason)
+                    Trade(trade_date, t, "sell", units_to_sell, price, gebuehr, realized_gain, reason)
                 )
                 process_realized_gain(realized_gain)
                 executed = True
@@ -215,9 +224,9 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                 buy_value = diff
                 units_to_buy = buy_value / price
                 pos.units += units_to_buy
-                pos.cost_total += buy_value + ORDERGEBUEHR
+                pos.cost_total += buy_value + gebuehr
                 trades.append(
-                    Trade(trade_date, t, "buy", units_to_buy, price, ORDERGEBUEHR, None, reason)
+                    Trade(trade_date, t, "buy", units_to_buy, price, gebuehr, None, reason)
                 )
                 executed = True
         return executed
@@ -250,16 +259,16 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
             gewinn_je_stueck = price - avg_cost
             if gewinn_je_stueck <= 0:
                 continue
-            units_to_sell = min((ziel_gewinn + ORDERGEBUEHR) / gewinn_je_stueck, pos.units)
+            units_to_sell = min((ziel_gewinn + gebuehr) / gewinn_je_stueck, pos.units)
             if units_to_sell <= 0:
                 continue
             proceeds = units_to_sell * price
             cost_removed = avg_cost * units_to_sell
-            realized_gain = proceeds - cost_removed - ORDERGEBUEHR
+            realized_gain = proceeds - cost_removed - gebuehr
             pos.units -= units_to_sell
             pos.cost_total -= cost_removed
             trades.append(
-                Trade(trade_date, t, "sell", units_to_sell, price, ORDERGEBUEHR, realized_gain, "freibetrag_gewinnmitnahme")
+                Trade(trade_date, t, "sell", units_to_sell, price, gebuehr, realized_gain, "freibetrag_gewinnmitnahme")
             )
             process_realized_gain(realized_gain)
             executed = True
@@ -267,9 +276,9 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
             # sofortiger Rückkauf zum selben Kurs, um die Marktexponierung zu
             # erhalten - hebt die Kostenbasis steuerfrei an.
             pos.units += units_to_sell
-            pos.cost_total += proceeds + ORDERGEBUEHR
+            pos.cost_total += proceeds + gebuehr
             trades.append(
-                Trade(trade_date, t, "buy", units_to_sell, price, ORDERGEBUEHR, None, "freibetrag_gewinnmitnahme_rebuy")
+                Trade(trade_date, t, "buy", units_to_sell, price, gebuehr, None, "freibetrag_gewinnmitnahme_rebuy")
             )
         return executed
 
@@ -303,7 +312,7 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
             verlust_je_stueck = avg_cost - price
             if verlust_je_stueck <= 0:
                 continue
-            units_needed = max(restziel - ORDERGEBUEHR, Decimal(0)) / verlust_je_stueck
+            units_needed = max(restziel - gebuehr, Decimal(0)) / verlust_je_stueck
             if units_needed <= 0:
                 # Restziel liegt unter der Gebühr allein - jeder Verkauf
                 # würde das Ziel überschießen, also hier abbrechen statt
@@ -312,11 +321,11 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
             units_to_sell = min(units_needed, pos.units)
             proceeds = units_to_sell * price
             cost_removed = avg_cost * units_to_sell
-            realized_gain = proceeds - cost_removed - ORDERGEBUEHR
+            realized_gain = proceeds - cost_removed - gebuehr
             pos.units -= units_to_sell
             pos.cost_total -= cost_removed
             trades.append(
-                Trade(trade_date, t, "sell", units_to_sell, price, ORDERGEBUEHR, realized_gain, "tax_loss_harvest")
+                Trade(trade_date, t, "sell", units_to_sell, price, gebuehr, realized_gain, "tax_loss_harvest")
             )
             process_realized_gain(realized_gain)
             harvested += -realized_gain
@@ -324,9 +333,9 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
 
             # sofortiger Rückkauf zum selben Kurs, um die Marktexponierung zu erhalten
             pos.units += units_to_sell
-            pos.cost_total += proceeds + ORDERGEBUEHR
+            pos.cost_total += proceeds + gebuehr
             trades.append(
-                Trade(trade_date, t, "buy", units_to_sell, price, ORDERGEBUEHR, None, "tax_loss_harvest_rebuy")
+                Trade(trade_date, t, "buy", units_to_sell, price, gebuehr, None, "tax_loss_harvest_rebuy")
             )
         return executed
 
@@ -357,7 +366,7 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
         if i == 0:
             initial_weights = weights_at(0)
             num_instruments = len(tickers)
-            total_fees = ORDERGEBUEHR * num_instruments
+            total_fees = gebuehr * num_instruments
             investable = strategy.startkapital - total_fees
             for t in tickers:
                 price = prices.get(t)
@@ -370,7 +379,7 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                 units = buy_value / price
                 positions[t].units = units
                 positions[t].cost_total = buy_value
-                trades.append(Trade(row.date, t, "buy", units, price, ORDERGEBUEHR, None, "initial_buy"))
+                trades.append(Trade(row.date, t, "buy", units, price, gebuehr, None, "initial_buy"))
         else:
             for t in tickers:
                 if pending_cash[t] > 0 and t in prices:
@@ -401,11 +410,11 @@ def simulate(price_history: list[PriceRow], strategy: Strategy) -> SimulationRes
                 )
                 ist_gewicht = ziel_topf_value / total_value
                 abweichung_pp = abs(ist_gewicht - ziel_gewicht_effektiv) * 100
-                if abweichung_pp > strategy.rebalancing_schwelle_pp:
+                if opt.rebalancing and abweichung_pp > strategy.rebalancing_schwelle_pp:
                     if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
                         last_rebalance_date = row.date
 
-        if row.date in harvest_dates:
+        if opt.steueroptimierung and row.date in harvest_dates:
             if freibetrag_verbleibend > 0:
                 if december_gewinnmitnahme(prices, row.date):
                     last_harvest_date = row.date

--- a/src/boersenspiel/scenarios.py
+++ b/src/boersenspiel/scenarios.py
@@ -32,7 +32,7 @@ from decimal import Decimal
 from typing import Callable
 
 from .history_store import PriceRow
-from .strategies import BARBELL_20_80, Beitrag, Strategy, Topf
+from .strategies import BARBELL_20_80, Beitrag, Optimierungen, Strategy, Topf
 
 TOPF_SICHERHEIT: Topf = BARBELL_20_80.toepfe[0]
 TOPF_WACHSTUM: Topf = BARBELL_20_80.toepfe[1]
@@ -119,6 +119,10 @@ SELL_IN_MAY = Strategy(
     # Regimewechsel (Mai <-> Oktober) zuverlässig eine Umschichtung auslöst.
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=sell_in_may_gewichte,
+    beschreibung=(
+        "Von Mai bis September (inklusive) 100% defensiv (Topf A), sonst normale "
+        "Barbell-Verteilung. Testet die Börsenweisheit 'Sell in May and go away'."
+    ),
 )
 
 
@@ -146,8 +150,17 @@ BUY_AND_HOLD = Strategy(
     toepfe=BARBELL_20_80.toepfe,
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
-    rebalancing_schwelle_pp=Decimal("1000"),
+    rebalancing_schwelle_pp=Decimal("10"),
     gewichte_fn=None,
+    # Rebalancing bewusst über den Optimierungs-Schalter (#17) statt einer künstlich
+    # unerreichbaren Schwelle abgeschaltet - "gar nicht rebalancieren" ist damit ehrlich
+    # benannt statt implizit über einen Zahlenwert erzwungen.
+    optimierungen=Optimierungen(rebalancing=False),
+    beschreibung=(
+        "Anfangsallokation wird nie aktiv rebalanciert ('Hin und her macht Taschen "
+        "leer'). Der Dezember-Steuermechanismus bleibt wie bei den anderen Strategien "
+        "aktiv."
+    ),
 )
 
 
@@ -180,6 +193,10 @@ SANTA_CLAUS_RALLY = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=santa_claus_rally_gewichte,
+    beschreibung=(
+        "In Dezember und Januar Wachstumsquote auf 95% hochgefahren ('Santa-Claus-"
+        "Rally'), sonst normale Barbell-Verteilung."
+    ),
 )
 
 
@@ -222,6 +239,11 @@ BUY_THE_DIP = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=buy_the_dip_gewichte,
+    beschreibung=(
+        "Liegt der MSCI-World-ETF mehr als 10% unter seinem 20-Wochen-Hoch, "
+        "Wachstumsquote auf 95% hochfahren ('kaufe, wenn die Kanonen donnern'), "
+        "sonst normale Verteilung."
+    ),
 )
 
 
@@ -277,6 +299,11 @@ CUT_LOSSES = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=cut_losses_gewichte,
+    beschreibung=(
+        "Trailing-Stop je Wachstums-Instrument: fällt eines mehr als 15% unter sein "
+        "eigenes 20-Wochen-Hoch, wird nur dieses auf 0% gesetzt ('cut your losses "
+        "short'), andere Wachstums-Instrumente bleiben unangetastet."
+    ),
 )
 
 
@@ -366,6 +393,12 @@ def _weisheiten_strategy(name: str, weisheiten: tuple[Weisheit, ...], **kwargs) 
 BOERSENWEISHEITEN = _weisheiten_strategy(
     "Börsenweisheiten (alle fünf kombiniert)",
     WEISHEITEN,
+    beschreibung=(
+        "Fasst die fünf Börsenweisheiten oben zu einer Strategie zusammen: jede votiert "
+        "für eine Wachstumsquote (oder enthält sich), die Ziel-Quote ist das "
+        "arithmetische Mittel der abgegebenen Voten. 'Verluste begrenzen' wirkt danach "
+        "zusätzlich als Instrument-Overlay."
+    ),
     beitraege=tuple(
         Beitrag(
             name=weisheit.spruch,
@@ -412,6 +445,11 @@ CHART_SMA_CROSSOVER = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=chart_sma_crossover_gewichte,
+    beschreibung=(
+        "Charttechnischer Trendindikator auf dem MSCI-World-ETF: liegt der 10-Wochen- "
+        "unter dem 40-Wochen-Durchschnitt ('Death Cross'), 100% defensiv, sonst "
+        "('Golden Cross'/normal) reguläre Barbell-Gewichte."
+    ),
 )
 
 
@@ -470,6 +508,11 @@ MOMENTUM_ROTATION = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=momentum_rotation_gewichte,
+    beschreibung=(
+        "Innerhalb des Wachstums-Topfs (80%) werden nur die 2 Instrumente mit der "
+        "höchsten 12-Wochen-Trailing-Rendite gleichgewichtet gehalten, die übrigen auf "
+        "0% gesetzt. Der Sicherheits-Topf bleibt unverändert."
+    ),
 )
 
 
@@ -532,6 +575,11 @@ VOLATILITY_TARGET = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
     gewichte_fn=volatility_target_gewichte,
+    beschreibung=(
+        "Die Wachstumsquote wird abhängig von der realisierten 12-Wochen-Volatilität "
+        "des MSCI-World-ETF linear zwischen 50% (hohe Volatilität) und 90% (niedrige "
+        "Volatilität) skaliert - Risk-Parity-/Vol-Targeting-Prinzip."
+    ),
 )
 
 
@@ -565,6 +613,11 @@ COST_AVERAGE_ENTRY = Strategy(
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("3"),
     gewichte_fn=cost_average_gewichte,
+    beschreibung=(
+        "Statt das Startkapital sofort komplett zu investieren, wird die "
+        "Wachstumsquote über die ersten 10 Wochen linear von 0% auf die normale "
+        "Barbell-Verteilung hochgefahren - Annäherung an ratierliches Investieren."
+    ),
 )
 
 

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -51,6 +51,21 @@ class Beitrag:
 
 
 @dataclass(frozen=True)
+class Optimierungen:
+    """Vier strategieübergreifende Simulationsmechanismen, die ``engine.simulate()``
+    unabhängig von der jeweiligen Gewichtungsregel anwendet. Einzeln ein-/ausschaltbar,
+    damit ihr isolierter Renditebeitrag messbar wird (siehe #17), statt nur geglaubt zu
+    werden. Defaults erhalten das bisherige Verhalten exakt - eine Strategie ohne
+    explizit gesetztes ``optimierungen``-Feld verhält sich wie vor Einführung dieser
+    Schalter."""
+
+    steueroptimierung: bool = True  # Dezember-Harvest (Freibetrag-Gewinnmitnahme / Tax-Loss-Harvest)
+    rebalancing: bool = True  # periodische Rückführung auf die Zielgewichte
+    ordergebuehren: bool = True  # False -> gebührenfreie Referenzrechnung
+    besteuerung: bool = True  # False -> realisierte Gewinne fließen nicht in Freibetrag/Steuer-Tracking
+
+
+@dataclass(frozen=True)
 class Strategy:
     name: str
     startkapital: Decimal
@@ -72,6 +87,13 @@ class Strategy:
     # Varianten haben ihrerseits keine ``beitraege`` - sonst würde die Auswertung
     # rekursiv.
     beitraege: tuple[Beitrag, ...] = ()
+    # Optional: Kurzbeschreibung der Strategie/des Szenarios fürs Dashboard (#26).
+    # Leer bedeutet: keine Beschreibung wird angezeigt.
+    beschreibung: str = ""
+    # Welche der vier Mechanismen aus ``Optimierungen`` für diese Strategie standardmäßig
+    # greifen. ``engine.simulate()`` übernimmt diese, sofern ihr nicht explizit eine
+    # andere ``Optimierungen``-Instanz übergeben wird (siehe #17).
+    optimierungen: Optimierungen = field(default_factory=Optimierungen)
 
     def alle_ticker_gewichte(self) -> dict[str, Decimal]:
         """Ziel-Gewicht jedes Instruments am Gesamtdepot."""
@@ -117,6 +139,11 @@ BARBELL_20_80 = Strategy(
     ziel_topf="Topf A - Sicherheit",
     ziel_gewicht=Decimal("0.20"),
     rebalancing_schwelle_pp=Decimal("10"),
+    beschreibung=(
+        "20% Sicherheit (breite Anleihen/Gold-ETFs), 80% Wachstum (breite Aktien-ETFs "
+        "plus Bitcoin). Rebalancing auf die Zielgewichte, sobald der Sicherheits-Topf "
+        "um mehr als 10 Prozentpunkte abweicht."
+    ),
 )
 
 # --- Strategie 2: Barbell 30/70 (Beispiel für eine alternative Gewichtung) -
@@ -148,6 +175,11 @@ BARBELL_30_70 = Strategy(
     ziel_topf="Topf A - Sicherheit",
     ziel_gewicht=Decimal("0.30"),
     rebalancing_schwelle_pp=Decimal("15"),
+    beschreibung=(
+        "Defensivere Variante des Barbell-Ansatzes: 30% Sicherheit statt 20%, dafür "
+        "70% Wachstum. Größere Rebalancing-Schwelle (15 statt 10 Prozentpunkte), weil "
+        "der breitere Sicherheits-Topf natürlicherweise stärker schwankt."
+    ),
 )
 
 # --- Strategie 3: Barbell 20/60/20 + Einzelaktien-Satellit -----------------
@@ -207,6 +239,11 @@ BARBELL_20_60_20_SATELLIT = Strategy(
     ziel_topf="Topf A - Sicherheit",
     ziel_gewicht=Decimal("0.20"),
     rebalancing_schwelle_pp=Decimal("10"),
+    beschreibung=(
+        "Wie Barbell 20/80, aber der Wachstums-Topf sinkt von 80% auf 60% zugunsten "
+        "eines dritten, gleichgewichteten Topfs aus 10 Einzelaktien (20%) - das "
+        "80/20-Risikoprofil bleibt erhalten, nur granularer gestreut."
+    ),
 )
 
 STRATEGIES: list[Strategy] = [BARBELL_20_80, BARBELL_30_70, BARBELL_20_60_20_SATELLIT]

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -179,6 +179,7 @@
 {% for s in strategies %}
   <section class="strategy" id="{{ s.id }}">
     <h2>{{ s.name }}</h2>
+    {% if s.beschreibung %}<p class="hint">{{ s.beschreibung }}</p>{% endif %}
     <div class="stat-row">
       <div class="stat-tile"><div class="label">Gesamtwert</div><div class="value">{{ s.total_value }} &euro;</div></div>
       <div class="stat-tile"><div class="label">Startkapital</div><div class="value">{{ s.startkapital }} &euro;</div></div>
@@ -222,6 +223,30 @@
       </div>
     </div>
     {% endif %}
+    <div class="beitraege">
+      <h3>Effekt der Optimierungs-Schalter</h3>
+      <p class="hint">
+        Leave-one-out je Mechanismus: Rendite dieser Strategie minus Rendite derselben
+        Strategie mit genau diesem einen Mechanismus ausgeschaltet (Dezember-Harvest,
+        Rebalancing, Ordergebühren, Besteuerung). Positiv = der Mechanismus hat Rendite
+        gebracht, negativ = er hat gekostet.
+      </p>
+      <div class="chart-box"><canvas id="opt-chart-{{ loop.index }}"></canvas></div>
+      <div class="overflow-x">
+        <table>
+          <thead><tr><th>Mechanismus</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Mechanismus %</th></tr></thead>
+          <tbody>
+          {% for o in s.optimierungs_effekte %}
+            <tr>
+              <td>{{ o.name }}</td>
+              <td class="{{ 'positive' if o.delta_pp >= 0 else 'negative' }}">{{ o.delta_label }}</td>
+              <td>{{ o.ohne_rendite_label }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
     <div class="overflow-x">
       <table>
         <thead><tr><th>Instrument</th><th>Einheiten</th><th>Kurs</th><th>Wert</th><th>Ist-Gewicht %</th><th>Ziel-Gewicht %</th></tr></thead>
@@ -263,6 +288,13 @@
     y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
   };
   const seriesPalette = [colors.series1, colors.series2, colors.series3, colors.series4];
+  // Gemeinsames Maximum ueber alle Wertverlauf-Charts (#24), damit unterschiedliche
+  // Strategien optisch vergleichbar bleiben statt jeweils unabhaengig zu skalieren.
+  const wertChartMax = {{ wert_chart_max | tojson }};
+  const wertChartScales = {
+    x: commonScales.x,
+    y: { ...commonScales.y, min: 0, suggestedMax: wertChartMax * 1.05 },
+  };
 
   new Chart(document.getElementById('summary-chart'), {
     type: 'bar',
@@ -303,7 +335,7 @@
     options: {
       responsive: true, maintainAspectRatio: false,
       plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Wertverlauf', color: colors.text } },
-      scales: commonScales,
+      scales: wertChartScales,
     },
   });
 
@@ -329,6 +361,27 @@
     },
   });
   {% endif %}
+
+  new Chart(document.getElementById('opt-chart-{{ loop.index }}'), {
+    type: 'bar',
+    data: {
+      labels: {{ s.optimierungs_effekte | map(attribute='name') | list | tojson }},
+      datasets: [{
+        label: 'Effekt (Prozentpunkte)',
+        data: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }},
+        backgroundColor: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+      }],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Optimierungs-Schalter (Prozentpunkte)', color: colors.text } },
+      scales: {
+        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+      },
+    },
+  });
 
   new Chart(document.getElementById('topf-chart-{{ loop.index }}'), {
     type: 'line',

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -60,8 +60,12 @@ def test_build_dashboard_renders_comparison_overview_with_correct_ranking(tmp_pa
     # Beide Strategien kaufen dasselbe Instrument T1 zum selben Startkapital
     # (kein Rebalancing, Schwelle ist unerreichbar hoch) -> identisches Ergebnis:
     # 999 investierbar (1000 - 1 Gebuehr) / 100 = 9.99 Einheiten, Endwert bei
-    # Kurs 150 = 1498.50, Rendite (1498.50-1000)/1000 = +49.85%.
-    assert html.count("+49.85") == 2
+    # Kurs 150 = 1498.50, Rendite (1498.50-1000)/1000 = +49.85%. Beschraenkt auf die
+    # Uebersichtstabelle, weil die Optimierungs-Effekte-Sektion (#17) je Strategie
+    # weitere "ohne <Mechanismus>"-Renditen anzeigt, die bei dieser einfachen
+    # Zwei-Zeilen-Historie zufaellig ebenfalls +49.85% betragen koennen.
+    uebersicht = html.split('id="uebersicht"', 1)[1].split("</section>", 1)[0]
+    assert uebersicht.count("+49.85") == 2
 
 
 def test_build_dashboard_summary_matches_detail_total_value(tmp_path: Path):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 
 from boersenspiel.engine import simulate
 from boersenspiel.history_store import PriceRow
-from boersenspiel.strategies import BARBELL_20_80, Strategy, Topf
+from boersenspiel.strategies import BARBELL_20_80, Optimierungen, Strategy, Topf
 
 SIMPLE_STRATEGY = Strategy(
     name="Test-Zwei-Toepfe",
@@ -179,6 +179,63 @@ MISSING_PRICE_STRATEGY = Strategy(
     ziel_gewicht=Decimal("0.5"),
     rebalancing_schwelle_pp=Decimal("100"),  # kein Rebalancing in diesen Tests
 )
+
+
+# --- Optimierungs-Schalter (Optimierungen, #17) -----------------------------------------
+
+
+def test_optimierungen_defaults_reproduce_baseline_result():
+    # Ein explizit übergebenes Optimierungen() mit Default-Werten muss exakt dasselbe
+    # Ergebnis liefern wie gar keine Übergabe (strategy.optimierungen greift dann).
+    ohne_override = simulate(_rows(), SIMPLE_STRATEGY)
+    mit_default = simulate(_rows(), SIMPLE_STRATEGY, Optimierungen())
+    assert ohne_override.value_history[-1].total_value == mit_default.value_history[-1].total_value
+    assert ohne_override.tax_status == mit_default.tax_status
+
+
+def test_ordergebuehren_false_entfernt_alle_gebuehren():
+    result = simulate(_rows(), SIMPLE_STRATEGY, Optimierungen(ordergebuehren=False))
+    assert all(t.fee == Decimal(0) for t in result.trades)
+    # Ohne Gebuehren wird das volle Startkapital investiert statt 1002 - 2*1 = 1000.
+    assert result.value_history[0].total_value == Decimal("1002")
+
+
+def test_rebalancing_false_unterlaesst_periodisches_rebalancing():
+    result = simulate(_rows(), SIMPLE_STRATEGY, Optimierungen(rebalancing=False))
+    assert all(t.reason != "rebalance" for t in result.trades)
+
+
+def test_steueroptimierung_false_unterlaesst_dezember_harvest():
+    result = simulate(_rows(), SIMPLE_STRATEGY, Optimierungen(steueroptimierung=False))
+    harvest_reasons = {
+        "freibetrag_gewinnmitnahme",
+        "freibetrag_gewinnmitnahme_rebuy",
+        "tax_loss_harvest",
+        "tax_loss_harvest_rebuy",
+    }
+    assert not any(t.reason in harvest_reasons for t in result.trades)
+    assert result.last_harvest_date is None
+
+
+def test_besteuerung_false_laesst_steuerstatus_unveraendert():
+    result = simulate(_rows(), SIMPLE_STRATEGY, Optimierungen(besteuerung=False))
+    assert result.tax_status.kumulierte_steuer == Decimal(0)
+    assert result.tax_status.verlustvortrag == Decimal(0)
+    assert result.tax_status.freibetrag_verbraucht == Decimal(0)
+
+
+def test_strategy_eigene_optimierungen_werden_ohne_override_verwendet():
+    strategy_ohne_rebalancing = Strategy(
+        name="Test-ohne-Rebalancing",
+        startkapital=Decimal("1002"),
+        toepfe=SIMPLE_STRATEGY.toepfe,
+        ziel_topf=SIMPLE_STRATEGY.ziel_topf,
+        ziel_gewicht=SIMPLE_STRATEGY.ziel_gewicht,
+        rebalancing_schwelle_pp=Decimal("10"),
+        optimierungen=Optimierungen(rebalancing=False),
+    )
+    result = simulate(_rows(), strategy_ohne_rebalancing)
+    assert all(t.reason != "rebalance" for t in result.trades)
 
 
 def test_missing_price_in_first_row_parks_capital_as_cash_and_invests_later():


### PR DESCRIPTION
## Summary

Setzt drei Issues in einem Paket um (erstes von zwei vorgeschlagenen Paketen):

- **#24 – Skaliere alle Grafiken im Dashboard gleich**: Alle "Wertverlauf"-Charts teilen sich jetzt eine gemeinsame Y-Achse (globales Maximum über alle Strategien/Szenarien), statt unabhängig zu skalieren. Macht unterschiedliche Strategien optisch vergleichbar.
- **#17 – Szenario-übergreifende Optimierungen als ein-/ausschaltbare Schalter**: Neue `Optimierungen`-Dataclass (`steueroptimierung`/`rebalancing`/`ordergebuehren`/`besteuerung`) macht die vier strategieübergreifenden Simulationsmechanismen einzeln ein-/ausschaltbar. `engine.simulate()` nimmt optional eine `Optimierungen`-Instanz entgegen (Default: `strategy.optimierungen`; Default-Werte erhalten das bisherige Verhalten exakt). Das Dashboard zeigt je Strategie den isolierten Renditebeitrag jedes Mechanismus per Leave-one-out. `BUY_AND_HOLD` nutzt jetzt `optimierungen=Optimierungen(rebalancing=False)` statt einer künstlich unerreichbaren Rebalancing-Schwelle.
- **#26 – Erklärung der Szenarien im Dashboard**: Jede Strategie/jedes Szenario bekommt eine kurze Beschreibung im Dashboard (neues `Strategy.beschreibung`-Feld).

Zweites Paket (#31 + einige der übrigen offenen Issues auf einer Unterseite je Szenario) folgt separat.

## Test plan

- [x] `pytest -q` – 116/116 Tests grün (inkl. neuer Tests für die Optimierungs-Schalter in `tests/test_engine.py` und angepasstem Test in `tests/test_dashboard.py`)
- [x] `python scripts/build_dashboard.py` lokal gegen die echte Kurshistorie ausgeführt und die neuen Dashboard-Abschnitte (Beschreibung, Optimierungs-Effekte-Sektion, einheitliche Y-Achse) stichprobenartig geprüft

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR8qRNd3XpxhCQi4BL3iqe)_