### PR TITLE
Unterseiten je Strategie/Szenario mit 50-/200-Tage-Näherung

### DIFF
--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -33,6 +33,27 @@ _OPTIMIERUNGS_LABELS: dict[str, str] = {
     "besteuerung": "Besteuerung",
 }
 
+# Wochen-Naeherung der klassischen 50-/200-Tage-Durchschnitte (5 Handelstage/Woche),
+# fuer die wochenweise gefuehrte Kurshistorie - derselbe Ansatz wie beim Szenario
+# "Charttechnik: SMA-Crossover" (scenarios.SMA_KURZ_WOCHEN/SMA_LANG_WOCHEN), hier aber
+# rein fuer die Anzeige auf dem Wertverlauf der jeweiligen Strategie statt als
+# Handelsregel (#31).
+_SMA_KURZ_WOCHEN = 10
+_SMA_LANG_WOCHEN = 40
+
+
+def _moving_average(values: list[float], fenster: int) -> list[float | None]:
+    """Gleitender Durchschnitt der letzten ``fenster`` Werte (inkl. aktuellem);
+    ``None`` solange noch nicht genug Werte vorliegen."""
+    ergebnis: list[float | None] = []
+    summe = 0.0
+    for i, wert in enumerate(values):
+        summe += wert
+        if i >= fenster:
+            summe -= values[i - fenster]
+        ergebnis.append(summe / fenster if i >= fenster - 1 else None)
+    return ergebnis
+
 
 def _f(value: Decimal) -> float:
     return float(value)
@@ -136,6 +157,8 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         "labels_json": json.dumps(labels),
         "total_values": total_values,
         "total_values_json": json.dumps(total_values),
+        "sma_kurz_json": json.dumps(_moving_average(total_values, _SMA_KURZ_WOCHEN)),
+        "sma_lang_json": json.dumps(_moving_average(total_values, _SMA_LANG_WOCHEN)),
         "topf_series_json": json.dumps(topf_series),
         "topf_targets": topf_targets,
         "topf_series_last": {name: series[-1] if series else 0.0 for name, series in topf_series.items()},
@@ -167,6 +190,9 @@ def build_dashboard(
     strategies: list[Strategy] | None = None,
     output_path: Path = DEFAULT_OUTPUT,
 ) -> Path:
+    """Baut die Startseite (nur Wertverlauf je Strategie/Szenario) sowie je eine
+    Detailseite pro Strategie/Szenario (alles andere, inkl. 50-/200-Tage-Näherung) -
+    siehe #31. Die Detailseiten landen als ``<slug>.html`` neben ``output_path``."""
     if not price_history:
         raise ValueError("Kurshistorie ist leer - kein Dashboard erzeugbar")
     strategies = strategies if strategies is not None else STRATEGIES
@@ -182,21 +208,32 @@ def build_dashboard(
     alle_werte = [wert for view in views for wert in view["total_values"]]
     wert_chart_max = max(alle_werte) if alle_werte else 0.0
 
+    common_context = dict(
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        row_count=len(price_history),
+        last_date=price_history[-1].date.isoformat(),
+    )
+
     env = Environment(
         loader=FileSystemLoader(str(TEMPLATE_DIR)),
         autoescape=select_autoescape(["html"]),
     )
-    template = env.get_template("dashboard.html.j2")
-    html = template.render(
+
+    index_template = env.get_template("dashboard.html.j2")
+    index_html = index_template.render(
         strategies=views,
         summary=summary,
         learnings=learnings,
-        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
-        row_count=len(price_history),
-        last_date=price_history[-1].date.isoformat(),
         wert_chart_max=wert_chart_max,
+        **common_context,
     )
-
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(html, encoding="utf-8")
+    output_path.write_text(index_html, encoding="utf-8")
+
+    detail_template = env.get_template("strategy_detail.html.j2")
+    for view in views:
+        detail_html = detail_template.render(s=view, **common_context)
+        detail_path = output_path.parent / f"{view['id']}.html"
+        detail_path.write_text(detail_html, encoding="utf-8")
+
     return output_path

--- a/src/boersenspiel/templates/base.html.j2
+++ b/src/boersenspiel/templates/base.html.j2
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% block title %}Barbell-Portfolio Dashboard{% endblock %}</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<style>
+  :root {
+    color-scheme: light;
+    --surface-1: #fcfcfb;
+    --page: #f9f9f7;
+    --text-primary: #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted: #898781;
+    --grid: #e1e0d9;
+    --axis: #c3c2b7;
+    --border: rgba(11,11,11,0.10);
+    --series-1: #2a78d6;
+    --series-2: #eb6834;
+    --series-3: #1baf7a;
+    --series-4: #eda100;
+    --good: #006300;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      color-scheme: dark;
+      --surface-1: #1a1a19;
+      --page: #0d0d0d;
+      --text-primary: #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted: #898781;
+      --grid: #2c2c2a;
+      --axis: #383835;
+      --border: rgba(255,255,255,0.10);
+      --series-1: #3987e5;
+      --series-2: #d95926;
+      --series-3: #199e70;
+      --series-4: #c98500;
+      --good: #0ca30c;
+    }
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --surface-1: #1a1a19;
+    --page: #0d0d0d;
+    --text-primary: #ffffff;
+    --text-secondary: #c3c2b7;
+    --text-muted: #898781;
+    --grid: #2c2c2a;
+    --axis: #383835;
+    --border: rgba(255,255,255,0.10);
+    --series-1: #3987e5;
+    --series-2: #d95926;
+    --series-3: #199e70;
+    --series-4: #c98500;
+    --good: #0ca30c;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--page);
+    color: var(--text-primary);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    padding: 24px;
+  }
+  header { max-width: 1100px; margin: 0 auto 24px; }
+  h1 { font-size: 1.5rem; margin: 0 0 4px; }
+  .meta { color: var(--text-secondary); font-size: 0.9rem; }
+  main { max-width: 1100px; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; }
+  section.strategy {
+    background: var(--surface-1);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px 24px;
+  }
+  h2 { margin: 0 0 12px; font-size: 1.2rem; }
+  .stat-row { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 20px; }
+  .stat-tile {
+    flex: 1 1 140px;
+    background: var(--page);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 14px;
+  }
+  .stat-tile .label { color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  .stat-tile .value { font-size: 1.1rem; font-variant-numeric: tabular-nums; margin-top: 2px; }
+  .charts { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 20px; }
+  @media (max-width: 760px) { .charts { grid-template-columns: 1fr; } }
+  .chart-box { position: relative; height: 260px; }
+  .chart-box-large { position: relative; height: 320px; margin-bottom: 16px; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  th, td { text-align: right; padding: 6px 8px; border-bottom: 1px solid var(--grid); font-variant-numeric: tabular-nums; }
+  th:first-child, td:first-child { text-align: left; }
+  th { color: var(--text-muted); font-weight: 500; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.02em; }
+  .overflow-x { overflow-x: auto; }
+  footer { max-width: 1100px; margin: 24px auto 0; color: var(--text-muted); font-size: 0.8rem; }
+  .summary-chart-box { position: relative; height: 340px; margin-bottom: 20px; }
+  .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 16px; max-width: 68ch; }
+  ol.learnings { list-style: none; counter-reset: learning; margin: 0; padding: 0; display: grid; gap: 14px; }
+  ol.learnings li {
+    counter-increment: learning;
+    position: relative;
+    background: var(--page);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px 18px 14px 52px;
+  }
+  ol.learnings li::before {
+    content: counter(learning);
+    position: absolute;
+    left: 16px;
+    top: 14px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--series-1);
+    color: #fff;
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  ol.learnings h3 { font-size: 0.98rem; margin: 0 0 4px; }
+  ol.learnings .kernaussage { margin: 0 0 6px; font-size: 0.95rem; }
+  ol.learnings .detail { margin: 0; color: var(--text-secondary); font-size: 0.85rem; max-width: 78ch; }
+  .beitraege { margin-bottom: 20px; }
+  .beitraege h3 { font-size: 1rem; margin: 0 0 4px; }
+  .beitraege .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 12px; max-width: 68ch; }
+  .beitraege .chart-box { height: 220px; margin-bottom: 12px; }
+  table.summary-table a { color: inherit; text-decoration: underline; text-decoration-color: var(--border); }
+  .positive { color: var(--good); }
+  .negative { color: var(--series-2); }
+  .detail-link { margin: 0; font-size: 0.9rem; }
+  .back-link { margin: 0; font-size: 0.9rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>{% block header_title %}Barbell-Portfolio Dashboard{% endblock %}</h1>
+  <div class="meta">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
+  {% block header_extra %}{% endblock %}
+</header>
+<main>
+{% block content %}{% endblock %}
+</main>
+<footer>
+  Barbell-Portfolio-Dashboard &middot; statisch erzeugt, keine Live-Daten &middot;
+  Kurshistorie und Simulation deterministisch aus <code>data/price_history.csv</code>.
+</footer>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -1,144 +1,5 @@
-<!doctype html>
-<html lang="de">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Barbell-Portfolio Dashboard</title>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-<style>
-  :root {
-    color-scheme: light;
-    --surface-1: #fcfcfb;
-    --page: #f9f9f7;
-    --text-primary: #0b0b0b;
-    --text-secondary: #52514e;
-    --text-muted: #898781;
-    --grid: #e1e0d9;
-    --axis: #c3c2b7;
-    --border: rgba(11,11,11,0.10);
-    --series-1: #2a78d6;
-    --series-2: #eb6834;
-    --series-3: #1baf7a;
-    --series-4: #eda100;
-    --good: #006300;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) {
-      color-scheme: dark;
-      --surface-1: #1a1a19;
-      --page: #0d0d0d;
-      --text-primary: #ffffff;
-      --text-secondary: #c3c2b7;
-      --text-muted: #898781;
-      --grid: #2c2c2a;
-      --axis: #383835;
-      --border: rgba(255,255,255,0.10);
-      --series-1: #3987e5;
-      --series-2: #d95926;
-      --series-3: #199e70;
-      --series-4: #c98500;
-      --good: #0ca30c;
-    }
-  }
-  :root[data-theme="dark"] {
-    color-scheme: dark;
-    --surface-1: #1a1a19;
-    --page: #0d0d0d;
-    --text-primary: #ffffff;
-    --text-secondary: #c3c2b7;
-    --text-muted: #898781;
-    --grid: #2c2c2a;
-    --axis: #383835;
-    --border: rgba(255,255,255,0.10);
-    --series-1: #3987e5;
-    --series-2: #d95926;
-    --series-3: #199e70;
-    --series-4: #c98500;
-    --good: #0ca30c;
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0;
-    background: var(--page);
-    color: var(--text-primary);
-    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
-    padding: 24px;
-  }
-  header { max-width: 1100px; margin: 0 auto 24px; }
-  h1 { font-size: 1.5rem; margin: 0 0 4px; }
-  .meta { color: var(--text-secondary); font-size: 0.9rem; }
-  main { max-width: 1100px; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; }
-  section.strategy {
-    background: var(--surface-1);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 20px 24px;
-  }
-  h2 { margin: 0 0 12px; font-size: 1.2rem; }
-  .stat-row { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 20px; }
-  .stat-tile {
-    flex: 1 1 140px;
-    background: var(--page);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 10px 14px;
-  }
-  .stat-tile .label { color: var(--text-muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.03em; }
-  .stat-tile .value { font-size: 1.1rem; font-variant-numeric: tabular-nums; margin-top: 2px; }
-  .charts { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 20px; }
-  @media (max-width: 760px) { .charts { grid-template-columns: 1fr; } }
-  .chart-box { position: relative; height: 260px; }
-  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
-  th, td { text-align: right; padding: 6px 8px; border-bottom: 1px solid var(--grid); font-variant-numeric: tabular-nums; }
-  th:first-child, td:first-child { text-align: left; }
-  th { color: var(--text-muted); font-weight: 500; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.02em; }
-  .overflow-x { overflow-x: auto; }
-  footer { max-width: 1100px; margin: 24px auto 0; color: var(--text-muted); font-size: 0.8rem; }
-  .summary-chart-box { position: relative; height: 340px; margin-bottom: 20px; }
-  .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 16px; max-width: 68ch; }
-  ol.learnings { list-style: none; counter-reset: learning; margin: 0; padding: 0; display: grid; gap: 14px; }
-  ol.learnings li {
-    counter-increment: learning;
-    position: relative;
-    background: var(--page);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 14px 18px 14px 52px;
-  }
-  ol.learnings li::before {
-    content: counter(learning);
-    position: absolute;
-    left: 16px;
-    top: 14px;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    background: var(--series-1);
-    color: #fff;
-    font-size: 0.8rem;
-    font-variant-numeric: tabular-nums;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-  ol.learnings h3 { font-size: 0.98rem; margin: 0 0 4px; }
-  ol.learnings .kernaussage { margin: 0 0 6px; font-size: 0.95rem; }
-  ol.learnings .detail { margin: 0; color: var(--text-secondary); font-size: 0.85rem; max-width: 78ch; }
-  .beitraege { margin-bottom: 20px; }
-  .beitraege h3 { font-size: 1rem; margin: 0 0 4px; }
-  .beitraege .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 12px; max-width: 68ch; }
-  .beitraege .chart-box { height: 220px; margin-bottom: 12px; }
-  table.summary-table a { color: inherit; text-decoration: underline; text-decoration-color: var(--border); }
-  .positive { color: var(--good); }
-  .negative { color: var(--series-2); }
-</style>
-</head>
-<body>
-<header>
-  <h1>Barbell-Portfolio Dashboard</h1>
-  <div class="meta">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
-</header>
-<main>
+{% extends "base.html.j2" %}
+{% block content %}
 {% if learnings %}
   <section class="strategy" id="key-learnings">
     <h2>Key Learnings</h2>
@@ -166,7 +27,7 @@
         <tbody>
         {% for s in summary %}
           <tr>
-            <td><a href="#{{ s.id }}">{{ s.name }}</a></td>
+            <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.gewinn_label }}</td>
             <td>{{ s.total_value }}</td>
@@ -180,97 +41,12 @@
   <section class="strategy" id="{{ s.id }}">
     <h2>{{ s.name }}</h2>
     {% if s.beschreibung %}<p class="hint">{{ s.beschreibung }}</p>{% endif %}
-    <div class="stat-row">
-      <div class="stat-tile"><div class="label">Gesamtwert</div><div class="value">{{ s.total_value }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Startkapital</div><div class="value">{{ s.startkapital }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Trades gesamt</div><div class="value">{{ s.trade_count }}</div></div>
-      <div class="stat-tile"><div class="label">Letztes Rebalancing</div><div class="value">{{ s.last_rebalance_date }}</div></div>
-      <div class="stat-tile"><div class="label">Letzter Dez.-Harvest</div><div class="value">{{ s.last_harvest_date }}</div></div>
-    </div>
-    <div class="stat-row">
-      <div class="stat-tile"><div class="label">Freibetrag verbraucht ({{ s.tax.year }})</div><div class="value">{{ s.tax.freibetrag_verbraucht }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Freibetrag verbleibend</div><div class="value">{{ s.tax.freibetrag_verbleibend }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Verlustvortrag</div><div class="value">{{ s.tax.verlustvortrag }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Kumulierte Steuer</div><div class="value">{{ s.tax.kumulierte_steuer }} &euro;</div></div>
-    </div>
-    <div class="charts">
-      <div class="chart-box"><canvas id="value-chart-{{ loop.index }}"></canvas></div>
-      <div class="chart-box"><canvas id="topf-chart-{{ loop.index }}"></canvas></div>
-    </div>
-    {% if s.beitraege %}
-    <div class="beitraege">
-      <h3>Effekt der einzelnen Börsenweisheiten</h3>
-      <p class="hint">
-        Leave-one-out: Rendite dieser Strategie minus Rendite derselben Strategie
-        <em>ohne</em> den jeweiligen Spruch. Positiv = der Spruch hat Rendite gebracht,
-        negativ = er hat gekostet. Die Regeln beeinflussen sich gegenseitig, die
-        Einzelbeiträge summieren sich deshalb nicht exakt zur Gesamtrendite.
-      </p>
-      <div class="chart-box"><canvas id="beitrag-chart-{{ loop.index }}"></canvas></div>
-      <div class="overflow-x">
-        <table>
-          <thead><tr><th>Börsenweisheit</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Spruch %</th></tr></thead>
-          <tbody>
-          {% for b in s.beitraege %}
-            <tr>
-              <td>{{ b.name }}</td>
-              <td class="{{ 'positive' if b.delta_pp >= 0 else 'negative' }}">{{ b.delta_label }}</td>
-              <td>{{ b.ohne_rendite_label }}</td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-    {% endif %}
-    <div class="beitraege">
-      <h3>Effekt der Optimierungs-Schalter</h3>
-      <p class="hint">
-        Leave-one-out je Mechanismus: Rendite dieser Strategie minus Rendite derselben
-        Strategie mit genau diesem einen Mechanismus ausgeschaltet (Dezember-Harvest,
-        Rebalancing, Ordergebühren, Besteuerung). Positiv = der Mechanismus hat Rendite
-        gebracht, negativ = er hat gekostet.
-      </p>
-      <div class="chart-box"><canvas id="opt-chart-{{ loop.index }}"></canvas></div>
-      <div class="overflow-x">
-        <table>
-          <thead><tr><th>Mechanismus</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Mechanismus %</th></tr></thead>
-          <tbody>
-          {% for o in s.optimierungs_effekte %}
-            <tr>
-              <td>{{ o.name }}</td>
-              <td class="{{ 'positive' if o.delta_pp >= 0 else 'negative' }}">{{ o.delta_label }}</td>
-              <td>{{ o.ohne_rendite_label }}</td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div class="overflow-x">
-      <table>
-        <thead><tr><th>Instrument</th><th>Einheiten</th><th>Kurs</th><th>Wert</th><th>Ist-Gewicht %</th><th>Ziel-Gewicht %</th></tr></thead>
-        <tbody>
-        {% for row in s.holdings_table %}
-          <tr>
-            <td>{{ row.ticker }}</td>
-            <td>{{ row.units }}</td>
-            <td>{{ row.price }}</td>
-            <td>{{ row.value }}</td>
-            <td>{{ row.ist_gewicht }}</td>
-            <td>{{ row.ziel_gewicht }}</td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-    </div>
+    <div class="chart-box-large"><canvas id="value-chart-{{ loop.index }}"></canvas></div>
+    <p class="detail-link"><a href="{{ s.id }}.html">Details ansehen (Kennzahlen, Topf-Gewichtung, Instrumente) &rarr;</a></p>
   </section>
 {% endfor %}
-</main>
-<footer>
-  Barbell-Portfolio-Dashboard &middot; statisch erzeugt, keine Live-Daten &middot;
-  Kurshistorie und Simulation deterministisch aus <code>data/price_history.csv</code>.
-</footer>
+{% endblock %}
+{% block scripts %}
 <script>
   const style = getComputedStyle(document.documentElement);
   const cssVar = (name) => style.getPropertyValue(name).trim();
@@ -287,7 +63,6 @@
     x: { grid: { color: colors.grid }, ticks: { color: colors.text, maxTicksLimit: 8 } },
     y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
   };
-  const seriesPalette = [colors.series1, colors.series2, colors.series3, colors.series4];
   // Gemeinsames Maximum ueber alle Wertverlauf-Charts (#24), damit unterschiedliche
   // Strategien optisch vergleichbar bleiben statt jeweils unabhaengig zu skalieren.
   const wertChartMax = {{ wert_chart_max | tojson }};
@@ -338,84 +113,6 @@
       scales: wertChartScales,
     },
   });
-
-  {% if s.beitraege %}
-  new Chart(document.getElementById('beitrag-chart-{{ loop.index }}'), {
-    type: 'bar',
-    data: {
-      labels: {{ s.beitraege | map(attribute='name') | list | tojson }},
-      datasets: [{
-        label: 'Effekt (Prozentpunkte)',
-        data: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }},
-        backgroundColor: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
-      }],
-    },
-    options: {
-      indexAxis: 'y',
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Börsenweisheit (Prozentpunkte)', color: colors.text } },
-      scales: {
-        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
-        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
-      },
-    },
-  });
-  {% endif %}
-
-  new Chart(document.getElementById('opt-chart-{{ loop.index }}'), {
-    type: 'bar',
-    data: {
-      labels: {{ s.optimierungs_effekte | map(attribute='name') | list | tojson }},
-      datasets: [{
-        label: 'Effekt (Prozentpunkte)',
-        data: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }},
-        backgroundColor: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
-      }],
-    },
-    options: {
-      indexAxis: 'y',
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Optimierungs-Schalter (Prozentpunkte)', color: colors.text } },
-      scales: {
-        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
-        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
-      },
-    },
-  });
-
-  new Chart(document.getElementById('topf-chart-{{ loop.index }}'), {
-    type: 'line',
-    data: {
-      labels: {{ s.labels_json | safe }},
-      datasets: [
-        {% for topf_name, target in s.topf_targets.items() %}
-        {
-          label: {{ topf_name | tojson }} + ' Ist %',
-          data: {{ s.topf_series_json | safe }}[{{ topf_name | tojson }}],
-          borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
-          backgroundColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
-          borderWidth: 2,
-          pointRadius: 0,
-          tension: 0.15,
-        },
-        {
-          label: {{ topf_name | tojson }} + ' Ziel %',
-          data: {{ s.labels_json | safe }}.map(() => {{ target }}),
-          borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
-          borderDash: [6, 4],
-          borderWidth: 1.5,
-          pointRadius: 0,
-        },
-        {% endfor %}
-      ],
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Topf-Gewichtung Ist vs. Ziel (%)', color: colors.text } },
-      scales: commonScales,
-    },
-  });
   {% endfor %}
 </script>
-</body>
-</html>
+{% endblock %}

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -1,0 +1,236 @@
+{% extends "base.html.j2" %}
+{% block title %}{{ s.name }} – Barbell-Portfolio Dashboard{% endblock %}
+{% block header_extra %}<p class="back-link"><a href="index.html">&larr; Zur Übersicht</a></p>{% endblock %}
+{% block content %}
+  <section class="strategy" id="{{ s.id }}">
+    <h2>{{ s.name }}</h2>
+    {% if s.beschreibung %}<p class="hint">{{ s.beschreibung }}</p>{% endif %}
+    <div class="stat-row">
+      <div class="stat-tile"><div class="label">Gesamtwert</div><div class="value">{{ s.total_value }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Startkapital</div><div class="value">{{ s.startkapital }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Trades gesamt</div><div class="value">{{ s.trade_count }}</div></div>
+      <div class="stat-tile"><div class="label">Letztes Rebalancing</div><div class="value">{{ s.last_rebalance_date }}</div></div>
+      <div class="stat-tile"><div class="label">Letzter Dez.-Harvest</div><div class="value">{{ s.last_harvest_date }}</div></div>
+    </div>
+    <div class="stat-row">
+      <div class="stat-tile"><div class="label">Freibetrag verbraucht ({{ s.tax.year }})</div><div class="value">{{ s.tax.freibetrag_verbraucht }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Freibetrag verbleibend</div><div class="value">{{ s.tax.freibetrag_verbleibend }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Verlustvortrag</div><div class="value">{{ s.tax.verlustvortrag }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Kumulierte Steuer</div><div class="value">{{ s.tax.kumulierte_steuer }} &euro;</div></div>
+    </div>
+    <p class="hint">
+      Gleitende Durchschnitte des Wertverlaufs als Wochen-Näherung der klassischen
+      50-/200-Tage-Linien (10 bzw. 40 Wochen à 5 Handelstage) - derselbe Ansatz wie
+      beim Szenario "Charttechnik: SMA-Crossover".
+    </p>
+    <div class="chart-box-large"><canvas id="sma-chart"></canvas></div>
+    <div class="charts">
+      <div class="chart-box"><canvas id="topf-chart"></canvas></div>
+    </div>
+    {% if s.beitraege %}
+    <div class="beitraege">
+      <h3>Effekt der einzelnen Börsenweisheiten</h3>
+      <p class="hint">
+        Leave-one-out: Rendite dieser Strategie minus Rendite derselben Strategie
+        <em>ohne</em> den jeweiligen Spruch. Positiv = der Spruch hat Rendite gebracht,
+        negativ = er hat gekostet. Die Regeln beeinflussen sich gegenseitig, die
+        Einzelbeiträge summieren sich deshalb nicht exakt zur Gesamtrendite.
+      </p>
+      <div class="chart-box"><canvas id="beitrag-chart"></canvas></div>
+      <div class="overflow-x">
+        <table>
+          <thead><tr><th>Börsenweisheit</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Spruch %</th></tr></thead>
+          <tbody>
+          {% for b in s.beitraege %}
+            <tr>
+              <td>{{ b.name }}</td>
+              <td class="{{ 'positive' if b.delta_pp >= 0 else 'negative' }}">{{ b.delta_label }}</td>
+              <td>{{ b.ohne_rendite_label }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    {% endif %}
+    <div class="beitraege">
+      <h3>Effekt der Optimierungs-Schalter</h3>
+      <p class="hint">
+        Leave-one-out je Mechanismus: Rendite dieser Strategie minus Rendite derselben
+        Strategie mit genau diesem einen Mechanismus ausgeschaltet (Dezember-Harvest,
+        Rebalancing, Ordergebühren, Besteuerung). Positiv = der Mechanismus hat Rendite
+        gebracht, negativ = er hat gekostet.
+      </p>
+      <div class="chart-box"><canvas id="opt-chart"></canvas></div>
+      <div class="overflow-x">
+        <table>
+          <thead><tr><th>Mechanismus</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Mechanismus %</th></tr></thead>
+          <tbody>
+          {% for o in s.optimierungs_effekte %}
+            <tr>
+              <td>{{ o.name }}</td>
+              <td class="{{ 'positive' if o.delta_pp >= 0 else 'negative' }}">{{ o.delta_label }}</td>
+              <td>{{ o.ohne_rendite_label }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="overflow-x">
+      <table>
+        <thead><tr><th>Instrument</th><th>Einheiten</th><th>Kurs</th><th>Wert</th><th>Ist-Gewicht %</th><th>Ziel-Gewicht %</th></tr></thead>
+        <tbody>
+        {% for row in s.holdings_table %}
+          <tr>
+            <td>{{ row.ticker }}</td>
+            <td>{{ row.units }}</td>
+            <td>{{ row.price }}</td>
+            <td>{{ row.value }}</td>
+            <td>{{ row.ist_gewicht }}</td>
+            <td>{{ row.ziel_gewicht }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+{% endblock %}
+{% block scripts %}
+<script>
+  const style = getComputedStyle(document.documentElement);
+  const cssVar = (name) => style.getPropertyValue(name).trim();
+  const colors = {
+    series1: cssVar('--series-1'),
+    series2: cssVar('--series-2'),
+    series3: cssVar('--series-3'),
+    series4: cssVar('--series-4'),
+    grid: cssVar('--grid'),
+    axis: cssVar('--axis'),
+    text: cssVar('--text-secondary'),
+  };
+  const commonScales = {
+    x: { grid: { color: colors.grid }, ticks: { color: colors.text, maxTicksLimit: 8 } },
+    y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+  };
+  const seriesPalette = [colors.series1, colors.series2, colors.series3, colors.series4];
+
+  new Chart(document.getElementById('sma-chart'), {
+    type: 'line',
+    data: {
+      labels: {{ s.labels_json | safe }},
+      datasets: [
+        {
+          label: 'Gesamtwert (€)',
+          data: {{ s.total_values_json | safe }},
+          borderColor: colors.series1,
+          backgroundColor: colors.series1,
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.15,
+        },
+        {
+          label: '50-Tage-Näherung (10 Wochen)',
+          data: {{ s.sma_kurz_json | safe }},
+          borderColor: colors.series4,
+          backgroundColor: colors.series4,
+          borderWidth: 1.5,
+          pointRadius: 0,
+          tension: 0.15,
+        },
+        {
+          label: '200-Tage-Näherung (40 Wochen)',
+          data: {{ s.sma_lang_json | safe }},
+          borderColor: colors.series2,
+          backgroundColor: colors.series2,
+          borderWidth: 1.5,
+          pointRadius: 0,
+          tension: 0.15,
+        },
+      ],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Wertverlauf mit 50-/200-Tage-Näherung', color: colors.text } },
+      scales: commonScales,
+    },
+  });
+
+  {% if s.beitraege %}
+  new Chart(document.getElementById('beitrag-chart'), {
+    type: 'bar',
+    data: {
+      labels: {{ s.beitraege | map(attribute='name') | list | tojson }},
+      datasets: [{
+        label: 'Effekt (Prozentpunkte)',
+        data: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }},
+        backgroundColor: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+      }],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Börsenweisheit (Prozentpunkte)', color: colors.text } },
+      scales: {
+        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+      },
+    },
+  });
+  {% endif %}
+
+  new Chart(document.getElementById('opt-chart'), {
+    type: 'bar',
+    data: {
+      labels: {{ s.optimierungs_effekte | map(attribute='name') | list | tojson }},
+      datasets: [{
+        label: 'Effekt (Prozentpunkte)',
+        data: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }},
+        backgroundColor: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+      }],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Optimierungs-Schalter (Prozentpunkte)', color: colors.text } },
+      scales: {
+        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+      },
+    },
+  });
+
+  new Chart(document.getElementById('topf-chart'), {
+    type: 'line',
+    data: {
+      labels: {{ s.labels_json | safe }},
+      datasets: [
+        {% for topf_name, target in s.topf_targets.items() %}
+        {
+          label: {{ topf_name | tojson }} + ' Ist %',
+          data: {{ s.topf_series_json | safe }}[{{ topf_name | tojson }}],
+          borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
+          backgroundColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.15,
+        },
+        {
+          label: {{ topf_name | tojson }} + ' Ziel %',
+          data: {{ s.labels_json | safe }}.map(() => {{ target }}),
+          borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
+          borderDash: [6, 4],
+          borderWidth: 1.5,
+          pointRadius: 0,
+        },
+        {% endfor %}
+      ],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Topf-Gewichtung Ist vs. Ziel (%)', color: colors.text } },
+      scales: commonScales,
+    },
+  });
+</script>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,13 +1,14 @@
 """Tests für die Dashboard-Rendering-Schicht (``dashboard.py``).
 
-Prüft insbesondere die Vergleichsübersicht (Rendite je Strategie/Szenario)
-und die Verlinkung zu den Detailabschnitten - reine Darstellungslogik, keine
-eigene Berechnung (die kommt aus ``engine.simulate()``).
+Prüft insbesondere die Vergleichsübersicht (Rendite je Strategie/Szenario) auf
+der Startseite und die Verlinkung zu den je Strategie/Szenario erzeugten
+Detailseiten (#31) - reine Darstellungslogik, keine eigene Berechnung (die
+kommt aus ``engine.simulate()``).
 """
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date
 from decimal import Decimal
 from pathlib import Path
 
@@ -42,6 +43,10 @@ def _rows() -> list[PriceRow]:
     ]
 
 
+def _detail_html(tmp_path: Path, slug: str) -> str:
+    return (tmp_path / f"{slug}.html").read_text(encoding="utf-8")
+
+
 def test_slug_transliterates_umlaute_and_strips_special_chars():
     assert _slug("Börsenweisheit: Sell in May") == "boersenweisheit-sell-in-may"
     assert _slug("Charttechnik: SMA-Crossover (10/40 Wochen)") == "charttechnik-sma-crossover-10-40-wochen"
@@ -52,27 +57,59 @@ def test_build_dashboard_renders_comparison_overview_with_correct_ranking(tmp_pa
     html = output.read_text(encoding="utf-8")
 
     assert "Übersicht: Rendite im Vergleich" in html
-    assert 'id="a-verdoppler"' in html
-    assert 'id="b-verlierer"' in html
-    assert 'href="#a-verdoppler"' in html
-    assert 'href="#b-verlierer"' in html
+    # Startseite verlinkt auf die je Strategie erzeugten Detailseiten statt auf
+    # Anker innerhalb derselben Seite (#31).
+    assert 'href="a-verdoppler.html"' in html
+    assert 'href="b-verlierer.html"' in html
 
     # Beide Strategien kaufen dasselbe Instrument T1 zum selben Startkapital
     # (kein Rebalancing, Schwelle ist unerreichbar hoch) -> identisches Ergebnis:
     # 999 investierbar (1000 - 1 Gebuehr) / 100 = 9.99 Einheiten, Endwert bei
-    # Kurs 150 = 1498.50, Rendite (1498.50-1000)/1000 = +49.85%. Beschraenkt auf die
-    # Uebersichtstabelle, weil die Optimierungs-Effekte-Sektion (#17) je Strategie
-    # weitere "ohne <Mechanismus>"-Renditen anzeigt, die bei dieser einfachen
-    # Zwei-Zeilen-Historie zufaellig ebenfalls +49.85% betragen koennen.
+    # Kurs 150 = 1498.50, Rendite (1498.50-1000)/1000 = +49.85%.
     uebersicht = html.split('id="uebersicht"', 1)[1].split("</section>", 1)[0]
     assert uebersicht.count("+49.85") == 2
 
 
+def test_build_dashboard_erzeugt_detailseite_je_strategie(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+
+    assert (tmp_path / "a-verdoppler.html").exists()
+    assert (tmp_path / "b-verlierer.html").exists()
+    detail = _detail_html(tmp_path, "a-verdoppler")
+    assert "A: Verdoppler" in detail
+    assert '<a href="index.html">' in detail  # Ruecklink zur Startseite
+
+
+def test_startseite_zeigt_nur_wertverlauf_alles_andere_auf_detailseite(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    index_html = output.read_text(encoding="utf-8")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    # Wertverlauf-Chart bleibt auf der Startseite (#31).
+    assert 'id="value-chart-1"' in index_html
+    assert "Wertverlauf" in index_html
+    # Stat-Kacheln, Topf-Gewichtung und Instrumententabelle sind Detailseiten-Inhalt,
+    # nicht (mehr) auf der Startseite.
+    assert '<div class="label">Gesamtwert</div>' not in index_html
+    assert "Topf-Gewichtung Ist vs. Ziel" not in index_html
+    assert "Ist-Gewicht %" not in index_html
+
+    assert '<div class="label">Gesamtwert</div>' in detail_html
+    assert "Topf-Gewichtung Ist vs. Ziel" in detail_html
+    assert "Ist-Gewicht %" in detail_html
+    # 50-/200-Tage-Naeherung (#31) nur auf der Detailseite.
+    assert "50-Tage-Näherung" in detail_html
+    assert "200-Tage-Näherung" in detail_html
+    assert "50-Tage-Näherung" not in index_html
+
+
 def test_build_dashboard_summary_matches_detail_total_value(tmp_path: Path):
     output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
-    html = output.read_text(encoding="utf-8")
-    # Endwert taucht sowohl in der Uebersichtstabelle als auch im Detail-Stat-Tile auf.
-    assert html.count("1498.50") >= 2
+    index_html = output.read_text(encoding="utf-8")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    assert "1498.50" in index_html
+    assert "1498.50" in detail_html
 
 
 # --- Leave-one-out-Beitraege zusammengesetzter Strategien ------------------------------
@@ -112,22 +149,20 @@ def _zwei_ticker_rows() -> list[PriceRow]:
 
 
 def test_build_dashboard_renders_beitrag_chart_and_table(tmp_path: Path):
-    output = build_dashboard(
-        _zwei_ticker_rows(), [_strategy_mit_beitraegen()], output_path=tmp_path / "index.html"
-    )
-    html = output.read_text(encoding="utf-8")
+    build_dashboard(_zwei_ticker_rows(), [_strategy_mit_beitraegen()], output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "kombiniert")
 
-    assert "Effekt der einzelnen Börsenweisheiten" in html
-    assert 'id="beitrag-chart-1"' in html
-    assert "Regel A" in html
-    assert "Regel B" in html
+    assert "Effekt der einzelnen Börsenweisheiten" in detail_html
+    assert 'id="beitrag-chart"' in detail_html
+    assert "Regel A" in detail_html
+    assert "Regel B" in detail_html
     # Identische Varianten -> Leave-one-out-Differenz exakt 0.
-    assert html.count("+0.00") >= 2
+    assert detail_html.count("+0.00") >= 2
 
 
 def test_build_dashboard_omits_beitrag_section_without_beitraege(tmp_path: Path):
-    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
-    html = output.read_text(encoding="utf-8")
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
 
-    assert "Effekt der einzelnen Börsenweisheiten" not in html
-    assert "beitrag-chart-" not in html
+    assert "Effekt der einzelnen Börsenweisheiten" not in detail_html
+    assert "beitrag-chart" not in detail_html


### PR DESCRIPTION
## Summary

Setzt #31 um (zweites Paket, Paket 1 mit #24/#17/#26 war PR #32):

- **Startseite** (`docs/index.html`) zeigt je Strategie/Szenario jetzt nur noch Name, Kurzbeschreibung und den Wertverlauf-Chart (mit der gemeinsamen Y-Achsen-Skalierung aus #24) sowie einen Link "Details ansehen".
- **Neue Detailseite** je Strategie/Szenario (`docs/<slug>.html`, z. B. `barbell-20-80.html`) mit allem anderen: Kennzahl-Kacheln, Steuer-Stats, Topf-Gewichtung, Beitrags-/Optimierungs-Effekte-Sektionen und Instrumententabelle. Rücklink zur Übersicht.
- Auf der Detailseite zusätzlich ein neuer Chart: Wertverlauf plus **10-/40-Wochen gleitendem Durchschnitt** als Wochen-Näherung der klassischen 50-/200-Tage-Linien (5 Handelstage/Woche) - derselbe Ansatz, den `scenarios.CHART_SMA_CROSSOVER` bereits für die Handelsregel nutzt, hier aber rein zur Anzeige.
- `templates/base.html.j2` (neu) fasst Kopf/Fuß/Styles beider Seitentypen per Jinja-Vererbung zusammen, um Duplikation zu vermeiden.
- `build_dashboard()` rendert weiterhin `index.html` als Rückgabewert (Signatur unverändert) und schreibt zusätzlich je Strategie/Szenario eine `<slug>.html` daneben.

## Test plan

- [x] `pytest -q` – 118/118 Tests grün (Tests in `tests/test_dashboard.py` auf die neue Start-/Detailseiten-Struktur umgestellt)
- [x] `python scripts/build_dashboard.py` lokal ausgeführt: Startseite + 13 Detailseiten erzeugt, stichprobenartig geprüft (Verlinkung, Inhaltstrennung Start-/Detailseite, 50-/200-Tage-Näherung nur auf Detailseite)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR8qRNd3XpxhCQi4BL3iqe)_