### PR TITLE
Dokumentiere Grundsatzentscheidung: keine separate Cash-Position (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,20 @@ pytest -q
 
 ## Modellierungsentscheidungen der Engine
 
+- **Keine separate Cash-Position:** Wenn ein Szenario "defensiv" schaltet
+  (z. B. "Sell in May", SMA-Death-Cross, Trailing-Stop "Verluste begrenzen"),
+  wandert das Kapital vollständig in Topf A (Sicherheit: EUNL/EUNA/4GLD —
+  breite Anleihen- und Gold-ETFs), **nicht** in eine unverzinste oder fest
+  verzinste Cash-Haltung. Topf A **ist** in diesem Modell die Cash-Rolle:
+  liquide, breit gestreut, deutlich schwankungsärmer als Topf B, aber nicht
+  garantiert wertstabil. Ein zusätzlicher, echter Cash-Posten hätte zwei
+  Nachteile: (1) er bräuchte eine frei erfundene Verzinsung (siehe
+  [#35](https://github.com/S540d/Boersenspiel/issues/35)) statt eines aus der
+  Kurshistorie ableitbaren Werts, und würde damit von dem Grundsatz
+  abweichen, dass alles Abgeleitete ausschließlich aus echten Marktdaten
+  entsteht; (2) er würde Topf A implizit duplizieren, ohne einen anderen
+  Zweck zu erfüllen. Diskutiert und entschieden in
+  [#35](https://github.com/S540d/Boersenspiel/issues/35).
 - **Initialkauf:** Ordergebühren (1 €/Trade) werden **vom Startkapital vor
   der Aufteilung** abgezogen.
 - **Spätere Trades** (Rebalancing, Dezember-Harvest): Gebühren mindern beim


### PR DESCRIPTION
## Summary
- Ergänzt README.md um einen Grundsatz-Abschnitt: warum defensive Szenarien (Sell in May, SMA-Death-Cross, Trailing-Stop etc.) das Kapital in Topf A (Sicherheit) statt in eine separate, verzinste Cash-Position umschichten
- Hintergrund: nach Diskussion in #35 wurde die ursprüngliche Idee einer mit 2% p.a. verzinsten Cash-Position verworfen, weil Topf A bereits die "Cash-Rolle" (liquide, schwankungsarm) übernimmt und eine erfundene Verzinsung dem Projektgrundsatz widerspräche, dass alles Abgeleitete aus echten Marktdaten statt aus angenommenen Werten entsteht
- Kein Code geändert — reine Dokumentation, damit die Entscheidung für andere (und künftige Nachfragen "warum keine Cash-Position?") nachvollziehbar bleibt

## Test plan
- Keine Codeänderung, keine neuen Tests nötig
- `pytest -q` zur Sicherheit lokal durchgelaufen (keine Auswirkung erwartet)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Narr2Z57oEvDAjSQ1vzgJR)_