### PR TITLE
Dashboard-Transparenz: Risikokennzahlen, Klumpenrisiko-Warnung, eingefrorene Kurse

### DIFF
--- a/scripts/build_dashboard.py
+++ b/scripts/build_dashboard.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import _bootstrap  # noqa: F401
 
 from boersenspiel.dashboard import DEFAULT_OUTPUT, build_dashboard
-from boersenspiel.history_store import read_price_history
+from boersenspiel.history_store import read_fetch_log, read_price_history
 from boersenspiel.scenarios import SCENARIOS, SCENARIOS_BY_NAME
 from boersenspiel.strategies import STRATEGIES, STRATEGIES_BY_NAME
 
@@ -35,7 +35,7 @@ def main() -> int:
             raise SystemExit(f"Unbekannte Strategie: {args.strategy!r}. Verfuegbar: {list(ALL_STRATEGIES_BY_NAME)}")
         strategies = [ALL_STRATEGIES_BY_NAME[args.strategy]]
 
-    output_path = build_dashboard(price_history, strategies, args.output)
+    output_path = build_dashboard(price_history, strategies, args.output, fetch_log=read_fetch_log())
     print(f"Dashboard erzeugt: {output_path}")
     return 0
 

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+import statistics
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -18,9 +19,13 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from .engine import SimulationResult, simulate
-from .history_store import PriceRow
+from .history_store import FetchLogEntry, PriceRow
 from .learnings import derive_learnings
 from .strategies import STRATEGIES, Strategy
+
+# Status-Werte in fetch_log.csv, bei denen der Kurs NICHT frisch abgerufen wurde
+# (siehe history_store.record_week) - Grundlage fuer die "eingefroren"-Markierung (#42).
+_STALE_STATUS = {"carried_forward", "missing"}
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 DEFAULT_OUTPUT = Path(__file__).resolve().parents[2] / "docs" / "index.html"
@@ -59,6 +64,66 @@ def _f(value: Decimal) -> float:
     return float(value)
 
 
+# --- Risikokennzahlen (#40) -------------------------------------------------------
+#
+# Ergaenzen die Rendite um Volatilitaet und Max Drawdown, damit Strategien mit sehr
+# unterschiedlichem Risikoprofil (breit diversifiziert vs. konzentriert, ungetestete
+# Chartsignale) nicht allein anhand der nominalen Rendite verglichen werden. Reine
+# Anzeige-Ableitung aus der bereits von engine.simulate() gelieferten Wertreihe, keine
+# eigene Simulation.
+
+
+def _wochenrenditen(total_values: list[float]) -> list[float]:
+    return [
+        (total_values[i] - total_values[i - 1]) / total_values[i - 1]
+        for i in range(1, len(total_values))
+        if total_values[i - 1] > 0
+    ]
+
+
+def _volatilitaet_pct(total_values: list[float]) -> float:
+    """Annualisierte Volatilitaet (Standardabweichung der Wochenrenditen * sqrt(52))
+    in Prozent."""
+    renditen = _wochenrenditen(total_values)
+    if len(renditen) < 2:
+        return 0.0
+    return statistics.pstdev(renditen) * (52**0.5) * 100
+
+
+def _max_drawdown_pct(total_values: list[float]) -> float:
+    """Groesster Wertverlust vom bisherigen Hoechststand aus, in Prozent (>= 0)."""
+    peak: float | None = None
+    max_dd = 0.0
+    for wert in total_values:
+        if peak is None or wert > peak:
+            peak = wert
+        if peak and peak > 0:
+            max_dd = max(max_dd, (peak - wert) / peak)
+    return max_dd * 100
+
+
+# --- Eingefrorene Kurse (#42) ------------------------------------------------------
+
+
+def _carry_forward_streaks(rows: list[PriceRow], fetch_log: list[FetchLogEntry]) -> dict[str, int]:
+    """Je Ticker: Anzahl der zuletzt aufeinanderfolgenden Wochen (endend bei der
+    letzten Kurszeile), in denen laut fetch_log.csv KEIN frischer Kurs abgerufen werden
+    konnte (Status carried_forward/missing) - macht sichtbar, wenn eine flache
+    Kursentwicklung einen fehlgeschlagenen Datenabruf statt echter Marktstille
+    widerspiegelt."""
+    stale = {(entry.date, entry.ticker) for entry in fetch_log if entry.status in _STALE_STATUS}
+    tickers = {ticker for row in rows for ticker in row.prices}
+    streaks: dict[str, int] = {}
+    for ticker in tickers:
+        wochen = 0
+        for row in reversed(rows):
+            if (row.date, ticker) not in stale:
+                break
+            wochen += 1
+        streaks[ticker] = wochen
+    return streaks
+
+
 _UMLAUT_TRANSLIT = str.maketrans({"ä": "ae", "ö": "oe", "ü": "ue", "ß": "ss"})
 
 
@@ -94,7 +159,12 @@ def _optimierungs_effekte(strategy: Strategy, rows: list[PriceRow], basis_rendit
     return effekte
 
 
-def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: list[PriceRow]) -> dict:
+def _build_strategy_view(
+    strategy: Strategy,
+    result: SimulationResult,
+    rows: list[PriceRow],
+    carry_forward: dict[str, int] | None = None,
+) -> dict:
     points = result.value_history
     labels = [vp.date.isoformat() for vp in points]
     total_values = [_f(vp.total_value) for vp in points]
@@ -112,6 +182,7 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         topf.name: _f(sum((ticker_targets.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0))) * 100
         for topf in strategy.toepfe
     }
+    carry_forward = carry_forward or {}
     last = points[-1]
     holdings_table = []
     for ticker, units in sorted(result.holdings.items()):
@@ -119,6 +190,8 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         price = (value / units) if units else Decimal(0)
         ist_gewicht = last.ticker_weights.get(ticker, Decimal(0)) * 100
         ziel_gewicht = ticker_targets.get(ticker, Decimal(0)) * 100
+        abweichung_pp = ist_gewicht - ziel_gewicht
+        carry_forward_wochen = carry_forward.get(ticker, 0)
         holdings_table.append(
             {
                 "ticker": ticker,
@@ -127,11 +200,21 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
                 "value": f"{value:.2f}",
                 "ist_gewicht": f"{ist_gewicht:.1f}",
                 "ziel_gewicht": f"{ziel_gewicht:.1f}",
+                "abweichung_pp_label": f"{abweichung_pp:+.1f}",
+                # Warnung bei starker Abweichung eines EINZELNEN Instruments vom
+                # Zielgewicht (#41) - der Rebalancing-Trigger prueft nur die
+                # Topf-A-Abweichung, nicht die Konzentration innerhalb eines Topfs.
+                # Nutzt bewusst dieselbe Schwelle wie das Topf-Rebalancing statt einer
+                # neu erfundenen Zahl.
+                "konzentration_warnung": abs(abweichung_pp) > strategy.rebalancing_schwelle_pp,
+                "carry_forward_wochen": carry_forward_wochen,
             }
         )
 
     gewinn = last.total_value - strategy.startkapital
     rendite_pct = _rendite_pct(result, strategy)
+    volatilitaet_pct = _volatilitaet_pct(total_values)
+    max_drawdown_pct = _max_drawdown_pct(total_values)
 
     # Leave-one-out: Einzeleffekt jeder Teilregel als Differenz zur Variante ohne sie.
     beitraege = []
@@ -154,6 +237,10 @@ def _build_strategy_view(strategy: Strategy, result: SimulationResult, rows: lis
         "rendite_pct": _f(rendite_pct),
         "rendite_pct_label": f"{rendite_pct:+.2f}",
         "gewinn_label": f"{gewinn:+.2f}",
+        "volatilitaet_pct": volatilitaet_pct,
+        "volatilitaet_label": f"{volatilitaet_pct:.2f}",
+        "max_drawdown_pct": max_drawdown_pct,
+        "max_drawdown_label": f"{-max_drawdown_pct:.2f}" if max_drawdown_pct else "0.00",
         "labels_json": json.dumps(labels),
         "total_values": total_values,
         "total_values_json": json.dumps(total_values),
@@ -189,16 +276,22 @@ def build_dashboard(
     price_history: list[PriceRow],
     strategies: list[Strategy] | None = None,
     output_path: Path = DEFAULT_OUTPUT,
+    fetch_log: list[FetchLogEntry] | None = None,
 ) -> Path:
     """Baut die Startseite (nur Wertverlauf je Strategie/Szenario) sowie je eine
     Detailseite pro Strategie/Szenario (alles andere, inkl. 50-/200-Tage-Näherung) -
-    siehe #31. Die Detailseiten landen als ``<slug>.html`` neben ``output_path``."""
+    siehe #31. Die Detailseiten landen als ``<slug>.html`` neben ``output_path``.
+
+    ``fetch_log`` (optional, aus ``history_store.read_fetch_log()``) macht sichtbar,
+    welche Instrumente zuletzt mit einem eingefrorenen statt frisch abgerufenen Kurs
+    bewertet wurden (#42)."""
     if not price_history:
         raise ValueError("Kurshistorie ist leer - kein Dashboard erzeugbar")
     strategies = strategies if strategies is not None else STRATEGIES
     rows = sorted(price_history, key=lambda r: r.date)
+    carry_forward = _carry_forward_streaks(rows, fetch_log or [])
 
-    views = [_build_strategy_view(s, simulate(rows, s), rows) for s in strategies]
+    views = [_build_strategy_view(s, simulate(rows, s), rows, carry_forward) for s in strategies]
     summary = sorted(views, key=lambda v: v["rendite_pct"], reverse=True)
     learnings = derive_learnings(views)
 

--- a/src/boersenspiel/history_store.py
+++ b/src/boersenspiel/history_store.py
@@ -35,6 +35,15 @@ class PriceRow:
     prices: dict[str, Decimal]
 
 
+@dataclass(frozen=True)
+class FetchLogEntry:
+    date: date
+    ticker: str
+    status: str
+    source: str
+    note: str
+
+
 def _price_history_path(data_dir: Path) -> Path:
     return data_dir / PRICE_HISTORY_FILE
 
@@ -67,6 +76,29 @@ def read_price_history(data_dir: Path = DEFAULT_DATA_DIR) -> list[PriceRow]:
             rows.append(PriceRow(date=row_date, prices=prices))
     rows.sort(key=lambda r: r.date)
     return rows
+
+
+def read_fetch_log(data_dir: Path = DEFAULT_DATA_DIR) -> list[FetchLogEntry]:
+    """Liest das Kursabruf-Protokoll: eine Zeile je Ticker/Woche, in der KEIN frischer
+    Kurs abgerufen werden konnte (Status ``carried_forward`` oder ``missing``, siehe
+    ``record_week``). Grundlage für die Sichtbarkeit eingefrorener Kurse im Dashboard
+    (#42) - ``price_history.csv`` allein zeigt nicht, ob ein Kurs echt oder
+    fortgeschrieben ist."""
+    _ensure_files(data_dir)
+    entries: list[FetchLogEntry] = []
+    with _fetch_log_path(data_dir).open(newline="") as f:
+        reader = csv.DictReader(f)
+        for raw in reader:
+            entries.append(
+                FetchLogEntry(
+                    date=date.fromisoformat(raw["Date"]),
+                    ticker=raw["Ticker"],
+                    status=raw["Status"],
+                    source=raw["Source"],
+                    note=raw["Note"],
+                )
+            )
+    return entries
 
 
 def _iso_week(d: date) -> tuple[int, int]:

--- a/src/boersenspiel/templates/base.html.j2
+++ b/src/boersenspiel/templates/base.html.j2
@@ -142,6 +142,7 @@
   table.summary-table a { color: inherit; text-decoration: underline; text-decoration-color: var(--border); }
   .positive { color: var(--good); }
   .negative { color: var(--series-2); }
+  .warn { color: var(--series-4); font-weight: 600; }
   .detail-link { margin: 0; font-size: 0.9rem; }
   .back-link { margin: 0; font-size: 0.9rem; }
 </style>

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -43,15 +43,24 @@
 {% endif %}
   <section class="strategy" id="uebersicht">
     <h2>Übersicht: Rendite im Vergleich</h2>
+    <p class="hint">
+      Volatilität (annualisierte Standardabweichung der Wochenrenditen) und Max
+      Drawdown (größter Wertverlust vom bisherigen Höchststand) stehen bewusst neben
+      der Rendite: eine hohe Rendite bei konzentrierten oder ungetesteten Regeln
+      (z. B. Chartsignale) kann mit entsprechend höherem Risiko erkauft sein, das die
+      Rendite allein nicht zeigt.
+    </p>
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
     <div class="overflow-x">
       <table class="summary-table">
-        <thead><tr><th>Strategie / Szenario</th><th>Rendite %</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
+        <thead><tr><th>Strategie / Szenario</th><th>Rendite %</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
         <tbody>
         {% for s in summary %}
           <tr>
             <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
+            <td>{{ s.volatilitaet_label }}</td>
+            <td class="{{ 'negative' if s.max_drawdown_pct else '' }}">{{ s.max_drawdown_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.gewinn_label }}</td>
             <td>{{ s.total_value }}</td>
           </tr>

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -79,9 +79,17 @@
         </table>
       </div>
     </div>
+    <p class="hint">
+      "Abw. pp" ist die Abweichung des Ist- vom Ziel-Gewicht dieses Instruments in
+      Prozentpunkten; ⚠ markiert eine Abweichung über der Rebalancing-Schwelle dieser
+      Strategie ({{ s.rebalancing_schwelle_pp }} pp) - der Rebalancing-Trigger selbst
+      prüft nur die Abweichung von Topf A, nicht die Konzentration einzelner
+      Instrumente innerhalb eines Topfs. "Kursstatus" zeigt, wenn der zuletzt
+      verwendete Kurs mangels frischem Abruf fortgeschrieben statt neu ermittelt wurde.
+    </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Instrument</th><th>Einheiten</th><th>Kurs</th><th>Wert</th><th>Ist-Gewicht %</th><th>Ziel-Gewicht %</th></tr></thead>
+        <thead><tr><th>Instrument</th><th>Einheiten</th><th>Kurs</th><th>Wert</th><th>Ist-Gewicht %</th><th>Ziel-Gewicht %</th><th>Abw. pp</th><th>Kursstatus</th></tr></thead>
         <tbody>
         {% for row in s.holdings_table %}
           <tr>
@@ -91,6 +99,10 @@
             <td>{{ row.value }}</td>
             <td>{{ row.ist_gewicht }}</td>
             <td>{{ row.ziel_gewicht }}</td>
+            <td class="{{ 'warn' if row.konzentration_warnung else '' }}">{{ row.abweichung_pp_label }}{% if row.konzentration_warnung %} &#9888;{% endif %}</td>
+            <td class="{{ 'warn' if row.carry_forward_wochen > 0 else '' }}">
+              {% if row.carry_forward_wochen > 0 %}&#9888; seit {{ row.carry_forward_wochen }} Woche{{ 'n' if row.carry_forward_wochen != 1 else '' }} eingefroren{% else %}&ndash;{% endif %}
+            </td>
           </tr>
         {% endfor %}
         </tbody>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -12,8 +12,8 @@ from datetime import date
 from decimal import Decimal
 from pathlib import Path
 
-from boersenspiel.dashboard import _slug, build_dashboard
-from boersenspiel.history_store import PriceRow
+from boersenspiel.dashboard import _max_drawdown_pct, _slug, _volatilitaet_pct, build_dashboard
+from boersenspiel.history_store import FetchLogEntry, PriceRow
 from boersenspiel.strategies import Beitrag, Strategy, Topf
 
 ZWEI_STRATEGIEN = [
@@ -166,3 +166,124 @@ def test_build_dashboard_omits_beitrag_section_without_beitraege(tmp_path: Path)
 
     assert "Effekt der einzelnen Börsenweisheiten" not in detail_html
     assert "beitrag-chart" not in detail_html
+
+
+# --- Risikokennzahlen: Volatilitaet & Max Drawdown (#40) ------------------------------
+
+
+def _auf_und_ab_rows() -> list[PriceRow]:
+    """T1 verdoppelt sich, faellt dann auf den Ausgangswert zurueck und erholt sich
+    teilweise - erzeugt sowohl einen messbaren Drawdown als auch Streuung in den
+    Wochenrenditen (anders als die monoton steigende Standard-Fixture ``_rows()``)."""
+    return [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("200")}),
+        PriceRow(date(2024, 1, 15), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 22), {"T1": Decimal("150")}),
+    ]
+
+
+def test_volatilitaet_pct_von_konstanter_reihe_ist_null():
+    assert _volatilitaet_pct([1000.0, 1000.0, 1000.0]) == 0.0
+
+
+def test_volatilitaet_pct_erkennt_streuung():
+    # Wechselnde Vorzeichen bei den Wochenrenditen (+100%, -50%, +50%) -> deutlich
+    # von 0 verschiedene Standardabweichung.
+    assert _volatilitaet_pct([100.0, 200.0, 100.0, 150.0]) > 0.0
+
+
+def test_max_drawdown_pct_bei_monotonem_anstieg_ist_null():
+    assert _max_drawdown_pct([100.0, 150.0, 200.0]) == 0.0
+
+
+def test_max_drawdown_pct_misst_groessten_ruecksetzer():
+    # Hoechststand 200, danach Rueckgang auf 100 -> 50% Drawdown; die anschliessende
+    # Teilerholung auf 150 bleibt darunter und darf das Maximum nicht verkleinern.
+    assert _max_drawdown_pct([100.0, 200.0, 100.0, 150.0]) == 50.0
+
+
+def test_summary_table_zeigt_volatilitaet_und_max_drawdown_spalten(tmp_path: Path):
+    output = build_dashboard(_auf_und_ab_rows(), [ZWEI_STRATEGIEN[0]], output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    assert "Volatilität % (ann.)" in html
+    assert "Max Drawdown %" in html
+
+
+def test_risikokennzahlen_sind_nur_auf_startseite(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+    # Volatilitaet/Max Drawdown sind Teil der Vergleichsuebersicht (#40), nicht der
+    # Detailseite - dieselbe Trennung wie bei Wertverlauf-Chart vs. Kennzahl-Kacheln.
+    assert "Max Drawdown %" not in detail_html
+
+
+# --- Klumpenrisiko-Warnung im Rebalancing (#41) ----------------------------------------
+
+
+def _konzentrations_strategie() -> Strategy:
+    return Strategy(
+        name="Konzentriert",
+        startkapital=Decimal("1000"),
+        toepfe=[
+            Topf(
+                name="Topf",
+                gewicht_gesamt=Decimal("1"),
+                sub_gewichte={"T1": Decimal("0.5"), "T2": Decimal("0.5")},
+            )
+        ],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("10"),
+    )
+
+
+def _drift_rows() -> list[PriceRow]:
+    return [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("1000"), "T2": Decimal("100")}),
+    ]
+
+
+def test_holdings_table_warnt_bei_instrument_konzentration_trotz_topf_im_ziel(tmp_path: Path):
+    # Einziger Topf haelt IMMER 100% des Depots -> der Topf-A-Rebalancing-Trigger
+    # (#41) loest nie aus, obwohl T1 hier den Grossteil des Topfs uebernimmt.
+    build_dashboard(_drift_rows(), [_konzentrations_strategie()], output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "konzentriert")
+
+    assert "Abw. pp" in detail_html
+    assert "&#9888;" in detail_html  # Warnsymbol fuer die zu stark abweichenden Instrumente
+
+
+def test_holdings_table_keine_warnung_wenn_abweichung_unter_schwelle(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+    # Einziges Instrument haelt exakt sein Zielgewicht (100%) -> keine Abweichung.
+    assert "&#9888;" not in detail_html
+
+
+# --- Sichtbarkeit eingefrorener Kurse (#42) --------------------------------------------
+
+
+def test_holdings_table_markiert_eingefrorenen_kurs(tmp_path: Path):
+    fetch_log = [
+        FetchLogEntry(
+            date=date(2024, 1, 8),
+            ticker="T1",
+            status="carried_forward",
+            source="test",
+            note="Kein aktueller Kurs verfuegbar, letzter bekannter Kurs uebernommen",
+        )
+    ]
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html", fetch_log=fetch_log)
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    assert "seit 1 Woche eingefroren" in detail_html
+
+
+def test_holdings_table_ohne_fetch_log_zeigt_keine_eingefroren_markierung(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    assert "eingefroren" not in detail_html

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -4,7 +4,8 @@ from datetime import date
 from decimal import Decimal
 from pathlib import Path
 
-from boersenspiel.history_store import read_price_history, record_week, row_date_from_quotes
+from boersenspiel.history_store import read_fetch_log, read_price_history, record_week, row_date_from_quotes
+from boersenspiel.instruments import TICKERS
 from boersenspiel.sources import PriceQuote
 
 
@@ -125,3 +126,27 @@ def test_row_date_falls_back_when_no_source_reports_a_trading_day():
     dort bleibt das uebergebene Datum massgeblich."""
     quotes = {"EUNL": _quote("EUNL", 80.0, None)}
     assert row_date_from_quotes(quotes, fallback=date(2026, 8, 24)) == date(2026, 8, 24)
+
+
+def _alle_kurse_ok() -> dict[str, PriceQuote]:
+    """Vollstaendige Quotes fuer ALLE Ticker (status ok), damit ein Test sich auf die
+    Status-Zeilen fuer die tatsaechlich interessierenden Ticker konzentrieren kann -
+    ``record_week`` protokolliert sonst jeden fehlenden Ticker als 'missing'."""
+    return _quotes(**{t: 100.0 for t in TICKERS})
+
+
+def test_read_fetch_log_returns_carried_forward_and_missing_entries(tmp_path: Path):
+    record_week(date(2024, 1, 1), _alle_kurse_ok(), data_dir=tmp_path)
+    quotes = _alle_kurse_ok()
+    quotes["EUNL"] = PriceQuote("EUNL", None, "missing", "test")
+    record_week(date(2024, 1, 8), quotes, data_dir=tmp_path)
+
+    entries = [e for e in read_fetch_log(tmp_path) if e.ticker == "EUNL"]
+    assert len(entries) == 1
+    assert entries[0].date == date(2024, 1, 8)
+    assert entries[0].status == "carried_forward"
+
+
+def test_read_fetch_log_empty_when_no_gaps(tmp_path: Path):
+    record_week(date(2024, 1, 1), _alle_kurse_ok(), data_dir=tmp_path)
+    assert read_fetch_log(tmp_path) == []


### PR DESCRIPTION
Closes #40, #41, #42.

## Zusammenfassung

Erstes von zwei Paketen aus einer Bündelung der 10 offenen Issues (siehe Diskussion in der Session). Dieses Paket ist rein additive Dashboard-Transparenz — keine Änderung an Simulation oder bestehenden Renditezahlen:

- **#40 (Risikokennzahlen)**: Die Übersichtstabelle zeigt jetzt annualisierte Volatilität und Max Drawdown neben der Rendite, damit z. B. das SMA-Crossover-Szenario (+235 % über 5 Jahre, laut eigener Doku "nicht optimiert/gebacktestet") nicht allein nach nominaler Rendite als überlegen erscheint.
- **#41 (Klumpenrisiko-Warnung)**: Die Instrumententabelle jeder Detailseite zeigt jetzt die Abweichung jedes Instruments vom Zielgewicht in Prozentpunkten und markiert sie mit ⚠, sobald sie über der Rebalancing-Schwelle der Strategie liegt. Macht sichtbar, dass der Rebalancing-Trigger nur die Topf-A-Abweichung prüft, nicht die Konzentration einzelner Instrumente (z. B. BTC oder eine Einzelaktie) innerhalb eines Topfs.
- **#42 (Sichtbarkeit eingefrorener Kurse)**: Die Instrumententabelle zeigt jetzt, wenn der zuletzt verwendete Kurs eines Tickers mangels frischem Abruf fortgeschrieben statt neu ermittelt wurde (aus `fetch_log.csv`, Status `carried_forward`/`missing`), inklusive Anzahl der betroffenen Wochen.

## Technisch

- `history_store.read_fetch_log()` neu: liest `fetch_log.csv` (bisher nur geschrieben, nie gelesen).
- `dashboard.py`: neue reine Anzeige-Ableitungen `_volatilitaet_pct`, `_max_drawdown_pct`, `_carry_forward_streaks` sowie `abweichung_pp`/`konzentration_warnung` je Instrument — alles auf Basis der bereits von `engine.simulate()` gelieferten Werte, keine eigene Simulationslogik.
- `scripts/build_dashboard.py` übergibt den Fetch-Log jetzt an `build_dashboard()`.
- Templates: neue Spalten in der Übersichtstabelle (Volatilität, Max Drawdown) und der Instrumententabelle (Abw. pp, Kursstatus) plus erklärende Hinweistexte.

## Test plan

- [x] `pytest -q` — 130 passed (12 neue Tests: Risikokennzahlen-Funktionen, Konzentrationswarnung, eingefrorene Kurse, `read_fetch_log`)
- [x] `python scripts/build_dashboard.py` — Build über die komplette echte Kurshistorie geprüft; Warnsymbole erscheinen u. a. bei "Buy & Hold" (rebalanciert bewusst nie) und den Momentum-/Vol-Szenarien, wie erwartet
- [x] `docs/` nicht committed (wie bisher — CI-generiert)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Lvv6UAgWELEvSwq6YvxfQ)_