### PR TITLE
Setze #47 um: Buy & Hold-Beschreibung (#27) und verkürzter SMA-Crossover (#28)

### DIFF
--- a/src/boersenspiel/scenarios.py
+++ b/src/boersenspiel/scenarios.py
@@ -159,7 +159,11 @@ BUY_AND_HOLD = Strategy(
     beschreibung=(
         "Anfangsallokation wird nie aktiv rebalanciert ('Hin und her macht Taschen "
         "leer'). Der Dezember-Steuermechanismus bleibt wie bei den anderen Strategien "
-        "aktiv."
+        "aktiv. Im kombinierten Szenario 'Börsenweisheiten (alle fünf kombiniert)' "
+        "wirkt dieselbe Weisheit anders: dort votiert sie als einzige Regel immer für "
+        "die normale Barbell-Quote und dient als Dauervotum/dämpfender Anker, weil sich "
+        "'gar nicht umschichten' nicht als Quoten-Votum neben den anderen Regeln "
+        "kombinieren lässt (siehe #27)."
     ),
 )
 
@@ -453,6 +457,45 @@ CHART_SMA_CROSSOVER = Strategy(
 )
 
 
+# --- 2b: Verkürzte Fensterlänge (100/21 statt 50/200 Handelstage, #28) ----------------
+#
+# Owner-Wunsch aus #28: dieselbe Golden-/Death-Cross-Logik wie oben, aber mit
+# kürzeren Fenstern für ein reaktionsschnelleres Signal. Wochen-Näherung wie beim
+# 10/40-Wochen-Original (5 Handelstage/Woche): 21 Handelstage ≈ 4 Wochen, 100
+# Handelstage = 20 Wochen.
+
+SMA_KURZ_WOCHEN_100_21 = 4
+SMA_LANG_WOCHEN_100_21 = 20
+
+
+def chart_sma_crossover_kurz_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    sma_kurz = _sma(rows, i, TREND_TICKER, SMA_KURZ_WOCHEN_100_21)
+    sma_lang = _sma(rows, i, TREND_TICKER, SMA_LANG_WOCHEN_100_21)
+    if sma_kurz is None or sma_lang is None:
+        # Noch nicht genug Historie fuer den langen SMA -> regulaer investiert.
+        return _NORMAL_GEWICHTE
+    if sma_kurz < sma_lang:
+        return _DEFENSIV_GEWICHTE
+    return _NORMAL_GEWICHTE
+
+
+CHART_SMA_CROSSOVER_KURZ = Strategy(
+    name="Charttechnik: SMA-Crossover (4/20 Wochen)",
+    startkapital=Decimal("10000"),
+    toepfe=BARBELL_20_80.toepfe,
+    ziel_topf=BARBELL_20_80.ziel_topf,
+    ziel_gewicht=BARBELL_20_80.ziel_gewicht,
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=chart_sma_crossover_kurz_gewichte,
+    beschreibung=(
+        "Wie 'SMA-Crossover (10/40 Wochen)', aber mit kürzeren Fenstern (4/20 statt "
+        "10/40 Wochen, entspricht 21/100 statt 50/200 Handelstagen) für ein "
+        "reaktionsschnelleres Signal - Erweiterung des Golden-/Death-Cross-Ansatzes "
+        "aus #28."
+    ),
+)
+
+
 # =====================================================================================
 # 3. Weitere Ansätze
 # =====================================================================================
@@ -629,6 +672,7 @@ SCENARIOS: list[Strategy] = [
     CUT_LOSSES,
     BOERSENWEISHEITEN,
     CHART_SMA_CROSSOVER,
+    CHART_SMA_CROSSOVER_KURZ,
     MOMENTUM_ROTATION,
     VOLATILITY_TARGET,
     COST_AVERAGE_ENTRY,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -22,6 +22,7 @@ from boersenspiel.scenarios import (
     BUY_AND_HOLD,
     BUY_THE_DIP,
     CHART_SMA_CROSSOVER,
+    CHART_SMA_CROSSOVER_KURZ,
     COST_AVERAGE_ENTRY,
     CUT_LOSSES,
     CUT_LOSSES_FENSTER_WOCHEN,
@@ -33,6 +34,7 @@ from boersenspiel.scenarios import (
     WEISHEITEN,
     buy_the_dip_gewichte,
     chart_sma_crossover_gewichte,
+    chart_sma_crossover_kurz_gewichte,
     cost_average_gewichte,
     cut_losses_gewichte,
     gewichte_fuer_wachstumsquote,
@@ -191,6 +193,21 @@ def test_chart_sma_crossover_defaults_to_normal_weights_without_enough_history()
 def test_chart_sma_crossover_scenario_runs_end_to_end():
     result = simulate(_sample_rows(), CHART_SMA_CROSSOVER)
     assert result.strategy_name == "Charttechnik: SMA-Crossover (10/40 Wochen)"
+    last_point = result.value_history[-1]
+    total_weight = sum(last_point.ticker_weights.values())
+    assert abs(total_weight - Decimal("1")) < Decimal("0.0001")
+
+
+def test_chart_sma_crossover_kurz_defaults_to_normal_weights_without_enough_history():
+    rows = _sample_rows()[:5]
+    gewichte = chart_sma_crossover_kurz_gewichte(rows, 4)
+    # Ticker-Gewicht am Gesamtdepot = Topf-A-Gewicht (0.20) * Sub-Gewicht (0.50).
+    assert gewichte["EUNL"] == Decimal("0.10")
+
+
+def test_chart_sma_crossover_kurz_scenario_runs_end_to_end():
+    result = simulate(_sample_rows(), CHART_SMA_CROSSOVER_KURZ)
+    assert result.strategy_name == "Charttechnik: SMA-Crossover (4/20 Wochen)"
     last_point = result.value_history[-1]
     total_weight = sum(last_point.ticker_weights.values())
     assert abs(total_weight - Decimal("1")) < Decimal("0.0001")


### PR DESCRIPTION
## Summary
Setzt die beiden noch offenen Punkte aus #47 um (#35 ist bereits durch den gemergten PR #36 erledigt):

- **#27**: Owner-Entscheidung war, die im Issue-Kommentar erklärte Mechanik unverändert zu lassen (Buy & Hold als Dauervotum/dämpfender Anker im kombinierten Börsenweisheiten-Szenario) und nur als Beschreibung auf die Detailseite von `BUY_AND_HOLD` zu übernehmen. Kein Verhaltensunterschied, nur `beschreibung` erweitert.
- **#28**: Owner-Konkretisierung war, die bestehende SMA-Crossover-Regel (10/40 Wochen ≈ 50/200 Handelstage) um eine Variante mit verkürztem Zeitraum zu erweitern: 100/21 Handelstage, als 20/4-Wochen-Näherung (5 Handelstage/Woche, gleiche Umrechnung wie beim Original). Neues Szenario `CHART_SMA_CROSSOVER_KURZ` ("Charttechnik: SMA-Crossover (4/20 Wochen)") ergänzt das bestehende, ersetzt es nicht.

Kein Eingriff in Engine/Steuerlogik, keine Änderung an bestehenden Szenario-Ergebnissen.

## Test plan
- `pytest -q` (132 passed)
- `python scripts/build_dashboard.py --strategy "Charttechnik: SMA-Crossover (4/20 Wochen)"` lokal gerendert, Ergebnis nicht committet (Build-Artefakt, wird vom wöchentlichen Workflow erzeugt)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qp8tf7WeWTzWeSVq7Evc58)_