### PR TITLE
Steuerkorrektheit: Teilfreistellung, Vorabpauschale, BTC-Spekulationsfrist (#37, #38, #39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,52 @@ inkrementell fortgeschrieben).
   überspringt den kompletten Dezember-Harvest-Block. Diese Schalter dienen
   dazu, den isolierten Renditebeitrag jedes Mechanismus messbar zu machen
   (#17) — siehe `dashboard._optimierungs_effekte()`.
+  **Steuerkorrekturen (#37/#38/#39, Paket A aus #46)**, alle über
+  `Instrument`-Felder in `instruments.py` gesteuert, nicht über
+  `Optimierungen` (das sind Modellfehler-Korrekturen, keine ein-/
+  ausschaltbaren Mechanismen):
+  - `Instrument.teilfreistellung` (#38): `process_realized_gain(gain,
+    ticker)` multipliziert Gewinn *und* Verlust vor der Verrechnung mit
+    `(1 - teilfreistellung)` — 30% für die vier Aktienfonds-ETFs (EUNL,
+    LYMS, SEMI, EIMI), 0% für Rentenfonds (EUNA), physisches Gold (4GLD),
+    Einzelaktien und BTC-EUR (kein Fondsprivileg).
+  - `Instrument.thesaurierend` (#39): `apply_vorabpauschale()` läuft bei
+    jeder Harvest-Zeile (`harvest_dates`, unabhängig von
+    `opt.steueroptimierung`, nur an `opt.besteuerung` gekoppelt) *vor* der
+    A/B-Entscheidung und wendet je thesaurierendem Instrument
+    `min(Wert_Jahresbeginn × VORABPAUSCHALE_BASISZINS_PLATZHALTER ×
+    VORABPAUSCHALE_FAKTOR, tatsächliche Wertsteigerung)` als zusätzlichen
+    Gewinn auf denselben Freibetrag-Topf an (inkl. Teilfreistellung) und
+    hebt die Kostenbasis um den vollen, unversteuerten Vorabpauschale-Betrag
+    an. `wert_jahresbeginn` wird am Ende jeder Zeile für das jeweils neue
+    Jahr aus den aktuellen `values` mitgeschrieben. **Bewusster Platzhalter:**
+    `VORABPAUSCHALE_BASISZINS_PLATZHALTER` in `strategies.py` ist ein
+    konstanter Ersatzwert, kein echter jährlicher BMF-Basiszins (siehe
+    TODO-Kommentar dort) — die Anwendung am Jahresende statt am 1. Werktag
+    des Folgejahres ist ebenfalls eine bewusste Vereinfachung der exakten
+    gesetzlichen Fälligkeit.
+  - `Instrument.spekulationsfrist_tage` (#37, nur BTC-EUR = 365): jede
+    `_Position` führt zusätzlich `kauf_tage_gewichtet` (stückzahlgewichtete
+    Summe der Kauf-Ordinaldaten, exakt analog zu `cost_total`/`avg_cost()`)
+    für ein vereinfachtes gewichtetes Kaufdatum
+    (`avg_kauf_tag_ordinal()`) statt echtem Per-Lot-Tracking. Bei jedem
+    Verkauf entscheidet `process_gain_for_sale()` anhand der Haltedauer
+    (Verkaufsdatum minus `avg_kauf_tag_ordinal()` vor dem Verkauf): über der
+    Frist steuerfrei (§ 23 EStG, berührt keinen Topf), sonst
+    `process_spekulationsgeschaeft()` — ein von Sparerpauschbetrag/
+    Verlustvortrag komplett getrennter Topf mit eigenem Verlustvortrag und
+    einer *Freigrenze* (§ 23 Abs. 3 Satz 5 EStG, `SPEKULATIONSFRIST_
+    FREIGRENZE_PRO_JAHR`) statt eines Freibetrags: unterhalb der Grenze
+    bleibt der GESAMTE Jahresgewinn steuerfrei, oberhalb wird der GESAMTE
+    Jahresgewinn steuerpflichtig (Kippgrenze, nicht Sockelbetrag) — als
+    Differenz `steuer(neuer Stand) - steuer(alter Stand)` pro Trade
+    berechnet, damit der rückwirkende Kipp-Effekt trotz zeilenweiser
+    Verarbeitung korrekt entsteht. `december_gewinnmitnahme()`/
+    `december_tax_loss_harvest()` schließen Instrumente mit gesetzter
+    Spekulationsfrist explizit aus ihren Kandidatenlisten aus, da beide
+    Maßnahmen ausschließlich den Abgeltungsteuer-Topf optimieren.
+    Vereinfachung: Besteuerung mit dem pauschalen `STEUERSATZ` statt dem
+    tatsächlich anzuwendenden persönlichen Einkommensteuersatz.
 - `dashboard.py` + `templates/` — reine Darstellungsschicht, rendert
   `engine.simulate()`-Ergebnisse für alle (oder eine ausgewählte)
   Strategie(n) aus `STRATEGIES`. Seit #31 zwei Seitentypen statt einer
@@ -281,6 +327,13 @@ Trades, keine `rebalance`-Trades, keine Dezember-Harvest-Trades, Steuerstatus
 bleibt bei den Defaultwerten), plus ein Test, dass ein explizit übergebenes
 `Optimierungen()` (alle Defaults) exakt dasselbe Ergebnis liefert wie gar
 keine Übergabe, und dass `Strategy.optimierungen` ohne Override greift.
+Eigener Abschnitt für die Steuerkorrekturen (#37/#38/#39): je ein von Hand
+nachgerechneter Test für Teilfreistellung (EUNL/4GLD-Rebalance, Freibetrag
+sinkt nur um 70% des Rohgewinns), Vorabpauschale (EUNL ohne jeden Verkauf,
+Freibetrag sinkt trotzdem am Jahresende) sowie BTC-Spekulationsfrist einmal
+innerhalb (Gewinn landet in der Freigrenze, Sparerpauschbetrag bleibt
+unangetastet) und einmal außerhalb der Frist (großer Gewinn bleibt komplett
+steuerfrei, andernfalls wäre eine deutliche Steuer sichtbar).
 `tests/test_history_store.py` prüft Wochen-Idempotenz, Carry-Forward und
 `read_fetch_log()`.
 `tests/test_sources.py` / `tests/test_alphavantage.py` mocken die jeweilige

--- a/README.md
+++ b/README.md
@@ -404,11 +404,39 @@ pytest -q
   already-taxed gain total, but builds up a loss carryforward that reduces
   future gains. The requirements document did not specify an exact algorithm
   here – this variant was confirmed during the planning discussion.
-- **Tax logic** unchanged from the requirements document: loss offsetting
-  before the tax-free allowance before tax (26.375%), tax-free allowance of
-  €1,000/year resetting at the calendar year boundary, one shared
-  loss/allowance pool, no advance lump-sum tax (Vorabpauschale), no partial
-  tax exemption (Teilfreistellung).
+- **Tax logic**, largely unchanged from the requirements document: loss
+  offsetting before the tax-free allowance before tax (26.375%), tax-free
+  allowance of €1,000/year resetting at the calendar year boundary, one
+  shared loss/allowance pool for capital-gains-taxed instruments. Three
+  corrections on top of the original spec (#37/#38/#39, tracked in #46):
+  - **Partial tax exemption (Teilfreistellung, #38):** realized gains and
+    losses on equity-fund ETFs (>51% equity allocation — EUNL, LYMS, SEMI,
+    EIMI) are reduced by the statutory 30% (§ 20 InvStG) before entering the
+    loss/allowance pool. Bond ETFs (EUNA), physical gold (4GLD), individual
+    stocks, and BTC-EUR (no fund privilege) get no exemption.
+  - **Advance lump-sum tax (Vorabpauschale, #39):** for instruments flagged
+    accumulating (thesaurierend), a simplified annual Vorabpauschale is
+    applied at each completed year's harvest date — capped at that year's
+    actual value increase — consuming part of that year's allowance before
+    the December harvest decision runs, and raising the position's cost
+    basis by the full (pre-exemption) amount. **Documented simplification:**
+    the base interest rate (Basiszins) is a constant placeholder
+    (`VORABPAUSCHALE_BASISZINS_PLATZHALTER` in `strategies.py`) rather than
+    the real, annually published BMF rate, and the timing (year-end instead
+    of the first business day of the following year) is approximated —
+    real historical Basiszins values are still needed to replace the
+    placeholder.
+  - **Crypto speculation period (Spekulationsfrist, #37):** BTC-EUR gains are
+    excluded from the capital-gains loss/allowance pool entirely. Instead, a
+    simplified average-purchase-date holding period (analogous to the
+    average-cost method already used for cost basis) decides per sale: held
+    over 365 days → completely tax-free (§ 23 EStG); held 365 days or less →
+    taxed via a separate, all-or-nothing €1,000/year exemption threshold
+    (Freigrenze, not an allowance — crossing it makes the *entire* year's
+    gain taxable, not just the excess), using the flat capital-gains rate as
+    a documented simplification for the actual personal income tax rate.
+    BTC-EUR is therefore also excluded from the December harvest measures,
+    which only ever optimize the capital-gains pool.
 
 ## Known limitations
 

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -53,7 +53,32 @@ from datetime import date
 from decimal import Decimal
 
 from .history_store import PriceRow
-from .strategies import ORDERGEBUEHR, SPARERPAUSCHBETRAG_PRO_JAHR, STEUERSATZ, Optimierungen, Strategy
+from .instruments import INSTRUMENTS
+from .strategies import (
+    ORDERGEBUEHR,
+    SPARERPAUSCHBETRAG_PRO_JAHR,
+    SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR,
+    STEUERSATZ,
+    VORABPAUSCHALE_BASISZINS_PLATZHALTER,
+    VORABPAUSCHALE_FAKTOR,
+    Optimierungen,
+    Strategy,
+)
+
+
+def _teilfreistellung(ticker: str) -> Decimal:
+    instrument = INSTRUMENTS.get(ticker)
+    return instrument.teilfreistellung if instrument is not None else Decimal(0)
+
+
+def _thesaurierend(ticker: str) -> bool:
+    instrument = INSTRUMENTS.get(ticker)
+    return instrument.thesaurierend if instrument is not None else False
+
+
+def _spekulationsfrist_tage(ticker: str) -> int | None:
+    instrument = INSTRUMENTS.get(ticker)
+    return instrument.spekulationsfrist_tage if instrument is not None else None
 
 
 @dataclass
@@ -102,11 +127,20 @@ class SimulationResult:
 class _Position:
     units: Decimal = field(default_factory=lambda: Decimal(0))
     cost_total: Decimal = field(default_factory=lambda: Decimal(0))
+    # Stückzahl-gewichtete Summe der Kauf-Ordinaldaten - Grundlage für
+    # avg_kauf_tag_ordinal(), der vereinfachten Haltedauer-Näherung für die
+    # Spekulationsfrist (#37), analog zur Durchschnittskosten-Methode.
+    kauf_tage_gewichtet: Decimal = field(default_factory=lambda: Decimal(0))
 
     def avg_cost(self) -> Decimal:
         if self.units == 0:
             return Decimal(0)
         return self.cost_total / self.units
+
+    def avg_kauf_tag_ordinal(self) -> Decimal:
+        if self.units == 0:
+            return Decimal(0)
+        return self.kauf_tage_gewichtet / self.units
 
 
 def simulate(
@@ -152,11 +186,23 @@ def simulate(
     # realisierten Gewinne - Trigger und Zielgröße für den Tax-Loss-Harvest
     # (Maßnahme B), unabhängig von freibetrag_verbleibend.
     steuerpflichtige_gewinne_jahr = Decimal(0)
+    # Getrennter Topf für private Veräußerungsgeschäfte innerhalb der
+    # Spekulationsfrist (§ 23 EStG, z. B. BTC vor Ablauf eines Jahres) - bewusst
+    # unabhängig vom Sparerpauschbetrag/Verlustvortrag der Kapitalerträge (#37).
+    spek_verlustvortrag = Decimal(0)
+    spek_gewinn_jahr = Decimal(0)
+    # Portfoliowert je thesaurierendem Instrument zu Jahresbeginn - Grundlage
+    # für die vereinfachte Vorabpauschale (#39), s. apply_vorabpauschale().
+    wert_jahresbeginn: dict[str, Decimal] = {}
+    wert_jahresbeginn_jahr: int | None = None
 
-    def process_realized_gain(gain: Decimal) -> None:
+    def process_realized_gain(gain: Decimal, ticker: str) -> None:
         nonlocal freibetrag_verbleibend, verlustvortrag, kumulierte_steuer, steuerpflichtige_gewinne_jahr
         if not opt.besteuerung:
             return
+        # Teilfreistellung (30% für Aktienfonds-ETFs, § 20 InvStG, #38) gilt
+        # symmetrisch für Gewinn und Verlust - reduziert beide um denselben Anteil.
+        gain = gain * (1 - _teilfreistellung(ticker))
         if gain <= 0:
             verlustvortrag += -gain
             return
@@ -169,12 +215,63 @@ def simulate(
         kumulierte_steuer += steuerpflichtig * STEUERSATZ
         steuerpflichtige_gewinne_jahr += steuerpflichtig
 
+    def process_spekulationsgeschaeft(gain: Decimal) -> None:
+        """BTC & Co. innerhalb der Spekulationsfrist (#37): eigener
+        Freigrenzen-Topf getrennt vom Sparerpauschbetrag. Anders als der
+        Sparerpauschbetrag ist die Freigrenze nach § 23 Abs. 3 Satz 5 EStG
+        eine Kippgrenze - bleibt der Jahresgewinn darunter, bleibt er komplett
+        steuerfrei; wird sie überschritten, ist der GESAMTE Jahresgewinn
+        steuerpflichtig. Die Differenz aus Steuer-auf-neuen-Stand minus
+        Steuer-auf-alten-Stand bildet diesen rückwirkenden Effekt korrekt ab,
+        auch wenn Trades einzeln nacheinander verarbeitet werden. Vereinfachung:
+        Besteuerung mit dem pauschalen STEUERSATZ statt dem tatsächlich
+        anzuwendenden persönlichen Einkommensteuersatz."""
+        nonlocal spek_verlustvortrag, spek_gewinn_jahr, kumulierte_steuer
+        if not opt.besteuerung:
+            return
+        if gain <= 0:
+            spek_verlustvortrag += -gain
+            return
+        offset_verlust = min(gain, spek_verlustvortrag)
+        spek_verlustvortrag -= offset_verlust
+        rest = gain - offset_verlust
+        vorher = spek_gewinn_jahr
+        spek_gewinn_jahr += rest
+        steuer_vorher = (
+            vorher * STEUERSATZ if vorher > SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR else Decimal(0)
+        )
+        steuer_nachher = (
+            spek_gewinn_jahr * STEUERSATZ
+            if spek_gewinn_jahr > SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR
+            else Decimal(0)
+        )
+        kumulierte_steuer += steuer_nachher - steuer_vorher
+
+    def process_gain_for_sale(ticker: str, trade_date: date, avg_kauf_tag: Decimal, gain: Decimal) -> None:
+        """Routet den realisierten Gewinn/Verlust eines Verkaufs in den
+        richtigen Steuertopf: normale Abgeltungsteuer, oder - falls das
+        Instrument einer Spekulationsfrist unterliegt (#37) - entweder
+        komplett steuerfrei (Frist abgelaufen) oder in den getrennten
+        Freigrenzen-Topf. ``avg_kauf_tag`` ist das vor diesem Verkauf gültige
+        gewichtete Kaufdatum der Position (Durchschnittskosten-Näherung)."""
+        frist = _spekulationsfrist_tage(ticker)
+        if frist is None:
+            process_realized_gain(gain, ticker)
+            return
+        haltedauer_tage = Decimal(trade_date.toordinal()) - avg_kauf_tag
+        if haltedauer_tage > frist:
+            # Spekulationsfrist abgelaufen -> privat und steuerfrei, berührt
+            # weder Freibetrag/Verlustvortrag noch die Freigrenze.
+            return
+        process_spekulationsgeschaeft(gain)
+
     def reset_year_if_needed(year: int) -> None:
-        nonlocal current_tax_year, freibetrag_verbleibend, steuerpflichtige_gewinne_jahr
+        nonlocal current_tax_year, freibetrag_verbleibend, steuerpflichtige_gewinne_jahr, spek_gewinn_jahr
         if year != current_tax_year:
             current_tax_year = year
             freibetrag_verbleibend = SPARERPAUSCHBETRAG_PRO_JAHR
             steuerpflichtige_gewinne_jahr = Decimal(0)
+            spek_gewinn_jahr = Decimal(0)
 
     def total_cash() -> Decimal:
         return sum(pending_cash.values(), Decimal(0))
@@ -187,6 +284,37 @@ def simulate(
                 continue
             values[t] = positions[t].units * price
         return values
+
+    def apply_vorabpauschale(prices: dict[str, Decimal], trade_date: date) -> None:
+        """Vereinfachte jährliche Vorabpauschale für thesaurierende Fonds
+        (#39, Platzhalter-Basiszins). Wendet sie am Jahresende an (statt
+        exakt am 1. Werktag des Folgejahres) und verbraucht damit den
+        Sparerpauschbetrag DIESES Jahres anteilig, bevor die
+        Dezember-Harvest-Entscheidung (Maßnahme A/B) greift - bewusste
+        Vereinfachung der exakten gesetzlichen Fälligkeit, siehe
+        VORABPAUSCHALE_BASISZINS_PLATZHALTER. Die Deckelung auf die
+        tatsächliche Wertsteigerung nutzt den zu Jahresbeginn erfassten
+        Portfoliowert (wert_jahresbeginn) gegen den aktuellen Wert dieser
+        Zeile als Näherung für den Jahresendwert."""
+        pre_values = current_values(prices)
+        for t in tickers:
+            if not _thesaurierend(t):
+                continue
+            start_wert = wert_jahresbeginn.get(t)
+            pos = positions[t]
+            if not start_wert or pos.units <= 0:
+                continue
+            aktueller_wert = pre_values.get(t, Decimal(0))
+            wertsteigerung = max(Decimal(0), aktueller_wert - start_wert)
+            vorabpauschale = min(
+                start_wert * VORABPAUSCHALE_BASISZINS_PLATZHALTER * VORABPAUSCHALE_FAKTOR, wertsteigerung
+            )
+            if vorabpauschale <= 0:
+                continue
+            process_realized_gain(vorabpauschale, t)
+            # Die gesamte (nicht nur die versteuerte) Vorabpauschale hebt die
+            # Kostenbasis an - sie gilt als fiktiv reinvestierte Ausschüttung.
+            pos.cost_total += vorabpauschale
 
     def rebalance_to_targets(
         prices: dict[str, Decimal], trade_date: date, reason: str, weights: dict[str, Decimal]
@@ -211,20 +339,24 @@ def simulate(
                 if units_to_sell <= 0:
                     continue
                 proceeds = units_to_sell * price
+                avg_kauf_tag = pos.avg_kauf_tag_ordinal()
                 cost_removed = pos.avg_cost() * units_to_sell
+                tage_removed = avg_kauf_tag * units_to_sell
                 realized_gain = proceeds - cost_removed - gebuehr
                 pos.units -= units_to_sell
                 pos.cost_total -= cost_removed
+                pos.kauf_tage_gewichtet -= tage_removed
                 trades.append(
                     Trade(trade_date, t, "sell", units_to_sell, price, gebuehr, realized_gain, reason)
                 )
-                process_realized_gain(realized_gain)
+                process_gain_for_sale(t, trade_date, avg_kauf_tag, realized_gain)
                 executed = True
             else:
                 buy_value = diff
                 units_to_buy = buy_value / price
                 pos.units += units_to_buy
                 pos.cost_total += buy_value + gebuehr
+                pos.kauf_tage_gewichtet += units_to_buy * Decimal(trade_date.toordinal())
                 trades.append(
                     Trade(trade_date, t, "buy", units_to_buy, price, gebuehr, None, reason)
                 )
@@ -240,6 +372,11 @@ def simulate(
             price = prices.get(t)
             pos = positions[t]
             if price is None or pos.units <= 0:
+                continue
+            if _spekulationsfrist_tage(t) is not None:
+                # Unterliegt der Spekulationsfrist (#37), nicht dem
+                # Sparerpauschbetrag - diese Maßnahme optimiert ausschließlich
+                # den Abgeltungsteuer-Topf.
                 continue
             unrealized = pos.units * price - pos.cost_total
             if unrealized > 0:
@@ -264,19 +401,22 @@ def simulate(
                 continue
             proceeds = units_to_sell * price
             cost_removed = avg_cost * units_to_sell
+            tage_removed = pos.avg_kauf_tag_ordinal() * units_to_sell
             realized_gain = proceeds - cost_removed - gebuehr
             pos.units -= units_to_sell
             pos.cost_total -= cost_removed
+            pos.kauf_tage_gewichtet -= tage_removed
             trades.append(
                 Trade(trade_date, t, "sell", units_to_sell, price, gebuehr, realized_gain, "freibetrag_gewinnmitnahme")
             )
-            process_realized_gain(realized_gain)
+            process_realized_gain(realized_gain, t)
             executed = True
 
             # sofortiger Rückkauf zum selben Kurs, um die Marktexponierung zu
             # erhalten - hebt die Kostenbasis steuerfrei an.
             pos.units += units_to_sell
             pos.cost_total += proceeds + gebuehr
+            pos.kauf_tage_gewichtet += units_to_sell * Decimal(trade_date.toordinal())
             trades.append(
                 Trade(trade_date, t, "buy", units_to_sell, price, gebuehr, None, "freibetrag_gewinnmitnahme_rebuy")
             )
@@ -291,6 +431,11 @@ def simulate(
             price = prices.get(t)
             pos = positions[t]
             if price is None or pos.units <= 0:
+                continue
+            if _spekulationsfrist_tage(t) is not None:
+                # Unterliegt der Spekulationsfrist (#37), nicht dem
+                # Sparerpauschbetrag - diese Maßnahme optimiert ausschließlich
+                # den Abgeltungsteuer-Topf.
                 continue
             unrealized = pos.units * price - pos.cost_total
             if unrealized < 0:
@@ -321,19 +466,22 @@ def simulate(
             units_to_sell = min(units_needed, pos.units)
             proceeds = units_to_sell * price
             cost_removed = avg_cost * units_to_sell
+            tage_removed = pos.avg_kauf_tag_ordinal() * units_to_sell
             realized_gain = proceeds - cost_removed - gebuehr
             pos.units -= units_to_sell
             pos.cost_total -= cost_removed
+            pos.kauf_tage_gewichtet -= tage_removed
             trades.append(
                 Trade(trade_date, t, "sell", units_to_sell, price, gebuehr, realized_gain, "tax_loss_harvest")
             )
-            process_realized_gain(realized_gain)
+            process_realized_gain(realized_gain, t)
             harvested += -realized_gain
             executed = True
 
             # sofortiger Rückkauf zum selben Kurs, um die Marktexponierung zu erhalten
             pos.units += units_to_sell
             pos.cost_total += proceeds + gebuehr
+            pos.kauf_tage_gewichtet += units_to_sell * Decimal(trade_date.toordinal())
             trades.append(
                 Trade(trade_date, t, "buy", units_to_sell, price, gebuehr, None, "tax_loss_harvest_rebuy")
             )
@@ -379,6 +527,7 @@ def simulate(
                 units = buy_value / price
                 positions[t].units = units
                 positions[t].cost_total = buy_value
+                positions[t].kauf_tage_gewichtet = units * Decimal(row.date.toordinal())
                 trades.append(Trade(row.date, t, "buy", units, price, gebuehr, None, "initial_buy"))
         else:
             for t in tickers:
@@ -388,6 +537,7 @@ def simulate(
                     units = buy_value / price
                     positions[t].units += units
                     positions[t].cost_total += buy_value
+                    positions[t].kauf_tage_gewichtet += units * Decimal(row.date.toordinal())
                     trades.append(
                         Trade(row.date, t, "buy", units, price, Decimal(0), None, "delayed_initial_buy")
                     )
@@ -414,6 +564,9 @@ def simulate(
                     if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
                         last_rebalance_date = row.date
 
+        if opt.besteuerung and row.date in harvest_dates:
+            apply_vorabpauschale(prices, row.date)
+
         if opt.steueroptimierung and row.date in harvest_dates:
             if freibetrag_verbleibend > 0:
                 if december_gewinnmitnahme(prices, row.date):
@@ -424,6 +577,9 @@ def simulate(
 
         values = current_values(prices)
         total_value = sum(values.values(), Decimal(0)) + total_cash()
+        if wert_jahresbeginn_jahr != row.date.year:
+            wert_jahresbeginn = {t: values.get(t, Decimal(0)) for t in tickers if _thesaurierend(t)}
+            wert_jahresbeginn_jahr = row.date.year
         ticker_weights = {
             t: (values.get(t, Decimal(0)) / total_value if total_value > 0 else Decimal(0)) for t in tickers
         }

--- a/src/boersenspiel/instruments.py
+++ b/src/boersenspiel/instruments.py
@@ -8,6 +8,7 @@ diese Datei unverändert, egal welche Kursquelle gerade aktiv ist.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 
 
 @dataclass(frozen=True)
@@ -15,18 +16,65 @@ class Instrument:
     ticker: str
     name: str
     isin: str | None
+    # Teilfreistellungsquote nach § 20 InvStG (30% für Aktienfonds mit >51%
+    # Aktienquote, 0% für Renten-/Misch-/Rohstofffonds, physische Edelmetalle
+    # und Einzelaktien, die keinem Fondsprivileg unterliegen). Siehe #38.
+    teilfreistellung: Decimal = Decimal("0")
+    # Thesaurierend (True) -> unterliegt der jährlichen Vorabpauschale (#39).
+    # Bewusst als Annahme markiert, wo die Ausschüttungsart nicht am Namen
+    # erkennbar ist (siehe #39-Kommentar "vermutlich auch ...") - noch nicht
+    # gegen den Fondsprospekt verifiziert.
+    thesaurierend: bool = False
+    # Gesetzt (Anzahl Tage), wenn das Instrument statt der Abgeltungsteuer der
+    # Spekulationsfrist für private Veräußerungsgeschäfte (§ 23 EStG)
+    # unterliegt - aktuell nur Kryptowährungen (365 Tage). None = normales
+    # Abgeltungsteuer-Regime. Siehe #37.
+    spekulationsfrist_tage: int | None = None
 
+
+# Teilfreistellungsquote für Aktienfonds-ETFs (>51% Aktienquote) nach § 20 InvStG.
+_TEILFREISTELLUNG_AKTIENFONDS = Decimal("0.30")
 
 INSTRUMENTS: dict[str, Instrument] = {
     i.ticker: i
     for i in [
-        Instrument("EUNL", "MSCI World ETF (iShares Core, thes.)", "IE00B4L5Y983"),
-        Instrument("EUNA", "Global Aggregate Bond ETF (iShares Core, EUR hedged)", "IE00BDBRDM35"),
+        Instrument(
+            "EUNL",
+            "MSCI World ETF (iShares Core, thes.)",
+            "IE00B4L5Y983",
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            thesaurierend=True,
+        ),
+        Instrument(
+            "EUNA",
+            "Global Aggregate Bond ETF (iShares Core, EUR hedged)",
+            "IE00BDBRDM35",
+            # Rentenfonds - keine Teilfreistellung (nur Aktienfonds).
+            thesaurierend=True,
+        ),
         Instrument("4GLD", "Xetra-Gold", "DE000A0S9GB0"),
-        Instrument("LYMS", "Nasdaq-100 ETF (Amundi Core, synthetisch)", "LU1829221024"),
-        Instrument("SEMI", "Global Semiconductors ETF (iShares)", "IE000I8KRLL9"),
-        Instrument("EIMI", "EM IMI ETF (iShares Core)", "IE00BKM4GZ66"),
-        Instrument("BTC-EUR", "Bitcoin", None),
+        Instrument(
+            "LYMS",
+            "Nasdaq-100 ETF (Amundi Core, synthetisch)",
+            "LU1829221024",
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            thesaurierend=True,
+        ),
+        Instrument(
+            "SEMI",
+            "Global Semiconductors ETF (iShares)",
+            "IE000I8KRLL9",
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            thesaurierend=True,
+        ),
+        Instrument(
+            "EIMI",
+            "EM IMI ETF (iShares Core)",
+            "IE00BKM4GZ66",
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            thesaurierend=True,
+        ),
+        Instrument("BTC-EUR", "Bitcoin", None, spekulationsfrist_tage=365),
         # Einzelaktien-Satellit (volatile Einzelwerte, siehe strategies.py
         # BARBELL_20_60_20_SATELLIT) - bewusst gemischt aus hoch-volatilen
         # Wachstumswerten und zwei defensiven Blue-Chips (Coca-Cola, Roche)

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -256,3 +256,24 @@ STRATEGIES_BY_NAME: dict[str, Strategy] = {s.name: s for s in STRATEGIES}
 ORDERGEBUEHR = Decimal("1")  # Euro pro Trade (Kauf wie Verkauf)
 STEUERSATZ = Decimal("0.26375")  # 25% Kapitalertragsteuer + 5,5% Soli darauf
 SPARERPAUSCHBETRAG_PRO_JAHR = Decimal("1000")  # Euro, Reset zu Jahresbeginn
+
+# --- Vorabpauschale für thesaurierende Fonds (#39) --------------------------
+#
+# TODO(#39): Platzhalter-Vereinfachung. Der tatsächliche Basiszins wird vom
+# BMF jährlich neu bekanntgegeben (2020-2026 unterschiedliche Werte) und kann
+# ohne eine autoritative Quelle hier nicht verlässlich hinterlegt werden.
+# Bis echte historische Jahreswerte nachgetragen sind, rechnet die Simulation
+# mit einem konstanten Platzhalter-Basiszins für alle Jahre.
+VORABPAUSCHALE_BASISZINS_PLATZHALTER = Decimal("0.02")  # 2,0% p.a., Platzhalter
+VORABPAUSCHALE_FAKTOR = Decimal("0.70")  # gesetzlich fixierter Anteil des Basisertrags
+
+# --- Spekulationsfrist für private Veräußerungsgeschäfte, z. B. BTC (#37) ---
+#
+# § 23 Abs. 3 Satz 5 EStG: Freigrenze (nicht Freibetrag!) für Gewinne aus
+# privaten Veräußerungsgeschäften innerhalb der Spekulationsfrist - bleibt der
+# Jahresgewinn darunter, bleibt er komplett steuerfrei; wird er überschritten,
+# ist der GESAMTE Gewinn steuerpflichtig (kein Sockelbetrag wie beim
+# Sparerpauschbetrag). Vereinfachung: Besteuerung mit dem pauschalen
+# STEUERSATZ statt dem tatsächlich anzuwendenden persönlichen
+# Einkommensteuersatz (siehe #37-Diskussion).
+SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR = Decimal("1000")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -259,6 +259,122 @@ def test_missing_price_in_first_row_parks_capital_as_cash_and_invests_later():
     assert delayed_buys[0].ticker == "T2"
 
 
+# --- Paket A: Steuerkorrektheit (#37/#38/#39, siehe #46) --------------------
+
+
+def test_teilfreistellung_reduziert_steuerpflichtigen_gewinn_um_30_prozent():
+    # EUNL (Aktienfonds-ETF, 30% Teilfreistellung) vs. 4GLD (kein Fonds, 0%
+    # Teilfreistellung) - sonst exakt dieselben Kurse/Gewichte wie die
+    # SIMPLE_STRATEGY-Fixture oben, damit sich der Effekt isoliert nachrechnen
+    # lässt: derselbe Rebalance-Verkauf, der ohne Teilfreistellung einen
+    # Gewinn von 186,50 ergäbe (siehe test_simple_strategy_...), wird jetzt
+    # nur zu 70% (130,55) gegen den Freibetrag verrechnet.
+    strategy = Strategy(
+        name="Test-Teilfreistellung",
+        startkapital=Decimal("1002"),
+        toepfe=[
+            Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"EUNL": Decimal("1")}),
+            Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"4GLD": Decimal("1")}),
+        ],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("0.5"),
+        rebalancing_schwelle_pp=Decimal("10"),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"EUNL": Decimal("100"), "4GLD": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"EUNL": Decimal("200"), "4GLD": Decimal("50")}),
+    ]
+    result = simulate(rows, strategy)
+
+    assert result.tax_status.freibetrag_verbleibend == Decimal("869.45")
+    assert result.tax_status.kumulierte_steuer == Decimal("0")
+
+
+def test_vorabpauschale_verbraucht_freibetrag_ohne_verkauf():
+    # EUNL ist thesaurierend - am Jahresende (hier: letzte Zeile 2024, mit
+    # Optimierungen(steueroptimierung=False), um den Effekt vom Dezember-
+    # Harvest zu isolieren) greift die vereinfachte Vorabpauschale, obwohl
+    # keine einzige Position verkauft wird.
+    # Wert Jahresbeginn: 9,99 Einheiten * 100 = 999.
+    # Wert an der Harvest-Zeile: 9,99 * 150 = 1498,50 -> Wertsteigerung 499,50.
+    # Vorabpauschale = min(999 * 0,02 * 0,70, 499,50) = 13,986.
+    # Nach 30% Teilfreistellung steuerpflichtig: 13,986 * 0,7 = 9,7902.
+    strategy = Strategy(
+        name="Test-Vorabpauschale",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={"EUNL": Decimal("1")})],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("100"),
+        optimierungen=Optimierungen(steueroptimierung=False),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"EUNL": Decimal("100")}),
+        PriceRow(date(2024, 12, 30), {"EUNL": Decimal("150")}),
+    ]
+    result = simulate(rows, strategy)
+
+    assert result.holdings["EUNL"] == Decimal("9.99")  # keine Trades ausser Initialkauf
+    assert result.tax_status.freibetrag_verbleibend == Decimal("990.2098")
+    assert result.tax_status.kumulierte_steuer == Decimal("0")
+
+
+def test_btc_gewinn_innerhalb_spekulationsfrist_landet_in_eigener_freigrenze():
+    # BTC-EUR (Spekulationsfrist 365 Tage) neben 4GLD (normale Abgeltungsteuer)
+    # - derselbe Rebalance-Verkauf wie in test_simple_strategy_... (Gewinn
+    # 186,50), aber nur 7 Tage Haltedauer: landet im getrennten
+    # Freigrenzen-Topf statt im Sparerpauschbetrag - dieser bleibt
+    # unangetastet bei 1000.
+    strategy = Strategy(
+        name="Test-BTC-innerhalb-Frist",
+        startkapital=Decimal("1002"),
+        toepfe=[
+            Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"BTC-EUR": Decimal("1")}),
+            Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"4GLD": Decimal("1")}),
+        ],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("0.5"),
+        rebalancing_schwelle_pp=Decimal("10"),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"BTC-EUR": Decimal("100"), "4GLD": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"BTC-EUR": Decimal("200"), "4GLD": Decimal("50")}),
+    ]
+    result = simulate(rows, strategy)
+
+    # Der BTC-Gewinn (186,50, unter der 1000€-Freigrenze) bleibt steuerfrei,
+    # verbraucht aber NICHT den Sparerpauschbetrag der Kapitalertraege.
+    assert result.tax_status.freibetrag_verbleibend == Decimal("1000")
+    assert result.tax_status.kumulierte_steuer == Decimal("0")
+
+
+def test_btc_gewinn_nach_ablauf_der_spekulationsfrist_ist_steuerfrei():
+    # Gleicher Rebalance-Mechanismus, aber die BTC-Position wird 367 Tage
+    # gehalten (> 365 Tage Spekulationsfrist) und der Gewinn faellt deutlich
+    # groesser aus (Kurssprung 100 -> 2000) - wuerde er (fehlerhaft) besteuert,
+    # sowohl die Freigrenze als auch der Sparerpauschbetrag wuerden deutlich
+    # sichtbare Steuer ausloesen. Stattdessen bleibt er komplett steuerfrei.
+    strategy = Strategy(
+        name="Test-BTC-ausserhalb-Frist",
+        startkapital=Decimal("1002"),
+        toepfe=[
+            Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"BTC-EUR": Decimal("1")}),
+            Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"4GLD": Decimal("1")}),
+        ],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("0.5"),
+        rebalancing_schwelle_pp=Decimal("10"),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"BTC-EUR": Decimal("100"), "4GLD": Decimal("100")}),
+        PriceRow(date(2025, 1, 2), {"BTC-EUR": Decimal("2000"), "4GLD": Decimal("100")}),
+    ]
+    result = simulate(rows, strategy)
+
+    assert result.tax_status.kumulierte_steuer == Decimal("0")
+    assert result.tax_status.freibetrag_verbleibend == Decimal("1000")
+
+
 def test_missing_price_in_later_row_values_with_last_known_price():
     # T2 fehlt in der mittleren Zeile - die Position darf nicht aus der Summe
     # herausfallen, sondern wird mit dem letzten bekannten Kurs bewertet.


### PR DESCRIPTION
## Summary

Setzt Paket A aus #46 vollständig um (alle drei zugehörigen Issues):

- **#38 Teilfreistellung**: Realisierte Gewinne/Verluste auf Aktienfonds-ETFs (EUNL, LYMS, SEMI, EIMI) werden nach § 20 InvStG symmetrisch um 30% reduziert, bevor sie gegen Freibetrag/Verlustvortrag verrechnet werden. Bond-ETF (EUNA), physisches Gold (4GLD), Einzelaktien und BTC-EUR bekommen keine Teilfreistellung (kein Fondsprivileg).
- **#39 Vorabpauschale**: Vereinfachte jährliche Vorabpauschale für thesaurierende Fonds (EUNL, EUNA, LYMS, SEMI, EIMI), gedeckelt auf die tatsächliche Wertsteigerung des Jahres, angewendet an der Harvest-Zeile vor der Dezember-Harvest-Entscheidung (Maßnahme A/B) - verbraucht den Sparerpauschbetrag anteilig, auch ohne jeden Verkauf. **Bewusster Platzhalter**: Der jährlich wechselnde BMF-Basiszins ist als Konstante (`VORABPAUSCHALE_BASISZINS_PLATZHALTER`) hinterlegt und als TODO markiert, bis echte historische Werte nachgetragen werden können (wie in der Issue-Diskussion mit dem Owner vereinbart).
- **#37 BTC-Spekulationsfrist**: BTC-EUR unterliegt jetzt § 23 EStG statt der Abgeltungsteuer. Ein vereinfachtes, stückzahlgewichtetes durchschnittliches Kaufdatum je Position (analog zur bestehenden Durchschnittskosten-Methode, kein echtes Per-Lot-Tracking - wie in der Issue-Diskussion vereinbart) entscheidet pro Verkauf: über 365 Tage gehalten → komplett steuerfrei; sonst → eigener, vom Sparerpauschbetrag getrennter Freigrenzen-Topf (§ 23 Abs. 3 S. 5 EStG - Kippgrenze, nicht Sockelbetrag: unterhalb steuerfrei, oberhalb der GESAMTE Jahresgewinn steuerpflichtig). BTC-EUR ist deshalb auch aus den Dezember-Harvest-Kandidatenlisten ausgeschlossen, da diese ausschließlich den Abgeltungsteuer-Topf optimieren.

Alle drei Korrekturen sind Instrument-Eigenschaften (`instruments.py`), nicht über die `Optimierungen`-Schalter aktivierbar/deaktivierbar - es handelt sich um Modellfehler-Korrekturen, nicht um optionale Mechanismen.

## Test plan

- 4 neue, von Hand nachgerechnete Tests in `tests/test_engine.py` (je einer für Teilfreistellung, Vorabpauschale, BTC innerhalb der Frist, BTC außerhalb der Frist)
- Alle 130 bestehenden Tests bleiben unverändert grün - die dortigen Test-Fixtures nutzen synthetische Ticker (T1/T2), die nicht in `INSTRUMENTS` vorkommen und dadurch automatisch neutrale Default-Werte (keine Korrektur) bekommen
- `pytest -q`: 134 passed
- `python scripts/build_dashboard.py` lokal erfolgreich durchgelaufen (End-to-End-Smoke-Test mit allen 17 Instrumenten)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYpfzE45n6byGzceYX8Cwu)_