### PR TITLE
Doc-Sync: #27/#28-Erweiterungen in CLAUDE.md/README nachtragen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,17 @@ inkrementell fortgeschrieben).
   abgegebenen Voten** — widersprüchliche Signale (Mai-Ausstieg vs. Dip-Kauf)
   heben sich damit teilweise auf, statt dass eine Regel die anderen
   überstimmt; "Buy & Hold" votiert als einzige immer (für die normale Quote)
-  und wirkt so als dämpfender Anker. "Verluste begrenzen" ist die einzige
+  und wirkt so als dämpfender Anker — dieser Mechanismus-Unterschied zum
+  Solo-Szenario (dort schaltet "Buy & Hold" stattdessen komplett das
+  Rebalancing ab) steht seit #27 auch als `beschreibung` auf der
+  `BUY_AND_HOLD`-Detailseite, nachdem der Owner entschieden hat, dass die
+  Mechanik selbst unverändert bleibt. "Verluste begrenzen" ist die einzige
   Overlay-Regel und läuft nach Phase 1. Der Einzeleffekt jedes Spruchs kommt
   über `Strategy.beitraege` (Leave-one-out) ins Dashboard; (2) Charttechnik — SMA-Crossover (Golden/Death Cross,
-  10/40 Wochen) auf dem MSCI-World-ETF; (3) weitere Ansätze — Momentum-/
+  10/40 Wochen) auf dem MSCI-World-ETF, seit #28 zusätzlich als eigenes
+  Szenario `CHART_SMA_CROSSOVER_KURZ` mit verkürztem Zeitraum (4/20 Wochen ≈
+  21/100 Handelstage statt 50/200, gleiche 5-Handelstage/Woche-Näherung wie
+  beim Original) für ein reaktionsschnelleres Signal; (3) weitere Ansätze — Momentum-/
   Relative-Stärke-Rotation (Top-2 der Wachstums-Instrumente nach
   12-Wochen-Trailing-Rendite), volatilitätsbasierte Aktienquote (50–90%
   Wachstum je nach realisierter EUNL-Volatilität) und Cost-Average-Einstieg
@@ -340,7 +347,8 @@ steuerfrei, andernfalls wäre eine deutliche Steuer sichtbar).
 Provider-API vollständig (kein echter Netzwerkzugriff in Tests).
 `tests/test_scenarios.py` verifiziert die generische `gewichte_fn`-Mechanik
 in der Engine anhand handgerechneter Werte sowie die konkreten Szenarien
-(Sell in May, Buy & Hold, SMA-Crossover) als End-to-End-Smoke-Tests. Für das
+(Sell in May, Buy & Hold, SMA-Crossover inkl. der verkürzten 4/20-Wochen-
+Variante aus #28) als End-to-End-Smoke-Tests. Für das
 kombinierte Börsenweisheiten-Szenario sind die gemittelten Quoten handgerechnet
 (Mai → 40%, Dezember → 87,5%) sowie geprüft, dass die Gewichte in jeder Woche zu
 1 summieren und jede Leave-one-out-Variante genau eine Weisheit weglässt.

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ pass – parameters are not optimized or backtested. Starting capital is
 | Scenario | Rule |
 |---|---|
 | Sell in May | Defensive (100% safety) May–September, normal 20/80 split October–April |
-| Buy & Hold | Starting allocation is never actively rebalanced (rebalancing threshold effectively unreachable); December tax optimization stays active as for all strategies |
+| Buy & Hold | Starting allocation is never actively rebalanced (rebalancing threshold effectively unreachable); December tax optimization stays active as for all strategies. In the combined "Market Wisdoms" scenario below it acts differently: it always votes for the normal 80% share as a dampening anchor, since "don't rebalance at all" can't itself be expressed as a share vote (clarified in [#27](https://github.com/S540d/Boersenspiel/issues/27)) |
 | Santa Claus Rally | Growth share set to 95% in December/January, normal split otherwise |
 | Buy the Dip | Growth share set to 95% as soon as the MSCI World ETF (EUNL) trades more than 10% below its 20-week high |
 | Cut Your Losses | Trailing stop per growth instrument: if one falls more than 15% below its own 20-week high, only that instrument is set to 0% (rest of the portfolio unchanged) |
@@ -330,6 +330,7 @@ return — it's a marginal, not an additive decomposition.
 | Scenario | Rule |
 |---|---|
 | SMA Crossover (10/40 weeks) | Golden Cross/Death Cross on the MSCI World ETF: 10-week SMA below 40-week SMA → defensive (100% safety), normal split otherwise |
+| SMA Crossover (4/20 weeks) | Same Golden Cross/Death Cross rule with a shorter window (4/20 weeks ≈ 21/100 trading days instead of 50/200) for a more responsive signal ([#28](https://github.com/S540d/Boersenspiel/issues/28)) |
 
 **Other approaches**
 


### PR DESCRIPTION
## Summary
Die Code-Änderungen aus #27 (Beschreibung auf der Buy & Hold-Detailseite) und #28 (neues Szenario `CHART_SMA_CROSSOVER_KURZ`, 4/20 statt 10/40 Wochen) waren bereits über PR #48 gemergt, die zugehörige Dokumentation in `CLAUDE.md` und `README.md` fehlte aber noch. Dieser PR trägt das nach.

Kein Code geändert, nur `CLAUDE.md` (Architektur-/Szenario-Beschreibung, Testabschnitt) und `README.md` (Szenario-Tabellen "Market Wisdoms"/"Chart patterns").

## Test plan
- `pytest -q` (136 passed, unverändert zum Stand vor diesem PR — reine Doku-Änderung)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qp8tf7WeWTzWeSVq7Evc58)_