### PR TITLE
README/CLAUDE.md: Verweis auf externes Pflichtenheft-Dokument entfernen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Virtuelles Portfolio-Dashboard nach einer Barbell-Strategie (siehe
-`Pflichtenheft_PortfolioProjekt_v2.md` für die ursprünglichen Anforderungen —
-die Datei liegt bewusst außerhalb dieses Repos, siehe Hinweis in der README).
-Wöchentlicher Kursabruf via GitHub Actions, Kurshistorie als CSV im Repo,
+Virtuelles Portfolio-Dashboard nach einer Barbell-Strategie, basierend auf
+einem ursprünglichen Anforderungsdokument aus der frühen Planungsphase
+(nicht Teil dieses Repos). Wöchentlicher Kursabruf via GitHub Actions, Kurshistorie als CSV im Repo,
 statisches Dashboard (Chart.js) auf GitHub Pages. Default-Branch ist `main`
 (ursprünglich hieß er `claude/pflichtenheft-umsetzung-planen-6kf05s`, da das
 Repo leer angelegt wurde, und wurde nachträglich zu `main` umbenannt).

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 **📊 Dashboard:** [s540d.github.io/Boersenspiel](https://s540d.github.io/Boersenspiel/)
 
-Virtual portfolio following a barbell strategy, based on the requirements
-document `Pflichtenheft_PortfolioProjekt_v2.md` (deliberately **not** part of
-this repository, see note below). The technical implementation intentionally
-deviates from that document in a few places (see
+Virtual portfolio following a barbell strategy, based on an original project
+requirements document from early planning. The technical implementation
+intentionally deviates from that document in a few places (see
 [Deviations from the requirements](#deviations-from-the-requirements) below):
 weekly instead of daily price fetching, CSV persistence in the Git repo
 instead of a Google Sheet, output as a static dashboard on GitHub Pages.
@@ -475,12 +474,3 @@ pytest -q
 Rebalancing threshold, order fees, and tax logic (26.375%, €1,000 tax-free
 allowance, loss carryforward) were carried over from the requirements
 document unchanged.
-
-> **Note on the requirements document:** `Pflichtenheft_PortfolioProjekt_v2.md`
-> is deliberately **not** checked into this repository (it lives elsewhere,
-> e.g. in Google Drive/Confluence from the original planning discussion) and
-> therefore can't be linked here. The table above and the modeling decisions
-> further up summarize the content relevant to the implementation; for
-> detailed questions about the exact wording (e.g. about the harvest
-> algorithm, see [#13](https://github.com/S540d/Boersenspiel/issues/13)),
-> the external document must be consulted.


### PR DESCRIPTION
## Summary
- Entfernt den Verweis auf `Pflichtenheft_PortfolioProjekt_v2.md` aus README.md und CLAUDE.md (Dateiname/-verweis, nicht die inhaltliche Dokumentation der Abweichungen davon)
- Die Einleitung sowie der "Deviations from the requirements"-Abschnitt bleiben inhaltlich erhalten, verweisen aber nicht mehr auf den konkreten, nicht im Repo enthaltenen Dateinamen
- Kein Code geändert

## Test plan
- `pytest -q` (136 passed, unverändert – reine Doku-Änderung)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qp8tf7WeWTzWeSVq7Evc58)_