### PR TITLE
Risikoadjustierte Kennzahlen (Sharpe/Sortino) + Walk-Forward-Robustheit, Backfill-Zeitraum erweitert

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -15,9 +15,9 @@ on:
   workflow_dispatch:
     inputs:
       years:
-        description: "Wie viele Jahre Historie zurueck"
+        description: "Wie viele Jahre Historie zurueck (nur untere Schranke - laeuft immer bis zur aeltesten verfuegbaren Historie je Ticker)"
         required: true
-        default: "5"
+        default: "20"
       confirm:
         description: "Ersetzt data/price_history.csv KOMPLETT. Zum Bestaetigen 'REPLACE' eintippen."
         required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ pytest tests/test_engine.py::test_simple_strategy_end_to_end_exact_values -q  # 
 
 python scripts/run_fetch.py                        # Kursabruf via Alpha Vantage (benötigt ALPHAVANTAGE_API_KEY env var)
 python scripts/record_prices.py --date 2026-08-17 --prices '{"EUNL": 82.1, ...}'  # manueller Kurseintrag
-python scripts/backfill_history.py --years 5        # einmaliger historischer Backfill (ersetzt price_history.csv, ~18 API-Requests)
+python scripts/backfill_history.py --years 20       # einmaliger historischer Backfill (ersetzt price_history.csv, ~18 API-Requests)
 python scripts/build_dashboard.py                  # baut docs/index.html aus data/price_history.csv (Strategien + Szenarien)
 python scripts/build_dashboard.py --strategy "Barbell 20/80"  # nur eine Strategie/ein Szenario rendern
 ```
@@ -260,6 +260,31 @@ inkrementell fortgeschrieben).
   eingefroren, aus `fetch_log.csv` via `read_fetch_log()`).
   `build_dashboard()` nimmt dafür optional `fetch_log` entgegen;
   `scripts/build_dashboard.py` übergibt `read_fetch_log()` standardmäßig.
+  Zwei weitere reine Anzeige-Ableitungen zur Fundiertheit von Invest-
+  Entscheidungen: `_sharpe_ratio()`/`_sortino_ratio()` ergänzen die
+  Übersichtstabelle um risikoadjustierte Rendite (annualisierte
+  Überrendite ÷ annualisierte Volatilität bzw. ÷ Downside-Deviation nur der
+  Verlustwochen, `_downside_deviation()`) — eine hohe Rendite bei ebenso
+  hoher Streuung ist kein besseres Ergebnis als eine niedrigere Rendite bei
+  wenig Risiko. `_RISIKOFREIER_ZINS_PLATZHALTER = 0.0` ist ein bewusster
+  Platzhalter nach demselben Muster wie
+  `VORABPAUSCHALE_BASISZINS_PLATZHALTER`, kein echter Referenzzins. Jede
+  Detailseite bekommt zusätzlich (sofern genug Kurshistorie vorliegt) den
+  Abschnitt "Robustheit über Teilperioden (Walk-Forward)"
+  (`_walk_forward_segmente()`): die Kurshistorie wird in bis zu drei
+  gleich große, aufeinanderfolgende Zeiträume geteilt (mindestens 10
+  Wochen je Segment, sonst entfällt der Abschnitt komplett — bei
+  `_rows()`-großen Test-Fixtures z. B.), und `engine.simulate()` läuft je
+  Segment unabhängig mit frischem Startkapital (keine fortgeführte
+  Position). Da die Regeln in `scenarios.py` nicht an Daten gefittete
+  Parameter haben, ist klassisches Train/Test-Splitting nicht anwendbar;
+  stattdessen macht dieser Abschnitt sichtbar, ob eine Strategie über
+  verschiedene Marktphasen hinweg ähnlich abschneidet oder ob die
+  Gesamtrendite nur aus einer einzelnen guten (oder schlechten) Teilperiode
+  stammt — relevant, weil alle Szenarien laut ihrer eigenen Beschreibung
+  "erster Ansatz, nicht optimiert/gebacktestet" auf einer einzigen, noch
+  kurzen Kurshistorie sind. Die Schwankungsbreite (größte minus kleinste
+  Perioden-Rendite) steht als Kennzahl über der Tabelle.
 - `learnings.py` — leitet die Sektion "Key Learnings" (ganz oben im Dashboard)
   bei jedem Build neu aus den Strategie-Views ab. **Keine hinterlegten
   Erkenntnis-Texte:** fest ist nur die Fragestellung je Regel (reine Funktion
@@ -311,7 +336,18 @@ Ticker-Abrufen, damit ein Fehlschlag einen statt 17 Requests kostet. Für den La
 Workflow `.github/workflows/backfill.yml` (nutzt das Repo-Secret, verlangt
 `confirm=REPLACE`, schreibt eine Plausibilitätsprüfung in die Job-Summary) -
 nicht am selben Tag wie den wöchentlichen Kursabruf starten (18 + 18
-Requests > Tageslimit 25).
+Requests > Tageslimit 25). `--years` ist nur eine untere Schranke, die
+`AlphaVantageSource.fetch_weekly_history()`/`fetch_crypto_weekly_history()`
+zum Filtern der von Alpha Vantage gelieferten Zeitreihe nutzen - ein Wert,
+der weiter zurückliegt als die tatsächlich verfügbare Historie eines
+Tickers, liefert einfach dessen komplette verfügbare Historie statt eines
+Fehlers. Default (Skript und Workflow-Input) ist deshalb bewusst 20 statt
+5: zielt auf "so weit wie möglich" statt auf einen Zeitraum, der
+zur jüngsten Satellit-Position passt (Rivian, IPO November 2021) - ältere
+Instrumente (ETFs, Coca-Cola, Roche) haben bei Alpha Vantage oft 15-20+
+Jahre Historie. Für Ticker ohne Kurs in einer früh liegenden Woche trägt
+`history_store.record_week()` ohnehin "missing" statt eines erfundenen
+Werts ein, dieselbe Lücken-Behandlung wie beim laufenden Live-Abruf.
 
 ### GitHub Actions (`.github/workflows/weekly-update.yml`)
 
@@ -362,7 +398,14 @@ gegen handgerechnete Kursreihen (konstant/monoton/auf-und-ab), die
 Konzentrationswarnung anhand einer Strategie mit einem einzelnen Topf (in
 dem der Topf-Trigger nie greift, weil der Topf immer 100% hält, während
 sich die Instrumente darin frei auseinanderentwickeln) sowie die
-Eingefroren-Markierung anhand eines übergebenen `fetch_log`.
+Eingefroren-Markierung anhand eines übergebenen `fetch_log`. Zusätzlich:
+Sharpe/Sortino gegen handgerechnete Grenzfälle (konstante Reihe → 0.0,
+nur Gewinnwochen → Sortino bewusst 0.0 statt undefiniert,
+`_downside_deviation()` ignoriert nachweislich Streuung nach oben) sowie
+`_walk_forward_segmente()` gegen eine lange synthetische Kursreihe (leer
+bei zu wenig Wochen, exakt drei Segmente bei ausreichender Historie) und
+End-to-End, dass der Detailseiten-Abschnitt "Robustheit über Teilperioden"
+nur bei genug Kurshistorie erscheint.
 `tests/test_learnings.py` fährt jede Learning-Regel gegen
 konstruierte Views mit bekannten Zahlen und prüft, dass die Aussagen den
 Daten folgen statt fest zu sein (inkl. Gegenprobe mit umgedrehter

--- a/scripts/backfill_history.py
+++ b/scripts/backfill_history.py
@@ -17,8 +17,20 @@ Krypto) - passt in das taegliche Alpha-Vantage-Free-Tier-Limit von 25, sollte
 aber NICHT mehrfach am selben Tag laufen (das Limit gilt pro Tag und API-Key,
 nicht pro Skriptlauf).
 
+``--years`` ist nur eine untere Schranke, die an die Source durchgereicht wird
+(``_parse_weekly_close_series``/``fetch_crypto_weekly_history`` filtern die von
+Alpha Vantage gelieferte Zeitreihe auf Kurse ab diesem Datum) - ein Wert, der
+weiter zurueckliegt als die tatsaechlich verfuegbare Historie eines Tickers,
+liefert einfach dessen gesamte verfuegbare Historie statt eines Fehlers. Der
+Default zielt deshalb bewusst auf "so weit wie moeglich" statt auf einen
+Zeitraum, der zur juengsten Position (Rivian, IPO November 2021) passt -
+aeltere Instrumente (ETFs, Einzelaktien wie Coca-Cola/Roche) haben oft
+15-20+ Jahre Historie bei Alpha Vantage. Fuer Ticker ohne Kurs in einer frueh
+liegenden Woche traegt ``history_store.record_week`` ohnehin "missing" statt
+eines erfundenen Werts ein.
+
 Nutzung:
-    python scripts/backfill_history.py --years 5
+    python scripts/backfill_history.py --years 20
 """
 
 from __future__ import annotations
@@ -150,7 +162,12 @@ def write_backfilled_history(per_ticker: dict[str, dict[date, float]], data_dir:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--years", type=int, default=5, help="Wie viele Jahre historischer Daten (Default: 5)")
+    parser.add_argument(
+        "--years",
+        type=int,
+        default=20,
+        help="Wie viele Jahre historischer Daten, nur untere Schranke (Default: 20 = so weit wie verfuegbar)",
+    )
     parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR, help="Zielverzeichnis (Default: data/)")
     args = parser.parse_args()
 

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -102,6 +102,97 @@ def _max_drawdown_pct(total_values: list[float]) -> float:
     return max_dd * 100
 
 
+# --- Risikoadjustierte Kennzahlen: Sharpe & Sortino -------------------------------
+#
+# Ergaenzen Rendite/Volatilitaet/Max-Drawdown um ein Rendite-pro-Risiko-Verhaeltnis:
+# eine hohe annualisierte Rendite bei ebenso hoher Volatilitaet (bzw. bei vielen
+# schweren Verlustwochen) ist kein besseres Ergebnis als eine niedrigere Rendite bei
+# geringem Risiko - genau das zeigt die nominale Rendite allein nicht.
+#
+# Bewusster Platzhalter (analog VORABPAUSCHALE_BASISZINS_PLATZHALTER in
+# strategies.py): ein echter risikofreier Zins (z. B. laufzeitnahe
+# Bundesanleihen-Rendite) ist hier noch nicht hinterlegt, 0% ist eine
+# vereinfachende Annahme.
+_RISIKOFREIER_ZINS_PLATZHALTER = 0.0
+
+
+def _sharpe_ratio(total_values: list[float]) -> float:
+    """Annualisierte Ueberrendite je Einheit annualisierter Volatilitaet
+    (Standardabweichung aller Wochenrenditen, positive wie negative)."""
+    renditen = _wochenrenditen(total_values)
+    if len(renditen) < 2:
+        return 0.0
+    std_pct = statistics.pstdev(renditen) * (52**0.5)
+    if std_pct == 0:
+        return 0.0
+    ann_mean_pct = statistics.fmean(renditen) * 52
+    return (ann_mean_pct - _RISIKOFREIER_ZINS_PLATZHALTER) / std_pct
+
+
+def _downside_deviation(renditen: list[float], ziel: float = 0.0) -> float:
+    """Wurzel des mittleren quadrierten Unterschreitens von ``ziel`` ueber ALLE
+    Wochen (nicht nur die negativen) - Standarddefinition der Sortino-Kennzahl."""
+    if not renditen:
+        return 0.0
+    quadrate = [min(r - ziel, 0.0) ** 2 for r in renditen]
+    return (sum(quadrate) / len(quadrate)) ** 0.5
+
+
+def _sortino_ratio(total_values: list[float]) -> float:
+    """Wie ``_sharpe_ratio``, aber nur Verlustwochen fliessen ins Risikomass ein -
+    Streuung nach oben (Gewinnwochen) wird nicht als Risiko gewertet."""
+    renditen = _wochenrenditen(total_values)
+    if len(renditen) < 2:
+        return 0.0
+    downside_pct = _downside_deviation(renditen) * (52**0.5)
+    if downside_pct == 0:
+        return 0.0
+    ann_mean_pct = statistics.fmean(renditen) * 52
+    return (ann_mean_pct - _RISIKOFREIER_ZINS_PLATZHALTER) / downside_pct
+
+
+# --- Walk-Forward-Robustheit ueber Teilperioden -----------------------------------
+#
+# Alle Szenarien in scenarios.py sind bislang "erster Ansatz, nicht optimiert" auf
+# EINER einzigen, kurzen Kurshistorie durchgerechnet - eine gut aussehende Rendite
+# koennte dort ebenso gut Zufall/Overfitting auf genau diesen Zeitraum sein wie ein
+# echter Vorteil. Da die Regeln selbst keine an Daten gefitteten Parameter haben
+# (kein Training im eigentlichen Sinn), ist eine klassische Train/Test-Aufteilung
+# nicht anwendbar; stattdessen prueft dieser Abschnitt Konsistenz ueber die Zeit:
+# dieselbe Strategie wird unabhaengig auf mehreren aufeinanderfolgenden Teilperioden
+# JEWEILS FRISCH (eigenes Startkapital, keine fortgefuehrte Position) simuliert. Eine
+# Strategie, die nur in einer Teilperiode stark performt und in den anderen schwach
+# oder negativ, ist weniger vertrauenswuerdig als eine mit aehnlicher Rendite in
+# jedem Segment - auch wenn die Gesamtrendite ueber die volle Historie identisch
+# waere. Reine Anzeige-Ableitung: ruft engine.simulate() mehrfach mit Ausschnitten
+# derselben Kurshistorie auf, keine eigene Berechnungslogik.
+_WALK_FORWARD_SEGMENTE = 3
+_WALK_FORWARD_MIN_WOCHEN_PRO_SEGMENT = 10
+
+
+def _walk_forward_segmente(rows: list[PriceRow], strategy: Strategy) -> list[dict]:
+    max_segmente = max(1, len(rows) // _WALK_FORWARD_MIN_WOCHEN_PRO_SEGMENT)
+    segmente = min(_WALK_FORWARD_SEGMENTE, max_segmente)
+    if segmente < 2:
+        return []
+
+    grenzen = [round(i * len(rows) / segmente) for i in range(segmente + 1)]
+    ergebnisse = []
+    for start, ende in zip(grenzen, grenzen[1:]):
+        segment_rows = rows[start:ende]
+        if len(segment_rows) < 2:
+            continue
+        rendite_pct = _rendite_pct(simulate(segment_rows, strategy), strategy)
+        ergebnisse.append(
+            {
+                "label": f"{segment_rows[0].date.isoformat()} – {segment_rows[-1].date.isoformat()}",
+                "rendite_pct": _f(rendite_pct),
+                "rendite_label": f"{rendite_pct:+.2f}",
+            }
+        )
+    return ergebnisse
+
+
 # --- Eingefrorene Kurse (#42) ------------------------------------------------------
 
 
@@ -215,6 +306,15 @@ def _build_strategy_view(
     rendite_pct = _rendite_pct(result, strategy)
     volatilitaet_pct = _volatilitaet_pct(total_values)
     max_drawdown_pct = _max_drawdown_pct(total_values)
+    sharpe_ratio = _sharpe_ratio(total_values)
+    sortino_ratio = _sortino_ratio(total_values)
+    walk_forward_segmente = _walk_forward_segmente(rows, strategy)
+    walk_forward_spread_pp = (
+        max(seg["rendite_pct"] for seg in walk_forward_segmente)
+        - min(seg["rendite_pct"] for seg in walk_forward_segmente)
+        if walk_forward_segmente
+        else 0.0
+    )
 
     # Leave-one-out: Einzeleffekt jeder Teilregel als Differenz zur Variante ohne sie.
     beitraege = []
@@ -241,6 +341,10 @@ def _build_strategy_view(
         "volatilitaet_label": f"{volatilitaet_pct:.2f}",
         "max_drawdown_pct": max_drawdown_pct,
         "max_drawdown_label": f"{-max_drawdown_pct:.2f}" if max_drawdown_pct else "0.00",
+        "sharpe_ratio": sharpe_ratio,
+        "sharpe_label": f"{sharpe_ratio:.2f}",
+        "sortino_ratio": sortino_ratio,
+        "sortino_label": f"{sortino_ratio:.2f}",
         "labels_json": json.dumps(labels),
         "total_values": total_values,
         "total_values_json": json.dumps(total_values),
@@ -269,6 +373,8 @@ def _build_strategy_view(
         "last_harvest_date": result.last_harvest_date.isoformat() if result.last_harvest_date else "-",
         "beitraege": beitraege,
         "optimierungs_effekte": _optimierungs_effekte(strategy, rows, rendite_pct),
+        "walk_forward_segmente": walk_forward_segmente,
+        "walk_forward_spread_label": f"{walk_forward_spread_pp:.2f}",
     }
 
 

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -48,12 +48,17 @@
       Drawdown (größter Wertverlust vom bisherigen Höchststand) stehen bewusst neben
       der Rendite: eine hohe Rendite bei konzentrierten oder ungetesteten Regeln
       (z. B. Chartsignale) kann mit entsprechend höherem Risiko erkauft sein, das die
-      Rendite allein nicht zeigt.
+      Rendite allein nicht zeigt. Sharpe- und Sortino-Ratio fassen das in eine
+      Rendite-pro-Risiko-Kennzahl: Sharpe teilt die annualisierte Rendite durch die
+      gesamte Streuung, Sortino nur durch die Streuung der Verlustwochen (Streuung
+      nach oben zählt dort nicht als Risiko). Höher ist besser; negativ heißt, das
+      eingegangene Risiko hat sich nicht gelohnt. Ein risikofreier Zins von 0% ist
+      dabei ein bewusster Platzhalter, kein realer Referenzzins.
     </p>
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
     <div class="overflow-x">
       <table class="summary-table">
-        <thead><tr><th>Strategie / Szenario</th><th>Rendite %</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
+        <thead><tr><th>Strategie / Szenario</th><th>Rendite %</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
         <tbody>
         {% for s in summary %}
           <tr>
@@ -61,6 +66,8 @@
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
             <td>{{ s.volatilitaet_label }}</td>
             <td class="{{ 'negative' if s.max_drawdown_pct else '' }}">{{ s.max_drawdown_label }}</td>
+            <td class="{{ 'positive' if s.sharpe_ratio >= 0 else 'negative' }}">{{ s.sharpe_label }}</td>
+            <td class="{{ 'positive' if s.sortino_ratio >= 0 else 'negative' }}">{{ s.sortino_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.gewinn_label }}</td>
             <td>{{ s.total_value }}</td>
           </tr>

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -79,6 +79,34 @@
         </table>
       </div>
     </div>
+    {% if s.walk_forward_segmente %}
+    <div class="beitraege">
+      <h3>Robustheit über Teilperioden (Walk-Forward)</h3>
+      <p class="hint">
+        Dieselbe Strategie unabhängig auf mehreren aufeinanderfolgenden Zeiträumen
+        simuliert - jeweils mit eigenem Startkapital, nicht als eine durchlaufende
+        Position. Zeigt, ob die Rendite über die Zeit einigermaßen konsistent ist
+        oder nur in einem einzelnen Zeitraum entstand (dann wäre die Gesamtrendite
+        wenig aussagekräftig für die Zukunft). Schwankungsbreite über die Perioden:
+        <strong>{{ s.walk_forward_spread_label }} Prozentpunkte</strong> (größte minus
+        kleinste Perioden-Rendite).
+      </p>
+      <div class="chart-box"><canvas id="walk-chart"></canvas></div>
+      <div class="overflow-x">
+        <table>
+          <thead><tr><th>Zeitraum</th><th>Rendite %</th></tr></thead>
+          <tbody>
+          {% for seg in s.walk_forward_segmente %}
+            <tr>
+              <td>{{ seg.label }}</td>
+              <td class="{{ 'positive' if seg.rendite_pct >= 0 else 'negative' }}">{{ seg.rendite_label }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    {% endif %}
     <p class="hint">
       "Abw. pp" ist die Abweichung des Ist- vom Ziel-Gewicht dieses Instruments in
       Prozentpunkten; ⚠ markiert eine Abweichung über der Rebalancing-Schwelle dieser
@@ -213,6 +241,25 @@
       },
     },
   });
+
+  {% if s.walk_forward_segmente %}
+  new Chart(document.getElementById('walk-chart'), {
+    type: 'bar',
+    data: {
+      labels: {{ s.walk_forward_segmente | map(attribute='label') | list | tojson }},
+      datasets: [{
+        label: 'Rendite % im Zeitraum',
+        data: {{ s.walk_forward_segmente | map(attribute='rendite_pct') | list | tojson }},
+        backgroundColor: {{ s.walk_forward_segmente | map(attribute='rendite_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+      }],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false }, title: { display: true, text: 'Rendite je Teilperiode (Walk-Forward)', color: colors.text } },
+      scales: commonScales,
+    },
+  });
+  {% endif %}
 
   new Chart(document.getElementById('topf-chart'), {
     type: 'line',

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -8,11 +8,20 @@ kommt aus ``engine.simulate()``).
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
 
-from boersenspiel.dashboard import _max_drawdown_pct, _slug, _volatilitaet_pct, build_dashboard
+from boersenspiel.dashboard import (
+    _downside_deviation,
+    _max_drawdown_pct,
+    _sharpe_ratio,
+    _slug,
+    _sortino_ratio,
+    _volatilitaet_pct,
+    _walk_forward_segmente,
+    build_dashboard,
+)
 from boersenspiel.history_store import FetchLogEntry, PriceRow
 from boersenspiel.strategies import Beitrag, Strategy, Topf
 
@@ -287,3 +296,96 @@ def test_holdings_table_ohne_fetch_log_zeigt_keine_eingefroren_markierung(tmp_pa
     detail_html = _detail_html(tmp_path, "a-verdoppler")
 
     assert "eingefroren" not in detail_html
+
+
+# --- Risikoadjustierte Kennzahlen: Sharpe & Sortino -------------------------------
+
+
+def test_sharpe_ratio_ist_null_bei_konstanter_reihe():
+    # Keine Streuung der Wochenrenditen -> Nenner 0 -> bewusst 0.0 statt Division durch 0.
+    assert _sharpe_ratio([1000.0, 1000.0, 1000.0]) == 0.0
+
+
+def test_sharpe_ratio_positiv_bei_positiver_ueberschussrendite():
+    assert _sharpe_ratio([100.0, 150.0, 200.0]) > 0.0
+
+
+def test_sortino_ratio_ist_null_ohne_verlustwochen():
+    # Nur Gewinnwochen -> keine Downside-Deviation -> bewusst 0.0 statt undefiniert.
+    assert _sortino_ratio([100.0, 150.0, 200.0]) == 0.0
+
+
+def test_sortino_ratio_positiv_trotz_verlustwoche_bei_positivem_gesamttrend():
+    assert _sortino_ratio([100.0, 200.0, 100.0, 150.0]) > 0.0
+
+
+def test_downside_deviation_ignoriert_streuung_nach_oben():
+    # Nur die Verlustwoche (-0.1) fliesst ein; wie stark die Gewinnwochen streuen, ist
+    # fuer die Downside-Deviation irrelevant - anders als bei der (Gesamt-)Volatilitaet.
+    assert _downside_deviation([0.1, 0.2, -0.1]) == _downside_deviation([0.5, 0.9, -0.1])
+
+
+def test_downside_deviation_ohne_verlustwochen_ist_null():
+    assert _downside_deviation([0.1, 0.2, 0.05]) == 0.0
+
+
+def test_summary_table_zeigt_sharpe_und_sortino_spalten(tmp_path: Path):
+    output = build_dashboard(_auf_und_ab_rows(), [ZWEI_STRATEGIEN[0]], output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    assert "Sharpe" in html
+    assert "Sortino" in html
+
+
+def test_sharpe_sortino_sind_nur_auf_startseite(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    assert "Sharpe" not in detail_html
+    assert "Sortino" not in detail_html
+
+
+# --- Walk-Forward-Robustheit ueber Teilperioden -----------------------------------
+
+
+def _lange_rows(wochen: int = 33) -> list[PriceRow]:
+    """Genug Wochen fuer 3 Walk-Forward-Segmente (>= 10 Wochen/Segment); T1 schwankt
+    auf und ab statt monoton zu steigen, damit die Teilperioden unterschiedlich
+    ausfallen koennen."""
+    start = date(2024, 1, 1)
+    rows = []
+    preis = Decimal("100")
+    for i in range(wochen):
+        preis = preis * Decimal("1.05") if i % 3 else preis * Decimal("0.9")
+        rows.append(PriceRow(start + timedelta(weeks=i), {"T1": preis}))
+    return rows
+
+
+def test_walk_forward_segmente_leer_bei_zu_wenig_wochen():
+    # 10 Wochen reichen nicht fuer 2 Segmente à mindestens 10 Wochen.
+    assert _walk_forward_segmente(_lange_rows(10), ZWEI_STRATEGIEN[0]) == []
+
+
+def test_walk_forward_segmente_teilt_lange_historie_in_drei_perioden():
+    segmente = _walk_forward_segmente(_lange_rows(33), ZWEI_STRATEGIEN[0])
+
+    assert len(segmente) == 3
+    for segment in segmente:
+        assert "–" in segment["label"]
+        assert "rendite_label" in segment
+
+
+def test_build_dashboard_zeigt_walk_forward_abschnitt_bei_genug_historie(tmp_path: Path):
+    build_dashboard(_lange_rows(33), [ZWEI_STRATEGIEN[0]], output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    assert "Robustheit über Teilperioden (Walk-Forward)" in detail_html
+    assert 'id="walk-chart"' in detail_html
+
+
+def test_build_dashboard_versteckt_walk_forward_abschnitt_bei_kurzer_historie(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    assert "Robustheit über Teilperioden" not in detail_html
+    assert "walk-chart" not in detail_html


### PR DESCRIPTION
## Zusammenfassung

Umsetzung des im Chat besprochenen nächsten Schritts Richtung fundierterer Invest-Entscheidungen: die bisherigen Risikokennzahlen (Volatilität, Max Drawdown, #40) allein zeigen noch keine Rendite-pro-Risiko-Relation, und alle Szenarien in `scenarios.py` laufen bislang unoptimiert auf einer einzigen, kurzen Kurshistorie – eine gute Rendite könnte dort ebenso gut Zufall wie ein echter Vorteil sein.

- **Sharpe- & Sortino-Ratio** in der Übersichtstabelle (`dashboard._sharpe_ratio()`/`_sortino_ratio()`): annualisierte Überrendite ÷ annualisierte Volatilität bzw. ÷ Downside-Deviation nur der Verlustwochen (`_downside_deviation()`). Risikofreier Zins ist ein bewusster 0%-Platzhalter, analog zu `VORABPAUSCHALE_BASISZINS_PLATZHALTER` in `strategies.py`.
- **Walk-Forward-Robustheit** als neuer Abschnitt auf jeder Detailseite (`dashboard._walk_forward_segmente()`): dieselbe Strategie läuft unabhängig auf bis zu drei aufeinanderfolgenden Teilperioden (je eigenes Startkapital, keine fortgeführte Position). Da die Regeln in `scenarios.py` keine an Daten gefitteten Parameter haben, ist klassisches Train/Test-Splitting nicht anwendbar – stattdessen macht der Abschnitt sichtbar, ob eine Rendite über Marktphasen konsistent ist oder nur aus einer einzelnen Teilperiode stammt (Schwankungsbreite als Kennzahl). Entfällt bei zu kurzer Historie (< 20 Wochen).
- **Backfill-Zeitraum erweitert**: Default von `scripts/backfill_history.py --years` und dem `backfill.yml`-Workflow-Input von 5 auf 20 Jahre. `--years` ist nur eine untere Schranke an die Alpha-Vantage-API – ein weiter zurückliegender Wert liefert einfach die komplette verfügbare Historie je Ticker (ETFs/ältere Einzelaktien oft 15–20+ Jahre) statt eines Fehlers, jüngere Positionen wie Rivian (IPO 2021) bleiben unverändert ab ihrem Börsengang befüllt.

## Hinweis: tatsächlicher Backfill noch ausstehend

Diese Session hat keinen Zugriff auf den `ALPHAVANTAGE_API_KEY` (Repo-Secret) und konnte den erweiterten Zeitraum daher nicht selbst gegen echte Marktdaten laufen lassen – `data/price_history.csv` ist unverändert. Um die längere Historie tatsächlich zu bekommen, muss der Workflow **Historischer Backfill (manuell)** manuell mit `confirm=REPLACE` gestartet werden (nicht am selben Tag wie der wöchentliche Kursabruf, siehe CLAUDE.md).

## Test plan

- [x] `pytest -q` – 148 Tests grün (12 neue: Sharpe/Sortino-Grenzfälle, Downside-Deviation, Walk-Forward-Segmentierung, End-to-End-Rendering beider Abschnitte)
- [x] `python scripts/build_dashboard.py --strategy "Barbell 20/80"` manuell gegen die reale 5-Jahres-Historie gerendert und die neuen Abschnitte (Sharpe/Sortino-Spalten, Walk-Forward-Sektion mit 3 Segmenten) visuell im HTML geprüft

---
_Generated by [Claude Code](https://claude.ai/code/session_012kp32b5QDsZs6SGVaFHroF)_