### PR TITLE
Fix: Depotwert bei noch nicht existierenden Instrumenten + Prämissen-Seite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,10 +252,13 @@ inkrementell fortgeschrieben).
     tatsächlich anzuwendenden persönlichen Einkommensteuersatz.
 - `dashboard.py` + `templates/` — reine Darstellungsschicht, rendert
   `engine.simulate()`-Ergebnisse für alle (oder eine ausgewählte)
-  Strategie(n) aus `STRATEGIES`. Seit #31 zwei Seitentypen statt einer
+  Strategie(n) aus `STRATEGIES`. Seit #31 mehrere Seitentypen statt einer
   einzigen `index.html`: `templates/base.html.j2` definiert Kopf/Fuß/Styles
   einmal per Jinja-Vererbung (`{% extends %}` + Blocks `title`/
-  `header_extra`/`content`/`scripts`); `templates/dashboard.html.j2` (die
+  `header_extra`/`content`/`scripts`) und enthält das Drei-Punkt-Menü
+  (`<details class="menu">`, reines CSS/HTML ohne JS), über das von **jeder**
+  Seite die Übersicht und die Prämissen-Seite erreichbar sind;
+  `templates/dashboard.html.j2` (die
   Startseite `docs/index.html`) zeigt die strategieübergreifende
   Vergleichsübersicht ("Übersicht: Rendite im Vergleich" - Balkendiagramm +
   nach Rendite sortierte Tabelle, Zeilen verlinken auf die Detailseite) sowie
@@ -321,6 +324,21 @@ inkrementell fortgeschrieben).
   "erster Ansatz, nicht optimiert/gebacktestet" auf einer einzigen, noch
   kurzen Kurshistorie sind. Die Schwankungsbreite (größte minus kleinste
   Perioden-Rendite) steht als Kennzahl über der Tabelle.
+  `templates/praemissen.html.j2` (`docs/praemissen.html`, über das
+  Drei-Punkt-Menü von jeder Seite erreichbar) sammelt die Prämissen, auf
+  denen alle Zahlen beruhen — Datenbasis und Zeitraum, Instrumententabelle
+  mit **erstem Kurstag je Ticker** (⚠ bei später verfügbaren), Handels- und
+  Steuerregeln, die Kennzahl-Definitionen sowie eine explizite Liste des
+  nicht Modellierten (Dividenden, Inflation, Spread/Slippage, TER,
+  Zinsen auf Cash). Ganz oben stehen die drei Einschränkungen, die schwerer
+  wiegen als jede Renditezahl: Rückschaufehler bei der Instrumentenauswahl,
+  nicht optimierte/gebacktestete Regeln, und ein einziger Kursverlauf ohne
+  Konfidenzintervalle. `_praemissen_kontext()` leitet dafür **alles** aus
+  den tatsächlich verwendeten Konstanten (`strategies.py`), aus
+  `instruments.py` und aus der übergebenen Kurshistorie ab — nach demselben
+  Prinzip wie `learnings.py`: nichts auf der Seite ist hinterlegter Text,
+  der gegenüber dem Code veralten könnte. Beim Ergänzen deshalb keine
+  Zahl hart ins Template schreiben, sondern über den Kontext ziehen.
 - `learnings.py` — leitet die Sektion "Key Learnings" (ganz oben im Dashboard)
   bei jedem Build neu aus den Strategie-Views ab. **Keine hinterlegten
   Erkenntnis-Texte:** fest ist nur die Fragestellung je Regel (reine Funktion
@@ -441,7 +459,12 @@ nur Gewinnwochen → Sortino bewusst 0.0 statt undefiniert,
 `_walk_forward_segmente()` gegen eine lange synthetische Kursreihe (leer
 bei zu wenig Wochen, exakt drei Segmente bei ausreichender Historie) und
 End-to-End, dass der Detailseiten-Abschnitt "Robustheit über Teilperioden"
-nur bei genug Kurshistorie erscheint.
+nur bei genug Kurshistorie erscheint. Für die Prämissen-Seite: dass sie
+erzeugt und von Start- *und* Detailseite verlinkt wird, dass ihre Werte
+tatsächlich aus `ORDERGEBUEHR`/`SPARERPAUSCHBETRAG_PRO_JAHR`/`TICKERS` und
+der übergebenen Historie stammen (statt hart im Template zu stehen), und
+dass die wesentlichen Einschränkungen samt Platzhalter-Kennzeichnung
+benannt sind.
 `tests/test_learnings.py` fährt jede Learning-Regel gegen
 konstruierte Views mit bekannten Zahlen und prüft, dass die Aussagen den
 Daten folgen statt fest zu sein (inkl. Gegenprobe mit umgedrehter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,14 +160,36 @@ inkrementell fortgeschrieben).
   Instrumente zu genau dem vorhandenen `pending_cash` aufaddieren. Ein
   Instrument einfach zu überspringen zerstört diese Invariante und lässt
   Geld ersatzlos verschwinden. Für Instrumente ohne Kurs in der aktuellen
-  Zeile (existieren noch nicht: Bitcoin vor 2009, Rivian vor dem IPO 2021,
-  die meisten ETFs am Anfang der 20-Jahres-Historie) wird der Zielanteil
-  deshalb als `pending_cash` geparkt — dieselbe Mechanik wie beim
-  Initialkauf (`delayed_initial_buy`), die das Kapital investiert, sobald
-  der Kurs erstmals existiert. Vor dieser Korrektur schrumpften alle
-  rebalancierenden Strategien über die lange Historie wöchentlich um
-  ~50% bis auf 0 EUR (nur `BUY_AND_HOLD` blieb korrekt, da es nie
-  rebalanciert) — Regressionstests in `tests/test_engine.py`. Dezember-Harvest realisiert Verluste (größter zuerst) bis der
+  Zeile wird der Zielanteil deshalb als `pending_cash` geparkt — dieselbe
+  Mechanik wie beim Initialkauf (`delayed_initial_buy`). Vor dieser
+  Korrektur schrumpften alle rebalancierenden Strategien über die lange
+  Historie wöchentlich um ~50% bis auf 0 EUR (nur `BUY_AND_HOLD` blieb
+  korrekt, da es nie rebalanciert) — Regressionstests in
+  `tests/test_engine.py`.
+  **Noch nicht existierende Instrumente (`handelbare_gewichte()`):** Über
+  die 20-Jahres-Historie existiert ein großer Teil der Instrumente anfangs
+  noch nicht (Bitcoin vor 2009, Rivian vor dem IPO 2021, die meisten ETFs
+  am Anfang). Ihr Zielanteil wird **anteilig auf die tatsächlich
+  handelbaren Instrumente umgelegt**, statt ihn unverzinst zu parken —
+  sonst lägen zu Beginn der Historie über 60% des Depots brach und die
+  Rendite der frühen Jahre wäre praktisch aussagelos (gemessen: Endwert
+  89.408 € beim Parken gegenüber 125.893 € beim Umlegen). Die relativen
+  Verhältnisse *innerhalb* der verfügbaren Instrumente bleiben dabei
+  erhalten; das Depot bleibt voll investiert, in dem, was es zu diesem
+  Zeitpunkt gab. Zwei Ereignisse setzen Kapital neu an, **beide bewusst
+  unabhängig von `opt.rebalancing`** (es sind Erstkäufe, kein Korrigieren
+  von Drift — dieselbe Logik wie beim bisherigen `delayed_initial_buy`,
+  sonst hielte `BUY_AND_HOLD` nie ein Instrument, das es bei
+  Simulationsbeginn noch nicht gab): `neues_instrument`, sobald ein Ticker
+  erstmals einen Kurs hat, und `kapitaleinsatz`, sobald geparktes Cash
+  wieder ein handelbares Ziel hat. Letzteres ist nötig, weil der
+  Rebalancing-Trigger nur Topf A prüft: war zeitweise *kein* Zielinstrument
+  handelbar (z. B. „Sell in May" startet im September 2006 defensiv, Topf A
+  existiert aber erst ab 2008), sind Ist- und Zielgewicht von Topf A beide
+  0 und das geparkte Kapital käme nie wieder zum Einsatz. Bleibt bei
+  `summe <= 0` (kein einziges Zielinstrument handelbar) alles geparkt, ist
+  das gewollt: „raus aus dem Markt" ohne verfügbares defensives Instrument
+  *ist* Cash. Dezember-Harvest realisiert Verluste (größter zuerst) bis der
   verbleibende Sparerpauschbetrag des Jahres gedeckt ist, mit sofortigem
   Rückkauf zum selben Kurs. `simulate(price_history, strategy,
   optimierungen=None)` nimmt optional eine `Optimierungen`-Instanz entgegen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,21 @@ inkrementell fortgeschrieben).
   nach der Durchschnittskosten-Methode (kein FIFO/LIFO); Rebalancing bringt
   bei Auslösung *alle* Instrumente auf ihr Zielgewicht zurück, nicht nur den
   auslösenden Topf; alle Geld-/Stückzahl-Arithmetik nutzt `Decimal`, nie
-  `float`. Dezember-Harvest realisiert Verluste (größter zuerst) bis der
+  `float`. **Werterhaltung beim Rebalancing (wichtig beim Ändern):**
+  `rebalance_to_targets()` führt kein Cash-Konto — Verkaufserlöse werden
+  nirgends gutgeschrieben, Kaufbeträge nirgends entnommen. Die Umschichtung
+  ist allein dadurch summenneutral, dass sich die `diffs` über *alle*
+  Instrumente zu genau dem vorhandenen `pending_cash` aufaddieren. Ein
+  Instrument einfach zu überspringen zerstört diese Invariante und lässt
+  Geld ersatzlos verschwinden. Für Instrumente ohne Kurs in der aktuellen
+  Zeile (existieren noch nicht: Bitcoin vor 2009, Rivian vor dem IPO 2021,
+  die meisten ETFs am Anfang der 20-Jahres-Historie) wird der Zielanteil
+  deshalb als `pending_cash` geparkt — dieselbe Mechanik wie beim
+  Initialkauf (`delayed_initial_buy`), die das Kapital investiert, sobald
+  der Kurs erstmals existiert. Vor dieser Korrektur schrumpften alle
+  rebalancierenden Strategien über die lange Historie wöchentlich um
+  ~50% bis auf 0 EUR (nur `BUY_AND_HOLD` blieb korrekt, da es nie
+  rebalanciert) — Regressionstests in `tests/test_engine.py`. Dezember-Harvest realisiert Verluste (größter zuerst) bis der
   verbleibende Sparerpauschbetrag des Jahres gedeckt ist, mit sofortigem
   Rückkauf zum selben Kurs. `simulate(price_history, strategy,
   optimierungen=None)` nimmt optional eine `Optimierungen`-Instanz entgegen

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ strategy always yields the identical result.
 | `src/boersenspiel/history_store.py` | Only write path to `data/price_history.csv` / `data/fetch_log.csv` |
 | `src/boersenspiel/sources/` | Interchangeable price sources (default: `alphavantage.py`) |
 | `src/boersenspiel/engine.py` | Pure simulation function: (price history, strategy) → portfolio/tax state |
-| `src/boersenspiel/dashboard.py` | Renders simulation results as `docs/index.html`, including key learnings and the cross-strategy return comparison overview at the top |
+| `src/boersenspiel/dashboard.py` | Renders simulation results as `docs/index.html`, one `docs/<slug>.html` detail page per strategy, and `docs/praemissen.html` (premises and assumptions) |
+| `src/boersenspiel/templates/` | Jinja templates: `base.html.j2` (shared shell incl. the three-dot menu), `dashboard.html.j2`, `strategy_detail.html.j2`, `praemissen.html.j2` |
 | `src/boersenspiel/learnings.py` | Re-derives the key-learnings text on every build from the simulation results (no stored insights) |
 | `scripts/run_fetch.py` | Automated weekly price fetch (GitHub Actions) |
 | `scripts/record_prices.py` | Manual entry point for prices from another source (e.g. Cowork/web search) |
@@ -246,7 +247,7 @@ the historical `FX_WEEKLY` rate for the same week (forward-fill if no FX
 rate is available for a given week).
 
 ```bash
-python scripts/backfill_history.py --years 5   # default: 5 years back
+python scripts/backfill_history.py --years 20  # default: 20 years back (lower bound only)
 ```
 
 Uses roughly 18 requests once (16 non-crypto tickers + 1× `FX_WEEKLY` + 1×
@@ -387,6 +388,37 @@ pytest -q
 - **Rebalancing**, once triggered (deviation from the target bucket weight
   exceeds the threshold), brings **all** instruments back to their target
   weight, not just the triggering bucket.
+- **Rebalancing conserves portfolio value by construction.**
+  `rebalance_to_targets()` keeps no cash account: sale proceeds are never
+  credited anywhere, purchase amounts never withdrawn. The reshuffle is
+  value-neutral *only* because the `diffs` across **all** instruments add up
+  to exactly the available `pending_cash`. Silently skipping an instrument
+  breaks that invariant and makes money disappear — the sales still run
+  while the matching purchase is dropped.
+- **Instruments that did not exist yet** (`handelbare_gewichte()`): over a
+  20-year history a large share of the instruments has no price at the start
+  (Bitcoin before 2009, Rivian before its 2021 IPO, most of the ETFs early
+  on). Their target share is **redistributed proportionally across the
+  instruments that are actually tradeable**, rather than parked
+  uninvested — otherwise more than 60% of the portfolio would sit idle at
+  the start of the history and the returns of the early years would be
+  largely meaningless (measured: €89,408 final value when parking vs.
+  €125,893 when redistributing). Relative proportions *within* the available
+  instruments are preserved. Two events put capital to work, **both
+  deliberately independent of `opt.rebalancing`** (they are initial
+  purchases, not drift correction — otherwise `BUY_AND_HOLD` would never
+  hold an instrument that didn't exist when the simulation started):
+  `neues_instrument` once a ticker first has a price, and `kapitaleinsatz`
+  once parked cash has a tradeable target again. The latter is needed
+  because the rebalancing trigger only checks bucket A: if *no* target
+  instrument was tradeable for a while (e.g. "Sell in May" starts defensively
+  in September 2006, but bucket A only exists from 2008), bucket A's actual
+  and target weights are both 0 and the parked capital would never be
+  deployed. If no target instrument is tradeable at all, everything stays
+  parked — deliberately: "out of the market" with no defensive instrument
+  available *is* cash.
+- **Distributions and dividends are not modeled.** For distributing
+  instruments the simulation therefore misses part of the real return.
 - **December harvest:** On the last price row of a completed calendar year,
   exactly one of two mutually exclusive measures applies, depending on how
   the tax year has gone so far (see
@@ -440,6 +472,26 @@ pytest -q
 
 ## Known limitations
 
+- **Hindsight bias in instrument selection:** the 17 instruments were picked
+  when their price history was already known. A backtested return therefore
+  does not answer "what would I have earned?", only "how would these rules
+  have played out on these, retrospectively chosen, instruments?". The
+  scenario rules themselves are a first pass, neither optimized nor
+  backtested, and everything rests on a single historical price series — no
+  Monte Carlo, no confidence intervals. Differences of a few percentage
+  points between two strategies are not meaningful. The dashboard's
+  **Premises page** (`docs/praemissen.html`, reachable from the three-dot
+  menu on every page) spells this out for readers.
+- **Placeholder constants:** `VORABPAUSCHALE_BASISZINS_PLATZHALTER` (2.0%)
+  is not a real annual BMF base rate, and `_RISIKOFREIER_ZINS_PLATZHALTER`
+  (0%) used by the Sharpe/Sortino ratios is not a real reference rate. Taxes
+  use the flat withholding rate rather than a personal income tax rate, and
+  the simulated portfolio value itself is never reduced by tax — the tax
+  figures are tracking only.
+- **`BTC-EUR` history is far shorter than requested:** the 20-year backfill
+  yields only ~50 weeks (from 2025-09-14), so Bitcoin is first bought near
+  its high rather than across the full period — see
+  [#56](https://github.com/S540d/Boersenspiel/issues/56).
 - **Alpha Vantage free-tier limit:** 25 requests/day, max. 1 request/second.
   Still unproblematic for the current 17 tickers fetched once a week, but
   barely any headroom for additional manual fetches on the same day;

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -20,8 +20,18 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from .engine import SimulationResult, simulate
 from .history_store import FetchLogEntry, PriceRow
+from .instruments import INSTRUMENTS, TICKERS
 from .learnings import derive_learnings
-from .strategies import STRATEGIES, Strategy
+from .strategies import (
+    ORDERGEBUEHR,
+    SPARERPAUSCHBETRAG_PRO_JAHR,
+    SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR,
+    STEUERSATZ,
+    STRATEGIES,
+    VORABPAUSCHALE_BASISZINS_PLATZHALTER,
+    VORABPAUSCHALE_FAKTOR,
+    Strategy,
+)
 
 # Status-Werte in fetch_log.csv, bei denen der Kurs NICHT frisch abgerufen wurde
 # (siehe history_store.record_week) - Grundlage fuer die "eingefroren"-Markierung (#42).
@@ -378,6 +388,82 @@ def _build_strategy_view(
     }
 
 
+def _erste_kurse(rows: list[PriceRow]) -> dict[str, str]:
+    """Datum der ersten Kurszeile je Ticker - macht sichtbar, ab wann ein
+    Instrument in der Simulation überhaupt handelbar war."""
+    erste: dict[str, str] = {}
+    for row in rows:
+        for ticker in row.prices:
+            if ticker not in erste:
+                erste[ticker] = row.date.isoformat()
+    return erste
+
+
+def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy]) -> dict:
+    """Baut die Daten für die Prämissen-Seite.
+
+    Bewusst durchgehend aus den tatsächlich verwendeten Konstanten,
+    ``instruments.py`` und der Kurshistorie abgeleitet - nach demselben Prinzip
+    wie ``learnings.py``: nichts hier ist hinterlegter Text, der gegenüber dem
+    Code veralten könnte. Ändert sich z. B. ``ORDERGEBUEHR`` oder die
+    Teilfreistellung eines Instruments, ändert sich diese Seite mit.
+    """
+    erste = _erste_kurse(rows)
+    instrumente = []
+    for ticker in TICKERS:
+        inst = INSTRUMENTS[ticker]
+        instrumente.append(
+            {
+                "ticker": ticker,
+                "name": inst.name,
+                "isin": inst.isin or "–",
+                "teilfreistellung": f"{inst.teilfreistellung * 100:.0f}",
+                "thesaurierend": "ja" if inst.thesaurierend else "nein",
+                "spekulationsfrist": (
+                    f"{inst.spekulationsfrist_tage} Tage" if inst.spekulationsfrist_tage else "–"
+                ),
+                "erster_kurs": erste.get(ticker, "– (nie)"),
+                "fehlt_anfangs": erste.get(ticker) != rows[0].date.isoformat(),
+            }
+        )
+
+    strategie_liste = []
+    for s in strategies:
+        strategie_liste.append(
+            {
+                "name": s.name,
+                "id": _slug(s.name),
+                "startkapital": f"{s.startkapital:.2f}",
+                "schwelle": f"{s.rebalancing_schwelle_pp}",
+                "ziel_topf": s.ziel_topf,
+                "ziel_gewicht": f"{s.ziel_gewicht * 100:.0f}",
+                "dynamisch": "ja" if s.gewichte_fn is not None else "nein",
+                "toepfe": [
+                    {"name": t.name, "gewicht": f"{t.gewicht_gesamt * 100:.0f}"} for t in s.toepfe
+                ],
+            }
+        )
+
+    return {
+        "instrumente": instrumente,
+        "strategien": strategie_liste,
+        "zeitraum_von": rows[0].date.isoformat(),
+        "zeitraum_bis": rows[-1].date.isoformat(),
+        "wochen": len(rows),
+        "ordergebuehr": f"{ORDERGEBUEHR:.2f}",
+        "steuersatz": f"{STEUERSATZ * 100:.3f}".rstrip("0").rstrip("."),
+        "sparerpauschbetrag": f"{SPARERPAUSCHBETRAG_PRO_JAHR:.0f}",
+        "spek_freigrenze": f"{SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR:.0f}",
+        "vorabpauschale_basiszins": f"{VORABPAUSCHALE_BASISZINS_PLATZHALTER * 100:.1f}".replace(".", ","),
+        "vorabpauschale_faktor": f"{VORABPAUSCHALE_FAKTOR * 100:.0f}",
+        "risikofreier_zins": f"{_RISIKOFREIER_ZINS_PLATZHALTER * 100:.0f}",
+        "sma_kurz": _SMA_KURZ_WOCHEN,
+        "sma_lang": _SMA_LANG_WOCHEN,
+        "walk_forward_segmente": _WALK_FORWARD_SEGMENTE,
+        "walk_forward_min_wochen": _WALK_FORWARD_MIN_WOCHEN_PRO_SEGMENT,
+    }
+
+
 def build_dashboard(
     price_history: list[PriceRow],
     strategies: list[Strategy] | None = None,
@@ -434,5 +520,10 @@ def build_dashboard(
         detail_html = detail_template.render(s=view, **common_context)
         detail_path = output_path.parent / f"{view['id']}.html"
         detail_path.write_text(detail_html, encoding="utf-8")
+
+    praemissen_html = env.get_template("praemissen.html.j2").render(
+        **_praemissen_kontext(rows, strategies), **common_context
+    )
+    (output_path.parent / "praemissen.html").write_text(praemissen_html, encoding="utf-8")
 
     return output_path

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -326,6 +326,24 @@ def simulate(
         diffs = {
             t: weights.get(t, Decimal(0)) * total_value - values.get(t, Decimal(0)) for t in tickers
         }
+        # Instrumente ohne Kurs in DIESER Zeile (typisch: das Instrument existiert
+        # noch nicht - Bitcoin vor 2009, Rivian vor dem IPO 2021, ...) sind nicht
+        # handelbar. Ihr Zielanteil wird als Cash geparkt, exakt wie beim
+        # Initialkauf (pending_cash/"delayed_initial_buy"), statt einfach
+        # uebersprungen zu werden.
+        #
+        # Das ist NOTWENDIG fuer die Werterhaltung, nicht bloss Kosmetik: die
+        # Verkaufserloese bzw. Kaufbetraege unten werden keinem Cash-Konto
+        # gutgeschrieben/entnommen - die Umschichtung ist allein dadurch
+        # summenneutral, dass sich die diffs zu genau dem vorhandenen Cash
+        # aufaddieren. Wird ein Instrument stattdessen stillschweigend
+        # uebersprungen, gilt das nicht mehr: die Verkaeufe der uebrigen
+        # Instrumente laufen weiter, der zugehoerige Kauf entfaellt, und der
+        # Erloes verschwindet ersatzlos aus dem Depot (bei langer Historie mit
+        # vielen noch nicht existierenden Instrumenten bis auf 0 EUR).
+        for t in tickers:
+            if prices.get(t) is None:
+                pending_cash[t] = weights.get(t, Decimal(0)) * total_value
         executed = False
         for t in tickers:
             diff = diffs[t]

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -166,7 +166,39 @@ def simulate(
             return strategy.gewichte_fn(rows, i)
         return base_weights
 
+    def handelbare_gewichte(
+        weights: dict[str, Decimal], prices: dict[str, Decimal]
+    ) -> dict[str, Decimal]:
+        """Ziel-Gewichte anteilig auf die Instrumente umlegen, die in DIESER Zeile
+        einen Kurs haben.
+
+        Über eine lange Kurshistorie existiert ein großer Teil der Instrumente
+        anfangs schlicht noch nicht (Bitcoin vor 2009, Rivian vor dem IPO 2021,
+        die meisten ETFs am Anfang der 20-Jahres-Historie). Ihr Zielanteil lässt
+        sich nicht investieren. Ihn unangetastet stehen zu lassen hieße, einen
+        entsprechenden Teil des Depots dauerhaft unverzinst zu parken - zu Beginn
+        der Historie über 60% - und würde die Rendite der frühen Jahre praktisch
+        aussagelos machen. Stattdessen wird das Zielgewicht auf die tatsächlich
+        verfügbaren Instrumente hochskaliert: das Depot bleibt voll investiert, in
+        dem, was es zu diesem Zeitpunkt gab.
+
+        Die relativen Verhältnisse innerhalb der verfügbaren Instrumente bleiben
+        dabei erhalten - fehlt Topf B ein Instrument, wächst der Anteil der
+        übrigen Topf-B-Instrumente ebenso wie der von Topf A.
+
+        Hat kein einziges Instrument einen Kurs, bleiben die Gewichte unverändert;
+        das Kapital wird dann wie gehabt als ``pending_cash`` geparkt.
+        """
+        verfuegbar = {t: w for t, w in weights.items() if t in prices and w > 0}
+        summe = sum(verfuegbar.values(), Decimal(0))
+        if summe <= 0:
+            return weights
+        return {t: w / summe for t, w in verfuegbar.items()}
+
     positions: dict[str, _Position] = {t: _Position() for t in tickers}
+    # Instrumente, die bereits mindestens einmal einen Kurs hatten - waechst diese
+    # Menge, ist ein neues Instrument investierbar geworden (s. "neues_instrument").
+    handelbare_ticker: set[str] = set()
     # Kapitalanteil eines Instruments ohne Kurs in der ersten Zeile (z. B. vor
     # dessen Börsengang) - wird investiert, sobald erstmals ein Kurs vorliegt.
     pending_cash: dict[str, Decimal] = {t: Decimal(0) for t in tickers}
@@ -530,7 +562,7 @@ def simulate(
                 last_price[t] = prices[t]
 
         if i == 0:
-            initial_weights = weights_at(0)
+            initial_weights = handelbare_gewichte(weights_at(0), prices)
             num_instruments = len(tickers)
             total_fees = gebuehr * num_instruments
             investable = strategy.startkapital - total_fees
@@ -565,14 +597,31 @@ def simulate(
             total_value = sum(values.values(), Decimal(0)) + total_cash()
             if total_value > 0:
                 ziel_topf = next(t for t in strategy.toepfe if t.name == strategy.ziel_topf)
-                if strategy.gewichte_fn is not None:
-                    current_weights = strategy.gewichte_fn(rows, i)
-                    ziel_gewicht_effektiv = sum(
-                        (current_weights.get(t, Decimal(0)) for t in ziel_topf.sub_gewichte), Decimal(0)
-                    )
-                else:
-                    current_weights = base_weights
-                    ziel_gewicht_effektiv = strategy.ziel_gewicht
+                current_weights = handelbare_gewichte(weights_at(i), prices)
+                # Die Schwelle vergleicht Ist gegen Ziel - beide muessen sich auf
+                # dieselbe (umgelegte) Zielverteilung beziehen, sonst schlaegt der
+                # Trigger dauerhaft an, solange Instrumente fehlen.
+                ziel_gewicht_effektiv = sum(
+                    (current_weights.get(t, Decimal(0)) for t in ziel_topf.sub_gewichte), Decimal(0)
+                )
+                # Ein Instrument, das erstmals einen Kurs hat (Boersengang, Start
+                # der verfuegbaren Historie), gehoert ab jetzt ins Zielportfolio.
+                # Das ist ein Erstkauf, kein Korrigieren von Drift - deshalb
+                # bewusst unabhaengig von opt.rebalancing, analog zum bisherigen
+                # "delayed_initial_buy" fuer geparktes Kapital.
+                # Ebenso muss noch nicht investiertes Kapital eingesetzt werden,
+                # sobald es ein Ziel dafuer gibt. Das passiert, wenn zeitweise KEIN
+                # Zielinstrument handelbar war (z. B. "Sell in May" startet im
+                # September 2006 defensiv, Topf A existiert aber erst ab 2008) -
+                # ueber den Topf-A-Trigger allein wuerde dieses Kapital nie wieder
+                # investiert, weil dessen Ist- und Zielgewicht dann beide 0 sind.
+                neue_instrumente = {t for t in tickers if t in prices} - handelbare_ticker
+                if neue_instrumente or total_cash() > 0:
+                    grund = "neues_instrument" if neue_instrumente else "kapitaleinsatz"
+                    if rebalance_to_targets(prices, row.date, grund, current_weights):
+                        last_rebalance_date = row.date
+                    values = current_values(prices)
+                    total_value = sum(values.values(), Decimal(0)) + total_cash()
                 ziel_topf_value = sum(
                     (values.get(t, Decimal(0)) for t in ziel_topf.sub_gewichte), Decimal(0)
                 )
@@ -611,6 +660,7 @@ def simulate(
         value_history.append(
             ValuePoint(row.date, total_value, values, ticker_weights, topf_values, topf_weights)
         )
+        handelbare_ticker.update(t for t in tickers if t in prices)
 
     tax_status = TaxStatus(
         year=current_tax_year,

--- a/src/boersenspiel/templates/base.html.j2
+++ b/src/boersenspiel/templates/base.html.j2
@@ -102,6 +102,9 @@
   table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
   th, td { text-align: right; padding: 6px 8px; border-bottom: 1px solid var(--grid); font-variant-numeric: tabular-nums; }
   th:first-child, td:first-child { text-align: left; }
+  /* Tabellenspalten sind auf Zahlen ausgelegt (rechtsbuendig); Textspalten
+     jenseits der ersten brauchen deshalb eine explizite Ausnahme. */
+  th.text-left, td.text-left { text-align: left; }
   th { color: var(--text-muted); font-weight: 500; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.02em; }
   .overflow-x { overflow-x: auto; }
   footer { max-width: 1100px; margin: 24px auto 0; color: var(--text-muted); font-size: 0.8rem; }
@@ -145,12 +148,46 @@
   .warn { color: var(--series-4); font-weight: 600; }
   .detail-link { margin: 0; font-size: 0.9rem; }
   .back-link { margin: 0; font-size: 0.9rem; }
+  .header-bar { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+  .menu { position: relative; flex: none; }
+  .menu summary {
+    list-style: none; cursor: pointer; width: 32px; height: 32px; border-radius: 6px;
+    display: flex; align-items: center; justify-content: center; font-size: 1.2rem;
+    line-height: 1; color: var(--text-secondary); border: 1px solid var(--border);
+    background: var(--surface-1);
+  }
+  .menu summary::-webkit-details-marker { display: none; }
+  .menu summary:hover { color: var(--text-primary); }
+  .menu[open] summary { color: var(--text-primary); }
+  .menu nav {
+    position: absolute; right: 0; top: 38px; z-index: 10; min-width: 220px;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px;
+    padding: 6px; box-shadow: 0 6px 24px rgba(0,0,0,0.12);
+  }
+  .menu nav a {
+    display: block; padding: 8px 10px; border-radius: 5px; font-size: 0.88rem;
+    color: var(--text-primary); text-decoration: none;
+  }
+  .menu nav a:hover { background: var(--page); }
+  .menu nav .menu-hint { display: block; padding: 4px 10px 8px; color: var(--text-muted); font-size: 0.75rem; }
 </style>
 </head>
 <body>
 <header>
-  <h1>{% block header_title %}Barbell-Portfolio Dashboard{% endblock %}</h1>
-  <div class="meta">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
+  <div class="header-bar">
+    <div>
+      <h1>{% block header_title %}Barbell-Portfolio Dashboard{% endblock %}</h1>
+      <div class="meta">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
+    </div>
+    <details class="menu">
+      <summary aria-label="Menü" title="Menü">&#8942;</summary>
+      <nav>
+        <a href="index.html">Übersicht</a>
+        <a href="praemissen.html">Prämissen &amp; Annahmen</a>
+        <span class="menu-hint">Worauf die Zahlen beruhen</span>
+      </nav>
+    </details>
+  </div>
   {% block header_extra %}{% endblock %}
 </header>
 <main>

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -1,0 +1,213 @@
+{% extends "base.html.j2" %}
+{% block title %}Prämissen &amp; Annahmen – Barbell-Portfolio Dashboard{% endblock %}
+{% block meta_description %}Welche Annahmen, Konstanten und Vereinfachungen hinter den Zahlen des Barbell-Portfolio-Dashboards stehen.{% endblock %}
+{% block canonical %}https://s540d.github.io/Boersenspiel/praemissen.html{% endblock %}
+{% block header_extra %}<p class="back-link"><a href="index.html">&larr; Zur Übersicht</a></p>{% endblock %}
+{% block content %}
+  <section class="strategy" id="praemissen">
+    <h2>Prämissen &amp; Annahmen</h2>
+    <p class="hint">
+      Diese Seite sammelt, worauf die Zahlen im Dashboard beruhen, damit die
+      Ergebnisse zumindest prinzipiell nachvollziehbar sind. Alle Werte hier
+      werden bei jedem Build aus denselben Konstanten und derselben Kurshistorie
+      abgeleitet, die auch die Simulation benutzt &ndash; es sind keine
+      hinterlegten Texte, die gegenüber dem Code veralten könnten.
+    </p>
+
+    <h3>Das Wichtigste zuerst</h3>
+    <p class="hint">
+      Dies ist ein <strong>virtuelles Depot zu Lernzwecken, keine
+      Anlageberatung</strong> und keine Aussage darüber, wie sich diese
+      Strategien in Zukunft entwickeln. Drei Einschränkungen wiegen dabei
+      schwerer als jede Renditezahl auf der Übersichtsseite:
+    </p>
+    <ul class="hint">
+      <li>
+        <strong>Rückschaufehler bei der Instrumentenauswahl.</strong> Die
+        {{ instrumente|length }} Instrumente wurden ausgewählt, als ihre
+        Kursentwicklung bereits bekannt war. Eine rückgerechnete Rendite
+        beantwortet deshalb nicht die Frage „was hätte ich verdient?“, sondern
+        bestenfalls „wie hätten sich diese Regeln auf diese, im Nachhinein
+        ausgewählten Werte ausgewirkt?“.
+      </li>
+      <li>
+        <strong>Die Regeln sind nicht optimiert und nicht gebacktestet.</strong>
+        Schwellen, Zeitfenster und Quoten der Szenarien sind ein erster Ansatz,
+        keine an Daten angepassten Parameter. Der Abschnitt „Robustheit über
+        Teilperioden“ auf jeder Detailseite zeigt, wie stark eine Rendite
+        zwischen Zeiträumen schwankt.
+      </li>
+      <li>
+        <strong>Ein Depot, ein Kursverlauf.</strong> Alle Ergebnisse beruhen auf
+        genau einer historischen Kursreihe. Es gibt keine Monte-Carlo-Simulation
+        und keine Konfidenzintervalle &ndash; Unterschiede von wenigen
+        Prozentpunkten zwischen zwei Strategien sind damit nicht belastbar.
+      </li>
+    </ul>
+
+    <h3>Datenbasis</h3>
+    <div class="stat-row">
+      <div class="stat-tile"><div class="label">Zeitraum</div><div class="value">{{ zeitraum_von }} &ndash; {{ zeitraum_bis }}</div></div>
+      <div class="stat-tile"><div class="label">Kurszeilen</div><div class="value">{{ wochen }}</div></div>
+      <div class="stat-tile"><div class="label">Frequenz</div><div class="value">wöchentlich</div></div>
+      <div class="stat-tile"><div class="label">Währung</div><div class="value">EUR</div></div>
+    </div>
+    <p class="hint">
+      Grundlage ist ausschließlich <code>data/price_history.csv</code>: ein
+      Wochenschlusskurs je Instrument, in Euro. USD-notierte Werte werden beim
+      Abruf mit dem Wechselkurs derselben Woche umgerechnet. Es werden
+      <strong>nur Rohkurse gespeichert</strong> &ndash; alles Abgeleitete
+      (Positionswerte, Rebalancing, Steuer) wird bei jedem Build vollständig neu
+      berechnet. Gleiche Kurshistorie plus gleiche Strategie ergibt deshalb immer
+      dasselbe Ergebnis.
+    </p>
+    <p class="hint">
+      Konnte ein Kurs nicht abgerufen werden, wird der letzte bekannte Kurs
+      fortgeschrieben, statt eine Lücke zu lassen. Wo das zuletzt passiert ist,
+      steht als Spalte „Kursstatus“ in der Instrumententabelle jeder
+      Detailseite.
+    </p>
+
+    <h3>Instrumente und ab wann es sie gab</h3>
+    <p class="hint">
+      Ein großer Teil der Instrumente existierte am Anfang des Zeitraums noch
+      nicht. Ihr Zielanteil wird dann <strong>anteilig auf die tatsächlich
+      handelbaren Instrumente umgelegt</strong>, damit das Depot voll investiert
+      bleibt &ndash; in dem, was es zu diesem Zeitpunkt gab. Andernfalls läge zu
+      Beginn ein großer Teil des Kapitals unverzinst brach und die Rendite der
+      frühen Jahre wäre kaum aussagekräftig. Sobald ein Instrument erstmals einen
+      Kurs hat, wird es auf sein Zielgewicht gekauft (im Trade-Log als
+      <code>neues_instrument</code>). Die frühen Jahre bilden damit ein deutlich
+      schmaleres Portfolio ab als die späten &ndash; ⚠ markiert die betroffenen
+      Instrumente.
+    </p>
+    <div class="overflow-x">
+      <table>
+        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Spekulationsfrist</th></tr></thead>
+        <tbody>
+        {% for i in instrumente %}
+          <tr>
+            <td>{{ i.ticker }}</td>
+            <td class="text-left">{{ i.name }}</td>
+            <td class="text-left">{{ i.isin }}</td>
+            <td class="{{ 'warn' if i.fehlt_anfangs else '' }}">{{ i.erster_kurs }}{% if i.fehlt_anfangs %} &#9888;{% endif %}</td>
+            <td>{{ i.teilfreistellung }}</td>
+            <td>{{ i.thesaurierend }}</td>
+            <td>{{ i.spekulationsfrist }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Handelsregeln</h3>
+    <div class="stat-row">
+      <div class="stat-tile"><div class="label">Ordergebühr je Trade</div><div class="value">{{ ordergebuehr }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Kostenbasis</div><div class="value">Durchschnitt</div></div>
+      <div class="stat-tile"><div class="label">Spread / Slippage</div><div class="value">nicht modelliert</div></div>
+      <div class="stat-tile"><div class="label">Dividenden</div><div class="value">nicht modelliert</div></div>
+    </div>
+    <p class="hint">
+      Gekauft und verkauft wird zum Wochenschlusskurs, in beliebigen
+      Bruchstücken, ohne Geld-Brief-Spanne und ohne Teilausführung. Gebühren des
+      Erstkaufs werden vor der Aufteilung vom Startkapital abgezogen; spätere
+      Trades mindern beim Verkauf den realisierten Gewinn um die Gebühr und
+      schlagen sie beim Kauf auf die Kostenbasis. Die Kostenbasis läuft nach der
+      Durchschnittskosten-Methode, nicht nach FIFO. <strong>Ausschüttungen
+      werden nicht modelliert</strong> &ndash; bei ausschüttenden Instrumenten
+      fehlt der Simulation damit ein Teil der realen Rendite.
+    </p>
+    <p class="hint">
+      Rebalanciert wird nur, wenn der überwachte Topf um mehr als die Schwelle
+      der jeweiligen Strategie vom Zielgewicht abweicht; dann werden
+      <em>alle</em> Instrumente auf ihr Zielgewicht zurückgeführt. Der Auslöser
+      prüft also die Topf-Ebene, nicht die Konzentration einzelner Instrumente
+      innerhalb eines Topfs &ndash; darauf weist ⚠ in der Instrumententabelle der
+      Detailseiten hin.
+    </p>
+    <div class="overflow-x">
+      <table>
+        <thead><tr><th>Strategie</th><th>Startkapital &euro;</th><th>Rebalancing-Schwelle pp</th><th class="text-left">Überwachter Topf</th><th>Zielgewicht %</th><th>Zeitabhängige Gewichte</th></tr></thead>
+        <tbody>
+        {% for s in strategien %}
+          <tr>
+            <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
+            <td>{{ s.startkapital }}</td>
+            <td>{{ s.schwelle }}</td>
+            <td class="text-left">{{ s.ziel_topf }}</td>
+            <td>{{ s.ziel_gewicht }}</td>
+            <td>{{ s.dynamisch }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Steuerannahmen</h3>
+    <div class="stat-row">
+      <div class="stat-tile"><div class="label">Steuersatz</div><div class="value">{{ steuersatz }} %</div></div>
+      <div class="stat-tile"><div class="label">Sparerpauschbetrag / Jahr</div><div class="value">{{ sparerpauschbetrag }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Freigrenze § 23 EStG</div><div class="value">{{ spek_freigrenze }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Vorabpauschale-Basiszins</div><div class="value">{{ vorabpauschale_basiszins }} % (Platzhalter)</div></div>
+    </div>
+    <p class="hint">
+      Gerechnet wird mit dem pauschalen Abgeltungsteuersatz (Kapitalertragsteuer
+      plus Solidaritätszuschlag), <strong>nicht mit einem persönlichen
+      Einkommensteuersatz</strong>; Kirchensteuer bleibt außen vor. Der
+      Sparerpauschbetrag wird zu Jahresbeginn zurückgesetzt, nicht verbrauchte
+      Verluste werden als Verlustvortrag fortgeschrieben. Aktienfonds-ETFs
+      bekommen ihre Teilfreistellung auf Gewinn <em>und</em> Verlust angerechnet
+      (siehe Tabelle oben).
+    </p>
+    <p class="hint">
+      Für thesaurierende Fonds wird eine vereinfachte Vorabpauschale angesetzt:
+      Wert zu Jahresbeginn &times; {{ vorabpauschale_basiszins }} % &times;
+      {{ vorabpauschale_faktor }} %, gedeckelt auf die tatsächliche
+      Wertsteigerung. Der Basiszins ist ein <strong>fester Platzhalter, kein
+      echter jährlicher BMF-Basiszins</strong>, und die Pauschale wird am
+      Jahresende statt am ersten Werktag des Folgejahres angesetzt. Krypto
+      unterliegt der Spekulationsfrist statt der Abgeltungsteuer, mit eigenem
+      Verlustvortrag und einer Freigrenze (nicht einem Freibetrag: oberhalb der
+      Grenze ist der gesamte Jahresgewinn steuerpflichtig). Das Haltedauer-Datum
+      ist ein stückzahlgewichtetes Durchschnittskaufdatum, kein echtes
+      Per-Lot-Tracking.
+    </p>
+    <p class="hint">
+      Wichtig für die Interpretation: Die ausgewiesene Steuer ist reines
+      Tracking &ndash; <strong>der simulierte Depotwert selbst wird nirgends um
+      Steuer gemindert</strong>.
+    </p>
+
+    <h3>Kennzahlen auf der Übersicht</h3>
+    <p class="hint">
+      Volatilität ist die annualisierte Standardabweichung der Wochenrenditen
+      (&times; &radic;52), Max Drawdown der größte Rückgang vom bisherigen
+      Höchststand. Sharpe teilt die annualisierte Rendite durch die gesamte
+      Streuung, Sortino nur durch die Streuung der Verlustwochen. Beide rechnen
+      mit einem risikofreien Zins von <strong>{{ risikofreier_zins }} %</strong>
+      &ndash; ebenfalls ein bewusster Platzhalter, kein realer Referenzzins. Hat
+      eine Reihe gar keine Verlustwochen, wird Sortino als 0 ausgewiesen statt
+      als undefiniert.
+    </p>
+    <p class="hint">
+      Die gleitenden Durchschnitte auf den Detailseiten nähern die klassischen
+      50-/200-Tage-Linien mit {{ sma_kurz }} bzw. {{ sma_lang }} Wochen (5
+      Handelstage je Woche) an &ndash; auf Wochendaten, nicht auf Tagesdaten. Der
+      Walk-Forward-Abschnitt teilt die Historie in bis zu
+      {{ walk_forward_segmente }} gleich große Zeiträume und simuliert jeden
+      unabhängig mit frischem Startkapital; bei weniger als
+      {{ walk_forward_min_wochen }} Wochen je Segment entfällt er.
+    </p>
+
+    <h3>Was nicht modelliert wird</h3>
+    <ul class="hint">
+      <li>Ausschüttungen und Dividenden</li>
+      <li>Inflation &ndash; alle Beträge sind nominal</li>
+      <li>Geld-Brief-Spanne, Slippage, Teilausführungen, Handelsaussetzungen</li>
+      <li>Depot-, Ausgabeaufschlags- und Fondskosten (TER) &ndash; nur die Ordergebühr</li>
+      <li>Zinsen auf nicht investiertes Kapital</li>
+      <li>Kapitalmaßnahmen wie Splits oder Fusionen über den Kursabruf hinaus</li>
+      <li>Steuerliche Effekte über das Abgeltungsteuer- und § 23-Regime hinaus</li>
+    </ul>
+  </section>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,14 @@ from boersenspiel.dashboard import (
     build_dashboard,
 )
 from boersenspiel.history_store import FetchLogEntry, PriceRow
-from boersenspiel.strategies import Beitrag, Strategy, Topf
+from boersenspiel.instruments import TICKERS
+from boersenspiel.strategies import (
+    ORDERGEBUEHR,
+    SPARERPAUSCHBETRAG_PRO_JAHR,
+    Beitrag,
+    Strategy,
+    Topf,
+)
 
 ZWEI_STRATEGIEN = [
     Strategy(
@@ -389,3 +396,64 @@ def test_build_dashboard_versteckt_walk_forward_abschnitt_bei_kurzer_historie(tm
 
     assert "Robustheit über Teilperioden" not in detail_html
     assert "walk-chart" not in detail_html
+
+
+# --- Praemissen-Seite -------------------------------------------------------------
+
+
+def test_praemissen_seite_wird_erzeugt_und_ueberall_verlinkt(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+
+    praemissen = tmp_path / "praemissen.html"
+    assert praemissen.exists()
+    # Erreichbar ueber das Drei-Punkt-Menue auf JEDER Seite, nicht nur der Startseite.
+    assert "praemissen.html" in output.read_text(encoding="utf-8")
+    assert "praemissen.html" in _detail_html(tmp_path, "a-verdoppler")
+
+
+def test_praemissen_seite_leitet_werte_aus_den_echten_konstanten_ab(tmp_path: Path):
+    # Kernanspruch der Seite: nichts hier ist hinterlegter Text, der gegenueber
+    # dem Code veralten koennte - die Werte kommen aus strategies.py/instruments.py
+    # und der uebergebenen Kurshistorie.
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    assert f"{ORDERGEBUEHR:.2f}" in html
+    assert f"{SPARERPAUSCHBETRAG_PRO_JAHR:.0f}" in html
+    # Zeitraum und Zeilenzahl stammen aus der uebergebenen Historie.
+    assert "2024-01-01" in html
+    assert "2024-01-08" in html
+    # Alle Instrumente aus instruments.py sind aufgefuehrt, mit ihrer
+    # Teilfreistellung und der BTC-Spekulationsfrist.
+    for ticker in TICKERS:
+        assert ticker in html
+    assert "365 Tage" in html
+
+
+def test_praemissen_seite_benennt_die_wesentlichen_einschraenkungen(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    # Einzeltoken statt ganzer Saetze: der Fliesstext im Template ist umbrochen,
+    # ein Satzfragment wuerde nur zufaellig matchen.
+    assert "Anlageberatung" in html
+    assert "Rückschaufehler" in html
+    # Die Platzhalter muessen als solche gekennzeichnet sein, nicht als echte Werte.
+    assert "Platzhalter" in html
+    # Nicht modellierte Effekte
+    assert "Dividenden" in html
+    assert "Inflation" in html
+
+
+def test_praemissen_seite_markiert_spaeter_verfuegbare_instrumente(tmp_path: Path):
+    # T2 hat in der ersten Zeile keinen Kurs -> muss als "erst ab" markiert sein,
+    # damit nachvollziehbar bleibt, dass die fruehen Jahre ein schmaleres
+    # Portfolio abbilden.
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("150"), "T2": Decimal("50")}),
+    ]
+    build_dashboard(rows, ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    assert "Instrumente und ab wann es sie gab" in html

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -259,6 +259,65 @@ def test_missing_price_in_first_row_parks_capital_as_cash_and_invests_later():
     assert delayed_buys[0].ticker == "T2"
 
 
+REBALANCING_MISSING_PRICE_STRATEGY = Strategy(
+    name="Test-Rebalancing-Missing",
+    startkapital=Decimal("1000"),
+    toepfe=[
+        Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T1": Decimal("1")}),
+        Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T2": Decimal("1")}),
+    ],
+    ziel_topf="TopfX",
+    ziel_gewicht=Decimal("0.5"),
+    rebalancing_schwelle_pp=Decimal("1"),  # niedrig genug, damit rebalanciert wird
+)
+
+
+def test_rebalancing_erhaelt_depotwert_wenn_ein_instrument_noch_keinen_kurs_hat():
+    # Regressionstest: T2 existiert noch nicht (kein Kurs - wie Bitcoin vor 2009
+    # oder Rivian vor dem IPO 2021), waehrend T1 sich verdoppelt und damit ein
+    # Rebalancing ausloest. Frueher wurde T2 beim Rebalancing stillschweigend
+    # uebersprungen: der T1-Verkauf lief, der zugehoerige T2-Kauf entfiel, und der
+    # Erloes verschwand ersatzlos aus dem Depot (ueber eine lange Kurshistorie
+    # schrumpfte das Depot dadurch woechentlich gegen 0 EUR).
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("200")}),
+    ]
+    result = simulate(rows, REBALANCING_MISSING_PRICE_STRATEGY)
+
+    # 1000 - 2*1 Gebuehr = 998 investierbar; T1 kauft fuer 499 zu 100 = 4.99 Stueck,
+    # die 499 fuer T2 bleiben als Cash geparkt.
+    # Zeile 2: T1 = 4.99 * 200 = 998, Cash 499 -> Gesamt 1497. TopfX haelt damit
+    # 66.7% statt 50% -> Rebalancing. T1 wird auf 748.50 zurueckgefuehrt, die
+    # freiwerdenden 249.50 wandern in den T2-Cash-Topf (748.50).
+    assert result.value_history[1].total_value == Decimal("1497")
+
+    rebalance_sells = [t for t in result.trades if t.reason == "rebalance" and t.side == "sell"]
+    assert len(rebalance_sells) == 1
+    assert rebalance_sells[0].ticker == "T1"
+    assert rebalance_sells[0].units * rebalance_sells[0].price == Decimal("249.50")
+
+    # T2 hat weiterhin keinen Kurs und darf deshalb auch nicht gehandelt worden sein.
+    assert all(t.ticker != "T2" for t in result.trades)
+
+
+def test_rebalancing_investiert_geparktes_kapital_sobald_der_kurs_existiert():
+    # Fortsetzung des Falls oben: sobald T2 erstmals einen Kurs hat, wird das
+    # zwischenzeitlich angewachsene geparkte Kapital investiert - der Depotwert
+    # bleibt dabei erhalten.
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("200")}),
+        PriceRow(date(2024, 1, 15), {"T1": Decimal("200"), "T2": Decimal("50")}),
+    ]
+    result = simulate(rows, REBALANCING_MISSING_PRICE_STRATEGY)
+
+    # Der Gesamtwert bleibt bei 1497 (T1 unveraendert bei 200), jetzt aber
+    # vollstaendig investiert: 748.50 / 50 = 14.97 Stueck T2.
+    assert result.value_history[2].total_value == Decimal("1497")
+    assert result.holdings["T2"] == Decimal("14.97")
+
+
 # --- Paket A: Steuerkorrektheit (#37/#38/#39, siehe #46) --------------------
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -238,25 +238,59 @@ def test_strategy_eigene_optimierungen_werden_ohne_override_verwendet():
     assert all(t.reason != "rebalance" for t in result.trades)
 
 
-def test_missing_price_in_first_row_parks_capital_as_cash_and_invests_later():
-    # T2 hat in der ersten Zeile noch keinen Kurs (z. B. vor seinem IPO). Der
-    # dafuer vorgesehene Kapitalanteil bleibt als Cash geparkt statt zu
-    # verfallen und wird investiert, sobald T2 erstmals einen Kurs hat.
+def test_fehlender_kurs_in_erster_zeile_wird_auf_vorhandene_instrumente_umgelegt():
+    # T2 hat in der ersten Zeile noch keinen Kurs (z. B. vor seinem IPO). Sein
+    # Zielanteil wird auf die vorhandenen Instrumente umgelegt, damit das Depot
+    # voll investiert bleibt statt einen Teil unverzinst zu parken; sobald T2
+    # erstmals einen Kurs hat, wird auf die eigentliche Zielverteilung gebracht.
     rows = [
         PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
         PriceRow(date(2024, 1, 8), {"T1": Decimal("100"), "T2": Decimal("50")}),
     ]
     result = simulate(rows, MISSING_PRICE_STRATEGY)
 
-    # Startkapital 1000 - 2*1 Gebuehr = 998 investierbar, je 499 -> T1 sofort,
-    # T2 verzoegert zum Kurs 50 der zweiten Zeile.
-    assert result.holdings["T1"] == Decimal("4.99")
-    assert result.holdings["T2"] == Decimal("9.98")
+    # Startkapital 1000 - 2*1 Gebuehr = 998 investierbar. Zeile 1: alles in T1
+    # (9.98 Stueck zu 100), nichts geparkt. Zeile 2: T2 existiert -> zurueck auf
+    # 50/50, also je 499 -> T1 4.99 Stueck, T2 9.98 Stueck zu 50.
     assert result.value_history[0].total_value == Decimal("998")
     assert result.value_history[1].total_value == Decimal("998")
-    delayed_buys = [t for t in result.trades if t.reason == "delayed_initial_buy"]
-    assert len(delayed_buys) == 1
-    assert delayed_buys[0].ticker == "T2"
+    assert result.holdings["T1"] == Decimal("4.99")
+    assert result.holdings["T2"] == Decimal("9.98")
+
+    # Der Erstkauf des neu verfuegbaren Instruments laeuft ueber "neues_instrument"
+    # und ist damit im Trade-Log von normaler Drift-Korrektur unterscheidbar.
+    neu = [t for t in result.trades if t.reason == "neues_instrument"]
+    assert {t.ticker for t in neu} == {"T1", "T2"}
+    assert next(t for t in neu if t.ticker == "T2").side == "buy"
+
+
+def test_neues_instrument_wird_auch_ohne_rebalancing_gekauft():
+    # MISSING_PRICE_STRATEGY hat eine unerreichbar hohe Rebalancing-Schwelle, und
+    # hier ist Rebalancing zusaetzlich ganz abgeschaltet: ein neu verfuegbares
+    # Instrument ist trotzdem ein Erstkauf, kein Korrigieren von Drift - sonst
+    # wuerde eine Strategie ein Instrument, das es bei Simulationsbeginn noch
+    # nicht gab, nie halten.
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("100"), "T2": Decimal("50")}),
+    ]
+    result = simulate(rows, MISSING_PRICE_STRATEGY, Optimierungen(rebalancing=False))
+
+    assert result.holdings["T2"] == Decimal("9.98")
+
+
+def test_ohne_jeden_kurs_in_erster_zeile_bleibt_kapital_geparkt():
+    # Grenzfall: hat KEIN Instrument einen Kurs, gibt es nichts, worauf umgelegt
+    # werden koennte - dann greift weiterhin das Parken als pending_cash.
+    rows = [
+        PriceRow(date(2024, 1, 1), {}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("100"), "T2": Decimal("50")}),
+    ]
+    result = simulate(rows, MISSING_PRICE_STRATEGY)
+
+    assert result.value_history[0].total_value == Decimal("998")
+    assert result.holdings["T1"] == Decimal("4.99")
+    assert result.holdings["T2"] == Decimal("9.98")
 
 
 REBALANCING_MISSING_PRICE_STRATEGY = Strategy(
@@ -285,26 +319,23 @@ def test_rebalancing_erhaelt_depotwert_wenn_ein_instrument_noch_keinen_kurs_hat(
     ]
     result = simulate(rows, REBALANCING_MISSING_PRICE_STRATEGY)
 
-    # 1000 - 2*1 Gebuehr = 998 investierbar; T1 kauft fuer 499 zu 100 = 4.99 Stueck,
-    # die 499 fuer T2 bleiben als Cash geparkt.
-    # Zeile 2: T1 = 4.99 * 200 = 998, Cash 499 -> Gesamt 1497. TopfX haelt damit
-    # 66.7% statt 50% -> Rebalancing. T1 wird auf 748.50 zurueckgefuehrt, die
-    # freiwerdenden 249.50 wandern in den T2-Cash-Topf (748.50).
-    assert result.value_history[1].total_value == Decimal("1497")
-
-    rebalance_sells = [t for t in result.trades if t.reason == "rebalance" and t.side == "sell"]
-    assert len(rebalance_sells) == 1
-    assert rebalance_sells[0].ticker == "T1"
-    assert rebalance_sells[0].units * rebalance_sells[0].price == Decimal("249.50")
+    # 1000 - 2*1 Gebuehr = 998 investierbar. T2 hat keinen Kurs, sein Zielanteil
+    # wird auf T1 umgelegt: 998 / 100 = 9.98 Stueck. Zeile 2 verdoppelt T1 auf 200
+    # -> 9.98 * 200 = 1996. Frueher wurde hier rebalanciert, der T2-Kauf entfiel,
+    # und der Verkaufserloes verschwand ersatzlos aus dem Depot.
+    assert result.value_history[1].total_value == Decimal("1996")
 
     # T2 hat weiterhin keinen Kurs und darf deshalb auch nicht gehandelt worden sein.
     assert all(t.ticker != "T2" for t in result.trades)
+    # Ist- und Zielverteilung stimmen ueberein (T1 haelt 100% der umgelegten
+    # Zielgewichte), es gibt also nichts zu rebalancieren.
+    assert all(t.reason != "rebalance" for t in result.trades)
 
 
-def test_rebalancing_investiert_geparktes_kapital_sobald_der_kurs_existiert():
-    # Fortsetzung des Falls oben: sobald T2 erstmals einen Kurs hat, wird das
-    # zwischenzeitlich angewachsene geparkte Kapital investiert - der Depotwert
-    # bleibt dabei erhalten.
+def test_neu_verfuegbares_instrument_wird_auf_zielgewicht_gebracht():
+    # Fortsetzung des Falls oben: sobald T2 erstmals einen Kurs hat, wird die
+    # eigentliche 50/50-Zielverteilung hergestellt - der Depotwert bleibt dabei
+    # unveraendert, es wird nur umgeschichtet.
     rows = [
         PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),
         PriceRow(date(2024, 1, 8), {"T1": Decimal("200")}),
@@ -312,10 +343,11 @@ def test_rebalancing_investiert_geparktes_kapital_sobald_der_kurs_existiert():
     ]
     result = simulate(rows, REBALANCING_MISSING_PRICE_STRATEGY)
 
-    # Der Gesamtwert bleibt bei 1497 (T1 unveraendert bei 200), jetzt aber
-    # vollstaendig investiert: 748.50 / 50 = 14.97 Stueck T2.
-    assert result.value_history[2].total_value == Decimal("1497")
-    assert result.holdings["T2"] == Decimal("14.97")
+    # T1 steht unveraendert bei 200, der Gesamtwert bleibt also 1996 - jetzt aber
+    # je 998 auf T1 (4.99 Stueck) und T2 (998 / 50 = 19.96 Stueck) verteilt.
+    assert result.value_history[2].total_value == Decimal("1996")
+    assert result.holdings["T1"] == Decimal("4.99")
+    assert result.holdings["T2"] == Decimal("19.96")
 
 
 # --- Paket A: Steuerkorrektheit (#37/#38/#39, siehe #46) --------------------


### PR DESCRIPTION
Zwei zusammenhängende Fehler, die erst durch die auf 20 Jahre verlängerte Kurshistorie sichtbar wurden, plus die dazugehörige Dokumentation. Beide Fehler betreffen Instrumente, die zu einem Zeitpunkt schlicht noch nicht existierten (Bitcoin vor 2009, Rivian vor dem IPO 2021, die meisten ETFs am Anfang der Historie).

**Der letzte Kursabruf war nicht die Ursache** – der letzte Problem-Eintrag in `fetch_log.csv` stammt von 2025-09-05, alle 17 Ticker haben in der letzten Zeile frische Kurse.

## Teil 1: Rebalancing zerstörte Depotwert

`engine.rebalance_to_targets()` führt kein Cash-Konto: Verkaufserlöse werden nirgends gutgeschrieben, Kaufbeträge nirgends entnommen. Die Umschichtung ist **allein dadurch summenneutral, dass sich die `diffs` über alle Instrumente zu genau dem vorhandenen `pending_cash` aufaddieren.**

Instrumente ohne Kurs wurden stillschweigend übersprungen (`if price is None: continue`). Damit galt die Invariante nicht mehr: die Verkäufe der übrigen Instrumente liefen weiter, der zugehörige Kauf entfiel, und der Erlös verschwand ersatzlos.

| Datum | Verkauf | Kauf | Verschwunden |
|---|---|---|---|
| 2017-12-22 | 3.973,55 € | 3.497,55 € | 476,00 € |
| 2017-12-29 | 4.141,10 € | 2.091,89 € | 2.049,20 € |
| 2018-01-05 | 1.085,40 € | 0,00 € | 1.085,40 € |

Der Zerfall beginnt exakt am 2017-12-22 – dem ersten Kurstag von EUNA – und halbiert das Depot danach wöchentlich bis auf **exakt 0 €** („Sell in May", „Cost-Average-Einstieg"). Bezeichnend: **„Buy & Hold" war als einziges Szenario unbetroffen**, weil es nie rebalanciert.

**Fix:** Der Zielanteil nicht handelbarer Instrumente wird als `pending_cash` geparkt.

## Teil 2: Totes Cash verzerrte die frühen Jahre

Das Parken behebt zwar die Wertzerstörung, lässt aber einen großen Teil des Depots unverzinst liegen: **2007 lagen 68% als Cash brach**. Die Rendite der frühen Jahre bildet damit vor allem Leerlauf ab, nicht den Markt.

**Fix:** `handelbare_gewichte()` legt den Zielanteil nicht handelbarer Instrumente anteilig auf die tatsächlich verfügbaren um. Die relativen Verhältnisse *innerhalb* der verfügbaren Instrumente bleiben erhalten; das Depot bleibt voll investiert – in dem, was es zu diesem Zeitpunkt gab.

Zwei Ereignisse setzen Kapital neu an, **beide bewusst unabhängig von `opt.rebalancing`**, weil es Erstkäufe sind und kein Korrigieren von Drift (sonst hielte `BUY_AND_HOLD` nie ein Instrument, das es bei Simulationsbeginn noch nicht gab):

- **`neues_instrument`** – sobald ein Ticker erstmals einen Kurs hat.
- **`kapitaleinsatz`** – sobald geparktes Cash wieder ein handelbares Ziel hat. Nötig, weil der Rebalancing-Trigger nur Topf A prüft: war zeitweise *kein* Zielinstrument handelbar (z. B. „Sell in May" startet im September 2006 defensiv, Topf A existiert erst ab 2008), sind Ist- und Zielgewicht von Topf A beide 0 und das Kapital käme nie wieder zum Einsatz.

Bleibt kein einziges Zielinstrument handelbar, wird weiterhin geparkt – „raus aus dem Markt" ohne verfügbares defensives Instrument *ist* Cash. Genau deshalb halten „Sell in May" und „Cost-Average-Einstieg" in der ersten Woche noch 100% Cash; das ist die Definition der Szenarien, kein Fehler.

## Teil 3: Prämissen-Seite und Doku

Neue Unterseite `docs/praemissen.html`, über ein **Drei-Punkt-Menü im Kopf jeder Seite** erreichbar (reines CSS/HTML via `<details>`, kein JS). Sie macht nachvollziehbar, worauf die Zahlen beruhen:

- Datenbasis (Zeitraum, Zeilenzahl, Frequenz, Währung, Carry-Forward)
- Instrumententabelle mit **erstem Kurstag je Ticker** – ⚠ markiert, wo ein Instrument anfangs noch nicht existierte – samt Teilfreistellung, Thesaurierung, Spekulationsfrist
- Handelsregeln inkl. Rebalancing-Auslöser je Strategie
- Steuerannahmen, mit ausdrücklich als **Platzhalter** gekennzeichneten Konstanten
- Definition der Kennzahlen (Volatilität, Max Drawdown, Sharpe, Sortino, SMA-Näherung, Walk-Forward)
- explizite Liste des **nicht** Modellierten: Dividenden, Inflation, Spread/Slippage, TER, Zinsen auf Cash, Kapitalmaßnahmen

Ganz oben stehen die drei Einschränkungen, die schwerer wiegen als jede Renditezahl: Rückschaufehler bei der Instrumentenauswahl, nicht optimierte/gebacktestete Regeln, und ein einziger Kursverlauf ohne Konfidenzintervalle.

`_praemissen_kontext()` leitet **alles** aus den tatsächlich verwendeten Konstanten, `instruments.py` und der übergebenen Kurshistorie ab – nach demselben Prinzip wie `learnings.py`, damit die Seite nicht gegenüber dem Code veralten kann. Ein Test prüft genau das.

CLAUDE.md und README dokumentieren zusätzlich die Werterhaltungs-Invariante, `handelbare_gewichte()`, beide neuen Auslöser, die Platzhalter-Konstanten, den Rückschaufehler und den auf 20 Jahre erhöhten Backfill-Default.

## Auswirkung (Startkapital 10.000 €, 20 Jahre)

| Strategie / Szenario | vorher | nur Teil 1 | mit Teil 2 |
|---|---|---|---|
| Barbell 20/80 | 92.068,87 | 89.407,61 | 125.893,13 |
| Barbell 30/70 | 86.320,00 | 84.593,54 | 111.486,78 |
| Barbell 20/60/20 + Satellit | 89.878,73 | 138.386,79 | 207.239,86 |
| Sell in May | **0,00** | 41.828,59 | 84.397,79 |
| Buy & Hold | 79.912,28 | 79.912,28 | 127.080,11 |
| Jahresendrallye | 19.403,81 | 53.516,12 | 119.230,05 |
| Antizyklisch kaufen | 22.968,54 | 56.915,76 | 137.228,80 |
| Verluste begrenzen | 17.173,36 | 44.900,35 | 103.106,49 |
| Börsenweisheiten (kombiniert) | 8.533,46 | 40.099,53 | 88.188,73 |
| SMA-Crossover (10/40) | 39.218,59 | 45.444,21 | 79.268,03 |
| SMA-Crossover (4/20) | 40.883,66 | 45.340,14 | 80.623,35 |
| Momentum-Rotation | 32.570,77 | 59.106,77 | 114.046,94 |
| Volatilitätsbasierte Aktienquote | 20.855,59 | 57.307,34 | 125.004,99 |
| Cost-Average-Einstieg | **0,00** | 58.793,85 | 125.320,44 |

Damit erklärt sich auch, warum SMA über 20 Jahre schlechter aussah als über 5: je länger die Historie, desto mehr Rebalancings mit noch nicht existierenden Instrumenten – und desto mehr zerstörter Wert.

## Test plan

- [x] Regressionstests in `tests/test_engine.py` mit von Hand vorgerechneten Werten: Werterhaltung über das Rebalancing, Umlegung auf vorhandene Instrumente, Erstkauf eines neu verfügbaren Instruments auch bei `rebalancing=False`, Grenzfall „kein einziges Instrument handelbar" (Parken greift weiterhin)
- [x] Gegenprobe: die Werterhaltungs-Tests schlagen ohne Teil 1 fehl (`1247.50` statt `1497` – exakt der ausgelassene Kaufbetrag)
- [x] Tests für die Prämissen-Seite: wird erzeugt, von Start- *und* Detailseite verlinkt, Werte stammen nachweislich aus den Konstanten statt aus hartem Template-Text
- [x] `pytest -q` – 156 Tests grün
- [x] Determinismus geprüft (zweifacher Lauf, identische Wertreihe und Trades)
- [x] Simulation über die reale 20-Jahres-Historie: kein Szenario fällt auf 0 €, keines hält dauerhaft totes Cash
- [x] `python scripts/build_dashboard.py` läuft durch; Prämissen-Seite und Drei-Punkt-Menü im Browser (Chromium) visuell geprüft, hell und dunkel über die vorhandenen Theme-Variablen

## Offener Punkt

`BTC-EUR` hat trotz `--years 20` nur 50 Wochen Historie – siehe #56. Bis das geklärt ist, wird BTC erst am 2025-09-14 zu 98.320 € gekauft, und ein realistischeres, gestaffeltes BTC-Einstiegsmuster bringt noch nichts.