### PR TITLE
Cash-Begründung dokumentieren: warum keine separate Cash-Position nötig ist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,18 @@ inkrementell fortgeschrieben).
   0 und das geparkte Kapital käme nie wieder zum Einsatz. Bleibt bei
   `summe <= 0` (kein einziges Zielinstrument handelbar) alles geparkt, ist
   das gewollt: „raus aus dem Markt" ohne verfügbares defensives Instrument
-  *ist* Cash. Dezember-Harvest realisiert Verluste (größter zuerst) bis der
+  *ist* Cash. **Warum das kaum vorkommt:** Die Strategien haben ohnehin
+  keine eigene Cash-Position im Zielportfolio (siehe README „No separate
+  cash position", #35) — Topf A übernimmt die Cash-Rolle. Geparktes Kapital
+  ist deshalb ein rein technischer, vorübergehender Zustand
+  (`pending_cash`), keine gewollte Anlageklasse. Gegen die reale
+  20-Jahres-Historie geprüft (Stand #55): über alle Strategien und
+  Szenarien hinweg liegt zu **jedem** Zeitpunkt 0% Cash, mit einer einzigen
+  Ausnahme — „Sell in May" hält 27 Wochen lang 100% Cash (September 2006
+  sowie Mai–September 2007), weil 4GLD als einziges Topf-A-Instrument
+  dieser Frühphase erst ab 2008-01-11 einen Kurs hat und die defensive
+  Season damit buchstäblich kein Ziel hatte. Ab 2008 tritt der Fall nie
+  wieder auf. Dezember-Harvest realisiert Verluste (größter zuerst) bis der
   verbleibende Sparerpauschbetrag des Jahres gedeckt ist, mit sofortigem
   Rückkauf zum selben Kurs. `simulate(price_history, strategy,
   optimierungen=None)` nimmt optional eine `Optimierungen`-Instanz entgegen
@@ -330,15 +341,26 @@ inkrementell fortgeschrieben).
   mit **erstem Kurstag je Ticker** (⚠ bei später verfügbaren), Handels- und
   Steuerregeln, die Kennzahl-Definitionen sowie eine explizite Liste des
   nicht Modellierten (Dividenden, Inflation, Spread/Slippage, TER,
-  Zinsen auf Cash). Ganz oben stehen die drei Einschränkungen, die schwerer
-  wiegen als jede Renditezahl: Rückschaufehler bei der Instrumentenauswahl,
-  nicht optimierte/gebacktestete Regeln, und ein einziger Kursverlauf ohne
-  Konfidenzintervalle. `_praemissen_kontext()` leitet dafür **alles** aus
-  den tatsächlich verwendeten Konstanten (`strategies.py`), aus
-  `instruments.py` und aus der übergebenen Kurshistorie ab — nach demselben
-  Prinzip wie `learnings.py`: nichts auf der Seite ist hinterlegter Text,
-  der gegenüber dem Code veralten könnte. Beim Ergänzen deshalb keine
-  Zahl hart ins Template schreiben, sondern über den Kontext ziehen.
+  Zinsen auf Cash). Ein eigener Abschnitt "Cash und ungenutztes Kapital"
+  begründet, warum Strategien keine eigene Cash-Zielallokation kennen (Topf
+  A übernimmt die Cash-Rolle, siehe README "No separate cash position",
+  #35) und zeigt zusätzlich `_cash_anteil_max()` je Strategie/Szenario: den
+  größten je erreichten Anteil an technischem `pending_cash`
+  (Kapitalanteil ganz ohne handelbares Ziel, #55) samt Datum — in
+  `_build_strategy_view()` aus `result.value_history` berechnet und als
+  `cash_max_pct`/`cash_max_datum` im View abgelegt, damit die empirische
+  Aussage ("Cash kommt praktisch nicht vor") nicht von der Kurshistorie
+  abweichen kann. Ganz oben stehen die drei Einschränkungen,
+  die schwerer wiegen als jede Renditezahl: Rückschaufehler bei der
+  Instrumentenauswahl, nicht optimierte/gebacktestete Regeln, und ein
+  einziger Kursverlauf ohne Konfidenzintervalle. `_praemissen_kontext()`
+  leitet dafür **alles** aus den tatsächlich verwendeten Konstanten
+  (`strategies.py`), aus `instruments.py`, aus der übergebenen Kurshistorie
+  und aus den bereits berechneten Strategie-`views` ab (keine zusätzliche
+  Simulation) — nach demselben Prinzip wie `learnings.py`: nichts auf der
+  Seite ist hinterlegter Text, der gegenüber dem Code veralten könnte. Beim
+  Ergänzen deshalb keine Zahl hart ins Template schreiben, sondern über den
+  Kontext ziehen.
 - `learnings.py` — leitet die Sektion "Key Learnings" (ganz oben im Dashboard)
   bei jedem Build neu aus den Strategie-Views ab. **Keine hinterlegten
   Erkenntnis-Texte:** fest ist nur die Fragestellung je Regel (reine Funktion
@@ -464,7 +486,9 @@ erzeugt und von Start- *und* Detailseite verlinkt wird, dass ihre Werte
 tatsächlich aus `ORDERGEBUEHR`/`SPARERPAUSCHBETRAG_PRO_JAHR`/`TICKERS` und
 der übergebenen Historie stammen (statt hart im Template zu stehen), und
 dass die wesentlichen Einschränkungen samt Platzhalter-Kennzeichnung
-benannt sind.
+benannt sind, sowie dass der Cash-Abschnitt für eine Strategie ohne jemals
+ungenutztes Kapital "0.0" und für eine Strategie mit durchgehend
+fehlendem Zielinstrument den korrekten Cash-Höchststand samt Datum zeigt.
 `tests/test_learnings.py` fährt jede Learning-Regel gegen
 konstruierte Views mit bekannten Zahlen und prüft, dass die Aussagen den
 Daten folgen statt fest zu sein (inkl. Gegenprobe mit umgedrehter

--- a/README.md
+++ b/README.md
@@ -378,6 +378,19 @@ pytest -q
   derived comes exclusively from real market data; (2) it would implicitly
   duplicate bucket A without serving any other purpose. Discussed and
   decided in [#35](https://github.com/S540d/Boersenspiel/issues/35).
+  A different, purely technical kind of "cash" still exists internally:
+  `pending_cash` in `engine.py` temporarily parks the target share of an
+  instrument that has no price *at all yet* for the current row (not yet
+  listed, or — before [#55](https://github.com/S540d/Boersenspiel/issues/55) —
+  no tradeable bucket-A target). It is not a strategic allocation, only a
+  bookkeeping placeholder invested as soon as a target exists (see
+  `handelbare_gewichte()` below). Checked against the real 20-year history
+  after #55: every strategy and scenario holds 0% cash at every point in
+  time, with a single exception — "Sell in May" holds 100% cash for 27
+  weeks (September 2006 and May–September 2007), because 4GLD, the only
+  bucket-A instrument available that early, has no price before
+  2008-01-11 and the defensive season therefore had no target at all. The
+  case never recurs after 2008.
 - **Initial purchase:** Order fees (€1/trade) are deducted **from the
   starting capital before the split** across buckets.
 - **Later trades** (rebalancing, December harvest): fees reduce the realized

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -318,6 +318,7 @@ def _build_strategy_view(
     max_drawdown_pct = _max_drawdown_pct(total_values)
     sharpe_ratio = _sharpe_ratio(total_values)
     sortino_ratio = _sortino_ratio(total_values)
+    cash_max_pct, cash_max_datum = _cash_anteil_max(points)
     walk_forward_segmente = _walk_forward_segmente(rows, strategy)
     walk_forward_spread_pp = (
         max(seg["rendite_pct"] for seg in walk_forward_segmente)
@@ -355,6 +356,9 @@ def _build_strategy_view(
         "sharpe_label": f"{sharpe_ratio:.2f}",
         "sortino_ratio": sortino_ratio,
         "sortino_label": f"{sortino_ratio:.2f}",
+        "cash_max_pct": cash_max_pct,
+        "cash_max_label": f"{cash_max_pct:.1f}",
+        "cash_max_datum": cash_max_datum or "–",
         "labels_json": json.dumps(labels),
         "total_values": total_values,
         "total_values_json": json.dumps(total_values),
@@ -388,6 +392,27 @@ def _build_strategy_view(
     }
 
 
+def _cash_anteil_max(points: list) -> tuple[float, str | None]:
+    """Größter Anteil ungenutzten (nicht in ein Instrument investierten)
+    Kapitals über den gesamten Wertverlauf, in Prozent, plus das Datum dieses
+    Höchststands. Cash ist hier ausschließlich der technische
+    ``pending_cash``-Zustand aus ``engine.py`` (Kapitalanteil ohne
+    handelbares Ziel) - siehe README „No separate cash position": die
+    Strategien selbst kennen keine Cash-Zielallokation, Topf A übernimmt
+    diese Rolle."""
+    best_pct = 0.0
+    best_datum: str | None = None
+    for vp in points:
+        if vp.total_value <= 0:
+            continue
+        invested = sum(vp.ticker_values.values(), Decimal(0))
+        pct = float((vp.total_value - invested) / vp.total_value * 100)
+        if pct > best_pct:
+            best_pct = pct
+            best_datum = vp.date.isoformat()
+    return best_pct, best_datum
+
+
 def _erste_kurse(rows: list[PriceRow]) -> dict[str, str]:
     """Datum der ersten Kurszeile je Ticker - macht sichtbar, ab wann ein
     Instrument in der Simulation überhaupt handelbar war."""
@@ -399,15 +424,22 @@ def _erste_kurse(rows: list[PriceRow]) -> dict[str, str]:
     return erste
 
 
-def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy]) -> dict:
+def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views: list[dict]) -> dict:
     """Baut die Daten für die Prämissen-Seite.
 
     Bewusst durchgehend aus den tatsächlich verwendeten Konstanten,
-    ``instruments.py`` und der Kurshistorie abgeleitet - nach demselben Prinzip
-    wie ``learnings.py``: nichts hier ist hinterlegter Text, der gegenüber dem
+    ``instruments.py``, der Kurshistorie und den bereits berechneten
+    Strategie-``views`` abgeleitet - nach demselben Prinzip wie
+    ``learnings.py``: nichts hier ist hinterlegter Text, der gegenüber dem
     Code veralten könnte. Ändert sich z. B. ``ORDERGEBUEHR`` oder die
-    Teilfreistellung eines Instruments, ändert sich diese Seite mit.
-    """
+    Teilfreistellung eines Instruments, ändert sich diese Seite mit. Die
+    ``views`` (statt einer erneuten Simulation) liefern insbesondere den
+    tatsächlichen Cash-Höchststand je Strategie/Szenario - siehe „No
+    separate cash position" (README, #35): die Strategien kennen keine
+    eigene Cash-Zielallokation, `cash_max_pct` misst deshalb ausschließlich
+    den technischen `pending_cash`-Zustand (Kapital ohne handelbares Ziel,
+    #55)."""
+    views_by_id = {v["id"]: v for v in views}
     erste = _erste_kurse(rows)
     instrumente = []
     for ticker in TICKERS:
@@ -429,10 +461,12 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy]) -> dic
 
     strategie_liste = []
     for s in strategies:
+        slug = _slug(s.name)
+        view = views_by_id.get(slug, {})
         strategie_liste.append(
             {
                 "name": s.name,
-                "id": _slug(s.name),
+                "id": slug,
                 "startkapital": f"{s.startkapital:.2f}",
                 "schwelle": f"{s.rebalancing_schwelle_pp}",
                 "ziel_topf": s.ziel_topf,
@@ -441,8 +475,12 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy]) -> dic
                 "toepfe": [
                     {"name": t.name, "gewicht": f"{t.gewicht_gesamt * 100:.0f}"} for t in s.toepfe
                 ],
+                "cash_max_label": view.get("cash_max_label", "0.0"),
+                "cash_max_datum": view.get("cash_max_datum", "–"),
             }
         )
+    cash_werte = [s["cash_max_label"] for s in strategie_liste]
+    cash_ueberall_null = all(float(v.replace(",", ".")) == 0.0 for v in cash_werte)
 
     return {
         "instrumente": instrumente,
@@ -461,6 +499,7 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy]) -> dic
         "sma_lang": _SMA_LANG_WOCHEN,
         "walk_forward_segmente": _WALK_FORWARD_SEGMENTE,
         "walk_forward_min_wochen": _WALK_FORWARD_MIN_WOCHEN_PRO_SEGMENT,
+        "cash_ueberall_null": cash_ueberall_null,
     }
 
 
@@ -522,7 +561,7 @@ def build_dashboard(
         detail_path.write_text(detail_html, encoding="utf-8")
 
     praemissen_html = env.get_template("praemissen.html.j2").render(
-        **_praemissen_kontext(rows, strategies), **common_context
+        **_praemissen_kontext(rows, strategies, views), **common_context
     )
     (output_path.parent / "praemissen.html").write_text(praemissen_html, encoding="utf-8")
 

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -143,6 +143,49 @@
       </table>
     </div>
 
+    <h3>Cash und ungenutztes Kapital</h3>
+    <p class="hint">
+      Keine Strategie hat eine eigene Cash-Zielallokation. Schaltet ein
+      Szenario auf „defensiv“ (z.&nbsp;B. „Sell in May“, SMA-Death-Cross,
+      Trailing-Stop), wandert das Kapital vollständig in Topf A (Sicherheit)
+      &ndash; <strong>Topf A übernimmt die Cash-Rolle</strong>, statt einer
+      unverzinsten oder mit einem erfundenen Zins versehenen Cash-Position.
+      Eine echte Cash-Position hätte zwei Nachteile: sie bräuchte einen
+      Phantasiezins statt eines aus der Kurshistorie ableitbaren Werts, und
+      sie würde Topf A ohne eigenen Zweck duplizieren.
+    </p>
+    <p class="hint">
+      Cash im technischen Sinn (<code>pending_cash</code> in
+      <code>engine.py</code>) entsteht trotzdem kurzzeitig, wenn ein
+      Kapitalanteil <em>überhaupt kein</em> handelbares Ziel hat &ndash; etwa
+      weil ein Instrument noch keinen Kurs hat oder, im Extremfall, kein
+      einziges Zielinstrument eines Topfs existiert. Das ist kein Fehler,
+      sondern die einzig ehrliche Abbildung von „raus aus dem Markt ohne
+      verfügbares Instrument“.
+      {% if cash_ueberall_null %}
+      Über die komplette Kurshistorie betrachtet hält aktuell jede
+      Strategie und jedes Szenario durchgehend 0% Cash.
+      {% else %}
+      Über die komplette Kurshistorie betrachtet hält aktuell nicht jede
+      Strategie durchgehend 0% Cash &ndash; die Tabelle unten zeigt den
+      höchsten je erreichten Anteil und wann er auftrat.
+      {% endif %}
+    </p>
+    <div class="overflow-x">
+      <table>
+        <thead><tr><th>Strategie</th><th>Cash-Höchststand %</th><th>Datum</th></tr></thead>
+        <tbody>
+        {% for s in strategien %}
+          <tr>
+            <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
+            <td class="{{ 'warn' if s.cash_max_label != '0.0' else '' }}">{{ s.cash_max_label }}</td>
+            <td>{{ s.cash_max_datum }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
     <h3>Steuerannahmen</h3>
     <div class="stat-row">
       <div class="stat-tile"><div class="label">Steuersatz</div><div class="value">{{ steuersatz }} %</div></div>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -457,3 +457,39 @@ def test_praemissen_seite_markiert_spaeter_verfuegbare_instrumente(tmp_path: Pat
     html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
 
     assert "Instrumente und ab wann es sie gab" in html
+
+
+# --- Cash-Abschnitt (Begruendung "keine separate Cash-Position" + Live-Werte) ----------
+
+
+def test_praemissen_seite_zeigt_null_prozent_cash_wenn_immer_alles_investiert_ist(tmp_path: Path):
+    # ZWEI_STRATEGIEN kaufen T1 sofort vollstaendig und rebalancieren nie -> zu
+    # keinem Zeitpunkt ungenutztes Kapital. Die Seite muss das aus den Views
+    # ableiten, nicht behaupten.
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    assert "Cash und ungenutztes Kapital" in html
+    assert "Topf A" in html  # Begruendung "Topf A uebernimmt die Cash-Rolle"
+    assert "hält aktuell jede" in html
+    assert html.count(">0.0<") >= 2
+
+
+def test_praemissen_seite_zeigt_cash_hoechststand_wenn_kein_zielinstrument_handelbar(tmp_path: Path):
+    # T2 hat in KEINER Zeile einen Kurs -> das Kapital dieses (isolierten)
+    # Topfs bleibt vollstaendig geparkt (pending_cash), da handelbare_gewichte()
+    # nichts zum Umlegen findet.
+    strategie = Strategy(
+        name="Nur T2",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T2": Decimal("1")})],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+    build_dashboard(_rows(), [strategie], output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    assert "hält aktuell nicht jede" in html
+    assert "100.0" in html
+    assert "2024-01-01" in html.split("Cash und ungenutztes Kapital", 1)[1]


### PR DESCRIPTION
## Kontext

Nachtrag zu PR #55: Dieser Commit wurde erst gepusht, **nachdem** #55 bereits gemergt war (Push um 16:46:57 UTC, Merge um ~16:43 UTC) und ist deshalb nicht in `main` gelandet, obwohl er im ursprünglichen Chat als Teil derselben Arbeit besprochen und angekündigt wurde. Dieser PR trägt ihn nach, sauber auf dem aktuellen `main` aufgesetzt (per Cherry-Pick des verwaisten Commits, keine Konflikte).

## Inhalt

Der Nutzer fand die im Chat besprochene Begründung überzeugend ("Cash nicht notwendig, weil Topf A die defensiven Werte verfügbar hat") und bat darum, sie dauerhaft zu dokumentieren statt nur mündlich stehen zu lassen:

- **README** – der bestehende Abschnitt „No separate cash position" (#35) beschrieb bisher nur die *strategische* Entscheidung (Topf A übernimmt die Cash-Rolle). Ergänzt um die *empirische* Bestätigung nach dem #55-Fix: über die reale 20-Jahres-Historie hält jede Strategie/jedes Szenario 0% Cash, mit einer dokumentierten Ausnahme (Sell in May, 27 Wochen 2006/2007, weil 4GLD als einziges frühe Topf-A-Instrument erst ab 2008 existiert). Klarstellung, dass Design-Entscheidung und der technische `pending_cash`-Mechanismus zwei verschiedene Ebenen sind.
- **CLAUDE.md** – dieselbe empirische Bestätigung direkt bei der `handelbare_gewichte()`-Doku.
- **Prämissen-Seite** (`docs/praemissen.html`) – neuer Abschnitt „Cash und ungenutztes Kapital": begründet die Topf-A-als-Cash-Rolle **und** zeigt live aus der Simulation für jede Strategie/jedes Szenario den tatsächlichen Cash-Höchststand samt Datum, statt die Aussage als Text zu behaupten. `dashboard._cash_anteil_max()` berechnet das aus `result.value_history` in `_build_strategy_view()` – nach demselben Prinzip wie der Rest der Seite (`learnings.py`-Muster): nichts hier ist hinterlegter Text, der gegenüber der Kurshistorie veralten könnte. `_praemissen_kontext()` nimmt dafür neu die bereits berechneten `views` entgegen statt selbst erneut zu simulieren.

## Test plan

- [x] Zwei neue Tests: eine Strategie ohne je ungenutztes Kapital zeigt `0.0`, eine Strategie mit durchgehend fehlendem Zielinstrument zeigt den korrekten Cash-Höchststand samt Datum
- [x] `pytest -q` – 158 Tests grün
- [x] `python scripts/build_dashboard.py` läuft durch; neuer Abschnitt gegen die reale Historie geprüft (Sell in May: 100,0% am 2006-09-01, alle übrigen 0,0%)

---
_Generated by [Claude Code](https://claude.ai/code/session_012kp32b5QDsZs6SGVaFHroF)_