### PR TITLE
7 Datenreihen aufnehmen, Tagesbudget 18 → 25 Requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ pytest tests/test_engine.py -q     # einzelne Testdatei
 pytest tests/test_engine.py::test_simple_strategy_end_to_end_exact_values -q  # einzelner Test
 
 python scripts/run_fetch.py                        # Kursabruf via Alpha Vantage (benötigt ALPHAVANTAGE_API_KEY env var)
-python scripts/backfill_history.py --years 20       # einmaliger historischer Backfill (ersetzt price_history.csv, ~18 API-Requests)
+python scripts/backfill_history.py --years 20       # einmaliger historischer Backfill (ersetzt price_history.csv, 25 API-Requests = Tageslimit)
 python scripts/build_dashboard.py                  # baut docs/index.html aus data/price_history.csv (Strategien + Szenarien)
 python scripts/build_dashboard.py --strategy "Barbell 20/80"  # nur eine Strategie/ein Szenario rendern
 ```
@@ -48,9 +48,28 @@ inkrementell fortgeschrieben).
 
 ### Trennung der Verantwortlichkeiten (wichtig beim Erweitern)
 
-- `instruments.py` — die 17 Instrumente (7 Barbell-Basisinstrumente + 10
-  Einzelaktien-Satellit, s.u.), **quellenunabhängig**. Kein
+- `instruments.py` — die 24 Instrumente (7 Barbell-Basisinstrumente + 10
+  Einzelaktien-Satellit + 7 nicht allokierte Datenreihen, s.u.), **quellenunabhängig**. Kein
   Provider-Symbol-Mapping hier.
+  **Datenreihen ohne Allokation (#64):** Die sieben zuletzt ergänzten
+  Instrumente (`IUSA`, `XEON`, `EXSA`, `IBCL`, `IBCI`, `IQQ6`, `EXXY`) stehen
+  bewusst in **keinem Topf**. `engine.simulate()` liest ausschließlich
+  `strategy.alle_ticker_gewichte()` — ein Instrument ohne Topf wird nie
+  gehandelt und verändert keine veröffentlichte Zahl (per Test abgesichert,
+  Renditen sind vor und nach der Aufnahme bit-identisch). Es landet nur in
+  `price_history.csv`. Grund: erst Daten sammeln, dann allokieren — die
+  Zuordnung hängt an den Methodenentscheidungen aus #63, ohne die Kurse jetzt
+  mitzuerheben bräuchte es später aber einen zweiten kompletten Backfill an
+  einem zweiten Tag. Alle sieben sind XETRA-Symbole in EUR, kosten also keinen
+  zusätzlichen FX-Request und umgehen das Währungsproblem aus #62 vollständig.
+  Ihre Steuerattribute (`teilfreistellung`/`thesaurierend`/`ausschuettend`)
+  sind aus Fondsgattung und Namenszusatz abgeleitet, **nicht** gegen die
+  Prospekte geprüft — solange die Instrumente in keinem Topf liegen, wertet die
+  Engine sie nie aus; vor einer Allokation gehören sie verifiziert.
+  **Request-Budget:** Mit 24 Instrumenten brauchen Backfill *und* Wochenabruf
+  je **genau 25** Requests — das volle Alpha-Vantage-Tageslimit, kein Puffer.
+  `tests/test_backfill_history.py` hält das als Test fest, damit ein
+  18. Instrument nicht still beide Workflows unmöglich macht.
 - `strategies.py` — austauschbare `Strategy`-Definitionen (Töpfe,
   Sub-Gewichte, Rebalancing-Schwelle, Startkapital) + strategieübergreifende
   Steuer-/Gebührkonstanten. Die Engine enthält **keine** Barbell-spezifischen
@@ -543,7 +562,7 @@ eine aussagekräftige Exception aus. Der FX-Abruf läuft bewusst **vor** den
 Ticker-Abrufen, damit ein Fehlschlag einen statt 17 Requests kostet. Für den Lauf gibt es den manuell startbaren
 Workflow `.github/workflows/backfill.yml` (nutzt das Repo-Secret, verlangt
 `confirm=REPLACE`, schreibt eine Plausibilitätsprüfung in die Job-Summary) -
-nicht am selben Tag wie den wöchentlichen Kursabruf starten (18 + 18
+nicht am selben Tag wie den wöchentlichen Kursabruf starten (25 + 25
 Requests > Tageslimit 25). `--years` ist nur eine untere Schranke, die
 `AlphaVantageSource.fetch_weekly_history()`/`fetch_crypto_weekly_history()`
 zum Filtern der von Alpha Vantage gelieferten Zeitreihe nutzen - ein Wert,

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ instead of a Google Sheet, output as a static dashboard on GitHub Pages.
 
 ## The portfolio
 
-Every strategy and scenario draws from the same 17 instruments defined in
-`instruments.py`; which of them a given strategy actually holds, and at what
-weight, is decided separately in `strategies.py`. Two buckets recur in every
-strategy:
+Every strategy and scenario draws from 17 of the 24 instruments defined in
+`instruments.py` — the other seven are unallocated data series (see below).
+Which of them a given strategy actually holds, and at what weight, is decided
+separately in `strategies.py`. Two buckets recur in every strategy:
 
 - **Bucket A – Safety**: broad, low-volatility instruments — a global bond
   ETF and physical gold. Always the smaller half of the barbell (20% or 30%,
@@ -38,6 +38,27 @@ Tesla, Palantir, Strategy/formerly MicroStrategy, Rivian) with two defensive
 blue chips (Coca-Cola, Roche) as a counterexample — a first pass, not an
 optimized or backtested selection.
 
+### Unallocated data series
+
+Seven further instruments are fetched every week but held by **no strategy**:
+
+| Role | Ticker | Instrument |
+|---|---|---|
+| Benchmark S&P 500 | `IUSA` | iShares Core S&P 500 (Dist) |
+| EUR money market | `XEON` | Xtrackers II EUR Overnight Rate 1C |
+| Europe | `EXSA` | iShares STOXX Europe 600 (DE) |
+| Government bonds 15–30y | `IBCL` | iShares € Govt Bond 15-30yr |
+| Inflation-linked | `IBCI` | iShares € Inflation Linked Govt Bond |
+| Real estate | `IQQ6` | iShares Developed Markets Property Yield |
+| Broad commodities | `EXXY` | iShares Diversified Commodity Swap (DE) |
+
+`engine.simulate()` only ever reads `strategy.alle_ticker_gewichte()`, so an
+instrument that belongs to no bucket is never traded and changes no published
+figure — it just lands in `price_history.csv`. Collecting the prices now means
+a later allocation decision does not require a second full backfill on a
+second day. All seven are XETRA symbols quoted in EUR, so they need no FX
+request and sidestep the currency problem described further below.
+
 ## Architecture
 
 The project splits into two halves that only touch each other through a CSV
@@ -55,7 +76,7 @@ flowchart TB
         store["history_store.record_week()<br/><b>only write path</b><br/>weekly idempotency · carry-forward"]
     end
 
-    store ==> csv[("<b>data/price_history.csv</b><br/>date × 17 tickers<br/><i>raw prices only, nothing derived</i>")]
+    store ==> csv[("<b>data/price_history.csv</b><br/>date × 24 tickers<br/><i>raw prices only, nothing derived</i>")]
     store -.log.-> log[("data/fetch_log.csv")]
 
     subgraph auswertung["② Analytics — fresh on every build, reading"]
@@ -75,7 +96,7 @@ flowchart TB
 ### Process overview
 
 **① Data acquisition.** Once a week, the workflow fetches a price for each of
-the 17 tickers. Everything source-specific — Alpha Vantage symbols, the
+the 24 tickers. Everything source-specific — Alpha Vantage symbols, the
 USD→EUR conversion of the satellite stocks, the dedicated crypto endpoint —
 stays inside `sources/`. The result is always the same: one `PriceQuote` per
 ticker. Which provider delivered the price is no longer visible, or relevant,
@@ -137,9 +158,10 @@ Three properties that are easy to miss:
   runs could happen in any order or in parallel.
 - **Scenarios only use part of the data.** All scenarios in `scenarios.py`
   build on the buckets of `Barbell 20/80` and therefore only touch **7 of the
-  17** tickers; the 10 satellite stocks appear only in
-  `Barbell 20/60/20 + Single-Stock Satellite`. The price history is
-  deliberately broader than any single evaluation.
+  24** tickers; the 10 satellite stocks appear only in
+  `Barbell 20/60/20 + Single-Stock Satellite`, and seven are unallocated data
+  series. The price history is deliberately broader than any single
+  evaluation.
 - **No lookahead.** Every `gewichte_fn` may only read `rows[:i+1]`. A rule
   deciding in week i must not know week i+1 — otherwise every result would be
   worthless.
@@ -172,7 +194,7 @@ strategy always yields the identical result.
 
 | File | Purpose |
 |---|---|
-| `src/boersenspiel/instruments.py` | The 17 instruments (7 barbell base instruments + 10 single-stock satellite; ticker, ISIN) – source-independent |
+| `src/boersenspiel/instruments.py` | The 24 instruments (7 barbell base + 10 single-stock satellite + 7 unallocated data series; ticker, ISIN) – source-independent |
 | `src/boersenspiel/strategies.py` | Interchangeable strategy definitions (weights, buckets, rebalancing threshold) + cross-strategy tax/fee constants |
 | `src/boersenspiel/history_store.py` | Only write path to `data/price_history.csv` / `data/fetch_log.csv` |
 | `src/boersenspiel/sources/` | Interchangeable price sources (default: `alphavantage.py`) |
@@ -241,9 +263,13 @@ rate is available for a given week).
 python scripts/backfill_history.py --years 20  # default: 20 years back (lower bound only)
 ```
 
-Uses roughly 18 requests once (16 non-crypto tickers + 1× `FX_WEEKLY` + 1×
-crypto) - fits within the daily free-tier limit of 25, but shouldn't run
-more than once on the same day. **Replaces** `price_history.csv` completely -
+Uses exactly 25 requests (23 non-crypto tickers + 1× `FX_WEEKLY` + 1× crypto)
+— the full daily free-tier limit, with no headroom left since the seven
+unallocated data series were added. A re-run after a network error, a debug
+call, or the weekly fetch on the same day will all breach it. An unresolvable
+ticker symbol aborts the run without returning the requests already spent, so
+verify symbols (`SYMBOL_SEARCH`) before adding an instrument;
+`tests/test_backfill_history.py` guards the budget itself. **Replaces** `price_history.csv` completely -
 no merging with previously live-collected weeks is needed, since the backfill
 already covers those (and older) weeks anyway.
 
@@ -522,7 +548,7 @@ pytest -q
 
 ## Known limitations
 
-- **Hindsight bias in instrument selection:** the 17 instruments were picked
+- **Hindsight bias in instrument selection:** the instruments were picked
   when their price history was already known. A backtested return therefore
   does not answer "what would I have earned?", only "how would these rules
   have played out on these, retrospectively chosen, instruments?". The
@@ -543,7 +569,7 @@ pytest -q
   its high rather than across the full period — see
   [#56](https://github.com/S540d/Boersenspiel/issues/56).
 - **Alpha Vantage free-tier limit:** 25 requests/day, max. 1 request/second.
-  Still unproblematic for the current 17 tickers fetched once a week, but
+  Still unproblematic for the current 24 tickers fetched once a week, but
   barely any headroom for additional manual fetches on the same day;
   `AlphaVantageSource` sleeps between requests. If a price still fails (e.g.
   due to rate limiting or an empty response), the last known price is

--- a/scripts/backfill_history.py
+++ b/scripts/backfill_history.py
@@ -12,10 +12,14 @@ EUR umgerechnet, damit die Historie waehrungskonsistent zum Rest des
 Portfolios ist - dieselbe Umrechnung, die auch der laufende Live-Abruf
 (``run_fetch.py``) fuer diese Ticker vornimmt.
 
-Verbraucht ca. 18 Requests (16 nicht-Krypto-Ticker + 1x FX_WEEKLY + 1x
-Krypto) - passt in das taegliche Alpha-Vantage-Free-Tier-Limit von 25, sollte
-aber NICHT mehrfach am selben Tag laufen (das Limit gilt pro Tag und API-Key,
-nicht pro Skriptlauf). BTC-EUR laeuft dabei ueber denselben einen FX_WEEKLY-
+Verbraucht 25 Requests (23 nicht-Krypto-Ticker + 1x FX_WEEKLY + 1x Krypto) -
+das ist GENAU das taegliche Alpha-Vantage-Free-Tier-Limit, seit #64 die sieben
+zusaetzlichen Datenreihen dazugekommen sind. Es gibt damit keinen Puffer mehr:
+ein Re-Run nach einem Netzwerkfehler, ein Debug-Abruf oder der Wochenabruf am
+selben Tag reissen das Limit (es gilt pro Tag und API-Key, nicht pro
+Skriptlauf). Ein nicht aufloesbares Ticker-Symbol bricht den Lauf ab, ohne die
+bereits verbrauchten Requests zurueckzugeben - Symbole deshalb vorher pruefen
+(SYMBOL_SEARCH). Der Regressionstest dazu steht in tests/test_backfill_history.py. BTC-EUR laeuft dabei ueber denselben einen FX_WEEKLY-
 Request wie die USD-Einzelaktien (kein zusaetzlicher Request) - siehe
 ``fetch_crypto_weekly_history`` in ``sources/alphavantage.py`` (Issue #56:
 ``DIGITAL_CURRENCY_WEEKLY`` liefert fuer ``market=EUR`` im Free-Tier nur ca.

--- a/src/boersenspiel/instruments.py
+++ b/src/boersenspiel/instruments.py
@@ -95,6 +95,76 @@ INSTRUMENTS: dict[str, Instrument] = {
         Instrument("RIVN", "Rivian Automotive", "US76954A1034", ausschuettend=True),
         Instrument("KO", "Coca-Cola (defensiver Blue Chip)", "US1912161007", ausschuettend=True),
         Instrument("RHHBY", "Roche Holding (ADR, defensiver Blue Chip)", "US7711951043", ausschuettend=True),
+        # --- Datenreihen ohne Allokation (#64) ---------------------------------
+        # Sieben zusaetzliche Instrumente, die das taegliche Alpha-Vantage-Budget
+        # von 25 Requests ausschoepfen (vorher 18). Sie stehen BEWUSST in KEINEM
+        # Topf einer Strategie: `engine.simulate()` liest ausschliesslich
+        # `strategy.alle_ticker_gewichte()`, ein Instrument ohne Topf wird also
+        # nie gehandelt und veraendert keine einzige veroeffentlichte Zahl. Es
+        # landet nur in `price_history.csv`.
+        #
+        # Das ist Absicht: erst Daten sammeln, dann allokieren. Die Zuordnung zu
+        # Toepfen haengt an den Methodenentscheidungen aus #63 (insbesondere dem
+        # Rebalancing-Trigger) - bis dahin waere jede Gewichtung geraten. Ohne
+        # die Kurse jetzt mitzuerheben braeuchte es spaeter aber einen zweiten
+        # kompletten Backfill an einem zweiten Tag.
+        #
+        # ACHTUNG bei der spaeteren Allokation: `teilfreistellung`,
+        # `thesaurierend` und `ausschuettend` unten sind aus Fondsgattung und
+        # Namenszusatz (Dist/Acc) abgeleitet, NICHT gegen die Fondsprospekte
+        # geprueft. Solange die Instrumente in keinem Topf liegen, wertet die
+        # Engine sie nie aus - sobald sie allokiert werden, gehoeren sie
+        # verifiziert, sonst rechnet das Steuermodell mit falschen Annahmen.
+        Instrument(
+            "IUSA",
+            "S&P 500 ETF (iShares Core, aussch.) - Benchmark, nicht allokiert",
+            "IE0031442068",
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            ausschuettend=True,
+        ),
+        Instrument(
+            "XEON",
+            "EUR-Geldmarkt ETF (Xtrackers II Overnight Rate, thes.)",
+            "LU0290358497",
+            # Kein Aktienfonds -> keine Teilfreistellung.
+            thesaurierend=True,
+        ),
+        Instrument(
+            "EXSA",
+            "STOXX Europe 600 ETF (iShares, aussch.)",
+            "DE0002635307",
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            ausschuettend=True,
+        ),
+        Instrument(
+            "IBCL",
+            "Euro-Staatsanleihen 15-30 Jahre ETF (iShares, aussch.)",
+            "IE00B1FZS913",
+            ausschuettend=True,
+        ),
+        Instrument(
+            "IBCI",
+            "Inflationsindexierte Euro-Staatsanleihen ETF (iShares)",
+            "IE00B0M62X26",
+            ausschuettend=True,
+        ),
+        Instrument(
+            "IQQ6",
+            "Immobilien-ETF (iShares Developed Markets Property Yield, aussch.)",
+            "IE00B1FZS350",
+            # Haelt boersennotierte Immobiliengesellschaften/REITs, also >51%
+            # Aktien -> Aktienfonds-Teilfreistellung, nicht die Immobilienfonds-
+            # Quote. Bei der Allokation gegen den Prospekt pruefen.
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            ausschuettend=True,
+        ),
+        Instrument(
+            "EXXY",
+            "Rohstoff-ETF breit (iShares Diversified Commodity Swap)",
+            "DE000A0H0728",
+            # Rohstofffonds -> keine Teilfreistellung.
+            ausschuettend=True,
+        ),
     ]
 }
 

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -59,6 +59,20 @@ ALPHAVANTAGE_SYMBOLS: dict[str, str] = {
     "RIVN": "RIVN",
     "KO": "KO",
     "RHHBY": "RHHBY",
+    # Datenreihen ohne Allokation (#64) - alle sieben bewusst als XETRA-Symbol
+    # in EUR. Damit faellt kein zusaetzlicher FX-Request an, und das gesamte
+    # Waehrungsproblem aus #62 entsteht fuer sie gar nicht erst (FX_WEEKLY
+    # beginnt erst im November 2014). Am 22.08.2026 per SYMBOL_SEARCH geprueft:
+    # jedes Symbol loest auf XETRA in EUR auf. Das ist wichtig, weil ein nicht
+    # aufloesbares Symbol den kompletten Backfill abbricht - bei 25 von 25
+    # Requests waere damit das Tagesbudget verbraucht.
+    "IUSA": "IUSA.DEX",
+    "XEON": "XEON.DEX",
+    "EXSA": "EXSA.DEX",
+    "IBCL": "IBCL.DEX",
+    "IBCI": "IBCI.DEX",
+    "IQQ6": "IQQ6.DEX",
+    "EXXY": "EXXY.DEX",
 }
 
 # Ticker, deren Alpha-Vantage-Symbol in USD notiert - Kurs wird bei jedem

--- a/tests/test_backfill_history.py
+++ b/tests/test_backfill_history.py
@@ -414,3 +414,66 @@ def test_mitgelieferte_fx_datei_deckt_die_luecke_bis_zum_api_beginn():
     # (EUR/USD-Hoch 1,599) und etwa 0,79 EUR im Juli 2010.
     assert fx[date(2008, 7, 15)] == pytest.approx(0.625391, abs=1e-6)
     assert fx[date(2010, 7, 9)] == pytest.approx(0.791327, abs=1e-6)
+
+
+# --- Request-Budget (#64) -----------------------------------------------------
+#
+# Alpha Vantages Free Tier erlaubt 25 Requests pro Tag und API-Key. Mit den
+# sieben Datenreihen aus #64 sind beide Laeufe bei exakt 25 - es gibt keinen
+# Puffer mehr. Ein weiteres Instrument macht jeden Lauf unmoeglich, und ein
+# nicht aufloesbares Symbol bricht den Backfill ab, ohne dass die bereits
+# verbrauchten Requests zurueckkommen. Deshalb als Test statt als Kommentar.
+
+_ALPHAVANTAGE_TAGESLIMIT = 25
+
+
+def _backfill_requests() -> int:
+    """1x FX_WEEKLY + 1x DIGITAL_CURRENCY_WEEKLY + je 1x TIME_SERIES pro
+    nicht-Krypto-Ticker."""
+    return 1 + 1 + len([t for t in TICKERS if t != "BTC-EUR"])
+
+
+def _wochenabruf_requests() -> int:
+    """1x CURRENCY_EXCHANGE_RATE (einmal je fetch(), nicht je Ticker) + je 1x
+    GLOBAL_QUOTE bzw. Krypto-Endpunkt pro Ticker."""
+    return 1 + len(TICKERS)
+
+
+def test_backfill_passt_in_das_tageslimit():
+    assert _backfill_requests() <= _ALPHAVANTAGE_TAGESLIMIT, (
+        f"Backfill braucht {_backfill_requests()} Requests, erlaubt sind "
+        f"{_ALPHAVANTAGE_TAGESLIMIT}. Ein Instrument entfernen oder Premium-Key."
+    )
+
+
+def test_wochenabruf_passt_in_das_tageslimit():
+    assert _wochenabruf_requests() <= _ALPHAVANTAGE_TAGESLIMIT, (
+        f"Wochenabruf braucht {_wochenabruf_requests()} Requests, erlaubt sind "
+        f"{_ALPHAVANTAGE_TAGESLIMIT}."
+    )
+
+
+def test_neue_datenreihen_sind_in_euro_notiert():
+    """Die sieben Instrumente aus #64 sind bewusst XETRA-Symbole. Landete eines
+    in USD_TICKERS, braeuchte es die Umrechnung - und haette damit vor November
+    2014 gar keinen Kurs, weil FX_WEEKLY erst dann beginnt (#62)."""
+    from boersenspiel.sources.alphavantage import ALPHAVANTAGE_SYMBOLS, USD_TICKERS
+
+    neue = ["IUSA", "XEON", "EXSA", "IBCL", "IBCI", "IQQ6", "EXXY"]
+    for ticker in neue:
+        assert ticker in TICKERS, f"{ticker} fehlt in instruments.py"
+        assert ALPHAVANTAGE_SYMBOLS[ticker].endswith(".DEX"), ticker
+        assert ticker not in USD_TICKERS, f"{ticker} braeuchte sonst FX-Umrechnung"
+
+
+def test_neue_datenreihen_liegen_in_keinem_topf():
+    """Solange die Zuordnung an #63 haengt, duerfen die neuen Instrumente keine
+    Strategie beeinflussen: engine.simulate() liest nur
+    strategy.alle_ticker_gewichte(), ein Ticker ohne Topf wird nie gehandelt."""
+    from boersenspiel.scenarios import SCENARIOS
+    from boersenspiel.strategies import STRATEGIES
+
+    neue = {"IUSA", "XEON", "EXSA", "IBCL", "IBCI", "IQQ6", "EXXY"}
+    for strategie in list(STRATEGIES) + list(SCENARIOS):
+        allokiert = set(strategie.alle_ticker_gewichte())
+        assert not (allokiert & neue), f"{strategie.name} allokiert {allokiert & neue}"


### PR DESCRIPTION
Setzt die Vorschläge aus #64 um. **Vor dem nächsten Backfill zu mergen** — sonst kommen die Kurse dieser sieben Instrumente erst mit einem zweiten kompletten Backfill an einem zweiten Tag mit (das Alpha-Vantage-Limit gilt pro Tag und API-Key).

## Die sieben Instrumente

Alle als XETRA-Symbol in EUR notiert:

| Rolle | Ticker | Symbol | Instrument |
|---|---|---|---|
| Benchmark S&P 500 | `IUSA` | `IUSA.DEX` | iShares Core S&P 500 UCITS ETF USD (Dist) |
| EUR-Geldmarkt | `XEON` | `XEON.DEX` | Xtrackers II EUR Overnight Rate Swap 1C |
| Europa | `EXSA` | `EXSA.DEX` | iShares STOXX Europe 600 (DE) EUR (Dist) |
| Staatsanleihen 15–30 J | `IBCL` | `IBCL.DEX` | iShares Euro Government Bond 15-30Yr |
| Inflationsindexiert | `IBCI` | `IBCI.DEX` | iShares Inflation Linked Government Bond |
| Immobilien | `IQQ6` | `IQQ6.DEX` | iShares Developed Markets Property Yield |
| Rohstoffe breit | `EXXY` | `EXXY.DEX` | iShares Diversified Commodity Swap (DE) |

**Symbole verifiziert.** Am 22.08.2026 per `SYMBOL_SEARCH` gegen Alpha Vantage geprüft — alle sieben lösen auf XETRA in EUR auf. Das ist keine Formalie: ein nicht auflösbares Symbol wirft in `_extract_time_series()` und bricht den **kompletten** Backfill ab, ohne die bereits verbrauchten Requests zurückzugeben. Bei 25 von 25 wäre damit der Tag verloren.

Abweichend von #64: für Rohstoffe `EXXY` statt des dort vorgeschlagenen Xtrackers DBLCI (LU0292106167) — letzterer löst bei Alpha Vantage nicht auf.

**EUR-Notierung ist Absicht.** Kein zusätzlicher FX-Request, und das Währungsproblem aus #62 entsteht für diese Instrumente gar nicht erst (`FX_WEEKLY` beginnt erst im November 2014).

## Keine Allokation — bewusst

Alle sieben stehen in **keinem Topf**. `engine.simulate()` liest ausschließlich `strategy.alle_ticker_gewichte()`; ein Instrument ohne Topf wird nie gehandelt und landet nur in `price_history.csv`.

Gegengeprüft — die Renditen sind vor und nach der Aufnahme bit-identisch:

| Strategie | vorher | nachher |
|---|---|---|
| Barbell 20/80 | +52.558,53 % | +52.558,53 % |
| Barbell 30/70 | +32.218,55 % | +32.218,55 % |
| Börsenweisheit: Buy & Hold | +25.941.587,32 % | +25.941.587,32 % |

Die Zuordnung zu Töpfen hängt an den Methodenentscheidungen aus #63, insbesondere am Rebalancing-Trigger — bis dahin wäre jede Gewichtung geraten. Deshalb: erst Daten sammeln, dann allokieren, wie in #64 vorgeschlagen.

⚠️ **Steuerattribute sind ungeprüft.** `teilfreistellung`, `thesaurierend` und `ausschuettend` sind aus Fondsgattung und Namenszusatz (Dist/Acc) abgeleitet, **nicht** gegen die Fondsprospekte. Solange die Instrumente in keinem Topf liegen, wertet die Engine sie nie aus — vor einer Allokation gehören sie verifiziert, sonst rechnet das Steuermodell mit falschen Annahmen. Als Kommentar an den Instrumenten vermerkt.

## Request-Budget: jetzt exakt am Limit

| Lauf | vorher | nachher |
|---|---|---|
| Backfill (`backfill_history.py`) | 18 | **25** |
| Wochenabruf (`run_fetch.py`) | 18 | **25** |

Kein Puffer mehr. Ein Re-Run nach einem Netzwerkfehler, ein Debug-Abruf oder beide Läufe am selben Tag reißen das Limit. Zwei neue Tests machen aus dem bisherigen Kommentar eine Zusicherung, damit ein 25. Instrument nicht still beide Workflows unmöglich macht.

## Kompatibilität mit der bestehenden CSV

Geprüft, dass die neuen Ticker eingetragen werden dürfen, **bevor** der Backfill läuft: `read_price_history()` nutzt `raw.get(t)` und überspringt fehlende Spalten. Der Dashboard-Build läuft gegen die alte 17-Spalten-CSV unverändert durch; die Prämissen-Seite zeigt für die neuen Ticker „– (nie) ⚠", bis der Backfill sie füllt.

## Tests

197 statt 193, alle grün. Neu:
- Backfill und Wochenabruf bleiben im Tageslimit von 25.
- Die neuen Ticker sind EUR-notiert (`.DEX`) und nicht in `USD_TICKERS` — landete einer dort, hätte er vor November 2014 gar keinen Kurs.
- Keine Strategie und kein Szenario allokiert die neuen Ticker.

## Danach

Backfill starten (`.github/workflows/backfill.yml`, `years=20`, `confirm=REPLACE`) — nicht am selben Tag wie den Wochenabruf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaZpeBc2tdNdbmFYSXgiaN)_