### PR TITLE
F4/F5/F6: Rückschaufehler, Rebalancing-Trigger, Kennzahlen-Darstellung (#63)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,28 @@ inkrementell fortgeschrieben).
   Simulationsmechanismen `engine.simulate()` für diese Strategie anwendet —
   `BUY_AND_HOLD` nutzt z. B. `Optimierungen(rebalancing=False)` statt einer
   künstlich unerreichbaren Rebalancing-Schwelle.
+  **Rebalancing-Trigger, "5/25-Regel je Topf" (#63, F5):** Optionales Feld
+  `Strategy.rebalancing_schwelle_relativ` (Decimal, Default `1` = 100%)
+  ergänzt `rebalancing_schwelle_pp` um eine relative Zusatzschwelle. Die
+  Engine rebalanciert, sobald IRGENDEIN Topf entweder um mehr als
+  `rebalancing_schwelle_pp` Prozentpunkte ABSOLUT vom eigenen (per
+  `handelbare_gewichte()` umgelegten) Zielgewicht abweicht, oder um mehr als
+  `rebalancing_schwelle_relativ` RELATIV zu diesem Zielgewicht — je nachdem,
+  welche der beiden Schwellen zuerst greift (Marktstandard-"5/25-Regel").
+  Vorher prüfte der Trigger ausschließlich `ziel_topf` (Topf A) mit einer
+  rein absoluten Schwelle; bei genau zwei komplementären Töpfen (A+B=100%)
+  ist die Abweichung von A immer exakt die von B, weshalb diese Änderung für
+  zweitöpfige Strategien/Szenarien allein wirkungslos bliebe — bei drei oder
+  mehr Töpfen (`BARBELL_20_60_20_SATELLIT`) kann seither aber ein einzelner
+  Topf unbemerkt driften, während Topf A zufällig im Band bleibt. Der
+  Default `rebalancing_schwelle_relativ=1` macht die relative Schwelle
+  faktisch wirkungslos (ein Zielgewicht kann nie um mehr als 100% seiner
+  selbst abweichen) — Strategien/Tests ohne explizit gesetzten Wert verhalten
+  sich deshalb exakt wie vor #63. Alle drei Produktivstrategien sowie alle
+  Szenarien in `scenarios.py` setzen explizit `rebalancing_schwelle_pp=5` und
+  `rebalancing_schwelle_relativ=Decimal("0.25")` (die kanonische 5/25-Regel,
+  Owner-Entscheidung zu #63) und ersetzen damit die vorherigen, uneinheitlich
+  gewählten Werte (10/15/3 Prozentpunkte je Strategie/Szenario).
 - `scenarios.py` — Auswertungs-Szenarien als gewöhnliche `Strategy`-Instanzen
   mit gesetztem `gewichte_fn`, in drei Kategorien: (1) Börsenweisheiten — seit
   #30 bewusst fünf der bekanntesten ENGLISCHEN Börsenweisheiten statt
@@ -193,7 +215,17 @@ inkrementell fortgeschrieben).
   nach der Durchschnittskosten-Methode (kein FIFO/LIFO); Rebalancing bringt
   bei Auslösung *alle* Instrumente auf ihr Zielgewicht zurück, nicht nur den
   auslösenden Topf; alle Geld-/Stückzahl-Arithmetik nutzt `Decimal`, nie
-  `float`. **Werterhaltung beim Rebalancing (wichtig beim Ändern):**
+  `float`. **Rebalancing-Trigger (#63, F5):** prüft seit #63 JEDEN Topf der
+  Strategie (nicht mehr nur `strategy.ziel_topf`) gegen die "5/25-Regel" aus
+  `Strategy.rebalancing_schwelle_pp`/`rebalancing_schwelle_relativ` (siehe
+  `strategies.py`) — sobald ein Topf entweder die absolute oder die relative
+  Schwelle überschreitet, läuft ein vollständiges `rebalance_to_targets()`
+  auf alle Instrumente, wie zuvor. Die Filterung nach look-ahead-verzerrten
+  Frühphasen (F4, siehe `dashboard.py`) passiert bewusst NICHT hier, sondern
+  ausschließlich in der Darstellungsschicht, bevor `rows` an `simulate()`
+  übergeben werden — `engine.py` bleibt dadurch unverändert gegenüber den
+  bestehenden, gegen die volle Testhistorie hand-gerechneten Engine-Tests.
+  **Werterhaltung beim Rebalancing (wichtig beim Ändern):**
   `rebalance_to_targets()` führt kein Cash-Konto — Verkaufserlöse werden
   nirgends gutgeschrieben, Kaufbeträge nirgends entnommen. Die Umschichtung
   ist allein dadurch summenneutral, dass sich die `diffs` über *alle*
@@ -442,6 +474,66 @@ inkrementell fortgeschrieben).
   Seite ist hinterlegter Text, der gegenüber dem Code veralten könnte. Beim
   Ergänzen deshalb keine Zahl hart ins Template schreiben, sondern über den
   Kontext ziehen.
+  **Rückschaufehler mit Hebel (#63, F4):** `build_dashboard()` wendet vor
+  jedem `simulate()`-Aufruf zwei Korrekturen auf `rows` an, beide rein in
+  der Darstellungsschicht (Owner-Entscheidung zu #63) — `engine.py` bleibt
+  unverändert. `_ohne_btc_fruehphase()` entfernt BTC-EUR-Kurse vor einem
+  Stichtag (`_BTC_FRUEHPHASE_ENDE`, aktuell 2017-01-01 — Platzhalter nach
+  demselben Muster wie `VORABPAUSCHALE_BASISZINS_PLATZHALTER`, kein
+  historisch belegtes Datum, sondern die Owner-Einschätzung, ab wann ein
+  deutscher Privatanleger realistischen EUR-Zugang zu Bitcoin hatte) und
+  nutzt damit denselben, bereits vorhandenen Mechanismus wie ein Instrument
+  vor seinem Börsengang, statt eine neue Sonderregel einzubauen.
+  `_real_investierbarer_zeitraum()` schneidet die (bereits BTC-bereinigte)
+  Historie je Strategie/Szenario auf den Zeitraum zurecht, ab dem ALLE ihre
+  Zielinstrumente (`Strategy.alle_ticker_gewichte()`) tatsächlich einen Kurs
+  haben — vorher hätte sich `handelbare_gewichte()` in der Frühphase auf die
+  anteilige Umlegung auf wenige, früh existierende Instrumente verlassen
+  (#55), was für die veröffentlichten Kennzahlen genau die Verzerrung
+  erzeugt, die F4 beschreibt (ein 2026 zusammengestelltes Instrumentenset
+  rückwirkend ab 2006 zu kaufen ist Look-ahead-Bias, verschärft dadurch, dass
+  ein extrem volatiles, früh existierendes Instrument wie Bitcoin in der
+  Frühphase ein Vielfaches seines nominalen Zielgewichts hält). Beide
+  Funktionen werden je Strategie separat angewendet (unterschiedliche
+  Instrumentensets ergeben unterschiedliche Simulationsbeginn-Daten, z. B.
+  2021-08-15 für die zwei- und 2021-11-21 für die dreitöpfige
+  Barbell-Strategie, Stand der vollen 20-Jahres-Historie) und liefern die je
+  Strategie tatsächlich verwendeten `rows` zurück, die anschließend
+  überall weiterverwendet werden (Hauptsimulation, Zeitraum-Presets,
+  Walk-Forward, Optimierungs-/Beitrags-Effekte) — nicht nur für die
+  Startwert-Anzeige. `carry_forward` (#42) bleibt bewusst auf der vollen,
+  unveränderten Historie berechnet, da es nur die jüngsten Wochen betrifft.
+  Die Prämissen-Seite nennt den Stichtag sowie je Strategie den tatsächlichen
+  `sim_beginn` in der Handelsregeln-Tabelle.
+  **CAGR als Leitkennzahl (#63, F6b/c):** `_cagr_pct(rendite_pct, tage)`
+  liefert die annualisierte Rendite aus der Gesamtrendite über die
+  tatsächliche Simulationsdauer (`_tage_zwischen()`, Differenz aus erster und
+  letzter Kurszeile) — über viele Jahre ist eine Gesamtrendite wie
+  "+52.558,53%" praktisch unlesbar, eine annualisierte Zahl lässt sich
+  direkt prüfen. `cagr_pct`/`cagr_label` im Strategie-View sind seither die
+  Leit-, `rendite_pct`/`rendite_pct_label` die Nebenspalte der
+  Übersichtstabelle (dort jetzt nach CAGR statt Gesamtrendite sortiert) —
+  dieselbe Umstellung löst zugleich F6c: die Leave-one-out-Differenzen in
+  `_optimierungs_effekte()` und den `beitraege` (Börsenweisheiten) liefen
+  vorher auf Basis der Gesamtrendite, was bei stark unterschiedlichen
+  Größenordnungen zwischen Basis- und Vergleichslauf (z. B. wenn Rebalancing
+  eine dominante Position wiederholt auf ihr Zielgewicht zurückführt) keine
+  sinnvolle Prozentpunkt-Angabe mehr war; beide Abschnitte rechnen jetzt mit
+  CAGR-Differenzen, die auch bei Größenordnungsunterschieden plausibel
+  bleiben.
+  **Geschätzte Nettorendite (#63, F6a):** `engine.py` führt
+  `kumulierte_steuer` bewusst nur als Tracking-Größe und zieht sie nirgends
+  vom simulierten Depotwert ab (reines Tracking, siehe engine.py-Abschnitt
+  oben) — alle Rendite-/CAGR-Werte sind deshalb Bruttowerte (vor Steuer).
+  `_build_strategy_view()` ergänzt daneben eine geschätzte Nettorendite
+  (`netto_rendite_pct_label`/`netto_cagr_label`): Endwert minus kumulierte
+  Steuer, einmalig am Simulationsende abgezogen. Eine bewusste
+  Vereinfachung — reale Steuerzahlungen fallen unterjährig zu
+  unterschiedlichen Zeitpunkten an, nicht als einmaliger Abzug am Ende —,
+  aber ohne Umbau der Engine (die weiterhin nur Bruttowerte simuliert) die
+  einzige Möglichkeit, überhaupt eine Netto-Größenordnung auszuweisen. Beide
+  Werte stehen nebeneinander auf jeder Detailseite, mit Fußnote; die
+  Übersichtstabelle bleibt bei den (klar so beschrifteten) Bruttowerten.
 - `learnings.py` — leitet die Sektion "Key Learnings" (ganz oben im Dashboard)
   bei jedem Build neu aus den Strategie-Views ab. **Keine hinterlegten
   Erkenntnis-Texte:** fest ist nur die Fragestellung je Regel (reine Funktion
@@ -610,7 +702,14 @@ sinkt nur um 70% des Rohgewinns), Vorabpauschale (EUNL ohne jeden Verkauf,
 Freibetrag sinkt trotzdem am Jahresende) sowie BTC-Spekulationsfrist einmal
 innerhalb (Gewinn landet in der Freigrenze, Sparerpauschbetrag bleibt
 unangetastet) und einmal außerhalb der Frist (großer Gewinn bleibt komplett
-steuerfrei, andernfalls wäre eine deutliche Steuer sichtbar).
+steuerfrei, andernfalls wäre eine deutliche Steuer sichtbar). Eigener
+Abschnitt für die "5/25-Regel je Topf" (#63, F5): ein von Hand nachgerechneter
+Drei-Töpfe-Test, dass ein Topf abseits von `ziel_topf` allein ein Rebalancing
+auslöst (der alte, nur-ziel_topf-Trigger hätte hier nicht ausgelöst), sowie
+ein Test-Paar mit identischem Kursverlauf, das mit gesetztem
+`rebalancing_schwelle_relativ=0.25` ein Rebalancing über die relative Schwelle
+auslöst und mit dem Default (`1`, effektiv deaktiviert) exakt das Verhalten
+vor #63 reproduziert (kein Rebalancing).
 `tests/test_history_store.py` prüft Wochen-Idempotenz, Carry-Forward und
 `read_fetch_log()`.
 `tests/test_sources.py` / `tests/test_alphavantage.py` mocken die jeweilige
@@ -665,6 +764,18 @@ dass die wesentlichen Einschränkungen samt Platzhalter-Kennzeichnung
 benannt sind, sowie dass der Cash-Abschnitt für eine Strategie ohne jemals
 ungenutztes Kapital "0.0" und für eine Strategie mit durchgehend
 fehlendem Zielinstrument den korrekten Cash-Höchststand samt Datum zeigt.
+Für F4/F6 (#63): `_cagr_pct()` gegen handgerechnete Grenzfälle (eine exakte
+Verdopplung über vier Jahre ergibt 100% CAGR, Totalverlust ergibt -100%,
+`tage=0` ergibt 0%), dass die Übersichtstabelle sowohl die CAGR- als auch die
+Gesamtrendite-Spalte zeigt, `_ohne_btc_fruehphase()` gegen eine Zeile vor und
+eine ab dem Stichtag (nur BTC-EUR wird vor dem Stichtag entfernt, andere
+Ticker bleiben unangetastet), `_real_investierbarer_zeitraum()` gegen eine
+Historie mit einem zunächst fehlenden Instrument (schneidet exakt auf den
+ersten vollständigen Zeitpunkt zu) sowie den Grenzfall, dass eine Strategie
+mit einem nie handelbaren Instrument die Historie unverändert zurückbekommt,
+und dass die geschätzte Nettorendite unter der Bruttorendite liegt, sobald
+über einen hand-konstruierten großen Rebalancing-Gewinn tatsächlich Steuer
+anfällt.
 `tests/test_learnings.py` fährt jede Learning-Regel gegen
 konstruierte Views mit bekannten Zahlen und prüft, dass die Aussagen den
 Daten folgen statt fest zu sein (inkl. Gegenprobe mit umgedrehter

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -49,6 +49,58 @@ _OPTIMIERUNGS_LABELS: dict[str, str] = {
     "besteuerung": "Besteuerung",
 }
 
+
+# --- F4 (#63): Rueckschaufehler mit Hebel ------------------------------------------
+#
+# Ein 2026 zusammengestelltes Instrumentenset rueckwirkend ab 2006 zu kaufen ist
+# Look-ahead-Bias, verschaerft durch handelbare_gewichte() (#55): solange nur ein
+# Teil der Zielinstrumente existiert, wird deren Gewicht anteilig auf die
+# VORHANDENEN umgelegt - trifft das ein extrem volatiles, frueh existierendes
+# Instrument wie Bitcoin, wird dessen effektive Zielquote fuer Jahre auf fast das
+# Doppelte hochskaliert. Owner-Entscheidung zu #63 (F4): zwei Massnahmen, beide rein
+# in der Darstellungsschicht (dashboard.py) angewandt, bevor rows an simulate()
+# gehen - engine.py bleibt unveraendert, die vorhandenen Engine-Tests (hand-
+# gerechnete Werte gegen die volle Testhistorie) sind davon nicht betroffen.
+_BTC_TICKER = "BTC-EUR"
+# Bitcoin ohne EUR-Handelsplatz mit Zugang fuer deutsche Privatanleger: Kraken
+# eroeffnete EUR-Paare erst 09/2013, echte Mainstream-Broker/Boersen-Anbindung
+# (Coinbase-EU-Rollout u.ae.) erst ab ca. 2017 - vor diesem Datum war Bitcoin fuer
+# einen deutschen Privatanleger ueber einen Broker faktisch nicht erreichbar
+# (Owner-Entscheidung). Bewusster Platzhalter nach demselben Muster wie
+# VORABPAUSCHALE_BASISZINS_PLATZHALTER, kein historisch belegtes Stichdatum.
+_BTC_FRUEHPHASE_ENDE = date(2017, 1, 1)
+
+
+def _ohne_btc_fruehphase(rows: list[PriceRow]) -> list[PriceRow]:
+    """Entfernt BTC-EUR-Kurse vor ``_BTC_FRUEHPHASE_ENDE`` aus den Zeilen - Bitcoin
+    gilt fuer die Simulation bis dahin als nicht handelbar, genau wie ein
+    Instrument, das seinen Boersengang noch nicht hatte. Nutzt damit denselben,
+    bereits vorhandenen Mechanismus (handelbare_gewichte() in engine.py) fuer
+    "noch nicht existierende" Instrumente, statt eine neue Sonderregel in die
+    Engine einzubauen."""
+    bereinigt = []
+    for row in rows:
+        if row.date < _BTC_FRUEHPHASE_ENDE and _BTC_TICKER in row.prices:
+            neue_prices = {t: p for t, p in row.prices.items() if t != _BTC_TICKER}
+            row = replace(row, prices=neue_prices)
+        bereinigt.append(row)
+    return bereinigt
+
+
+def _real_investierbarer_zeitraum(rows: list[PriceRow], strategy: Strategy) -> list[PriceRow]:
+    """Schneidet die Kurshistorie auf den Zeitraum zurecht, ab dem ALLE
+    Zielinstrumente dieser Strategie tatsaechlich einen Kurs haben - vorher
+    verlaesst sich handelbare_gewichte() auf die anteilige Umlegung (#55), was fuer
+    die veroeffentlichten Kennzahlen genau die Verzerrung erzeugt, die F4
+    beschreibt. Je Strategie unterschiedlich, weil unterschiedliche Strategien
+    unterschiedliche Instrumentensets haben. Betrifft nur die fuer die
+    Darstellung verwendeten rows, nicht die Rohdaten in price_history.csv."""
+    ziel_ticker = set(strategy.alle_ticker_gewichte())
+    for i, row in enumerate(rows):
+        if ziel_ticker <= set(row.prices):
+            return rows[i:]
+    return rows
+
 # Wochen-Naeherung der klassischen 50-/200-Tage-Durchschnitte (5 Handelstage/Woche),
 # fuer die wochenweise gefuehrte Kurshistorie - derselbe Ansatz wie beim Szenario
 # "Charttechnik: SMA-Crossover" (scenarios.SMA_KURZ_WOCHEN/SMA_LANG_WOCHEN), hier aber
@@ -346,21 +398,53 @@ def _rendite_pct(result: SimulationResult, strategy: Strategy) -> Decimal:
     return ((endwert - strategy.startkapital) / strategy.startkapital) * 100
 
 
-def _optimierungs_effekte(strategy: Strategy, rows: list[PriceRow], basis_rendite_pct: Decimal) -> list[dict]:
-    """Effekt jedes der vier Optimierungs-Schalter (#17) als Leave-one-out-Differenz:
-    Rendite mit allen Schaltern wie konfiguriert minus Rendite mit genau diesem einen
-    Schalter aus."""
+def _tage_zwischen(result: SimulationResult) -> int:
+    points = result.value_history
+    return (points[-1].date - points[0].date).days
+
+
+def _cagr_pct(rendite_pct: float, tage: int) -> float:
+    """Annualisierte Rendite (CAGR) aus der Gesamtrendite ueber ``tage`` Tage (F6b,
+    #63) - ueber viele Jahre ist eine Gesamtrendite wie "+52.558,53%" praktisch
+    unlesbar, waehrend eine annualisierte Zahl direkt geprueft werden kann. Dient
+    zugleich als Basis fuer die Leave-one-out-Differenzen (F6c): die Differenz
+    zweier CAGR-Werte bleibt eine sinnvolle Prozentpunkt-Angabe, auch wenn sich die
+    zugrundeliegenden Gesamtrenditen um Groessenordnungen unterscheiden (z. B. durch
+    eine einzelne dominante Position) - anders als die Differenz zweier
+    Gesamtrenditen, die dort in absurde Groessenordnungen laufen kann."""
+    if tage <= 0:
+        return 0.0
+    faktor = 1 + rendite_pct / 100
+    if faktor <= 0:
+        return -100.0
+    jahre = tage / 365.25
+    return (faktor ** (1 / jahre) - 1) * 100
+
+
+def _optimierungs_effekte(
+    strategy: Strategy, rows: list[PriceRow], basis_cagr_pct: float, tage: int
+) -> list[dict]:
+    """Effekt jedes der vier Optimierungs-Schalter (#17) als Leave-one-out-Differenz
+    auf CAGR-Basis (F6c, #63): CAGR mit allen Schaltern wie konfiguriert minus CAGR
+    mit genau diesem einen Schalter aus. Eine Differenz zweier Gesamtrenditen ist
+    hier keine sinnvolle Prozentpunkt-Angabe, sobald sich Basis- und Vergleichslauf
+    um Groessenordnungen unterscheiden (z. B. durch Rebalancing in eine dominante
+    Position wie Bitcoin) - CAGR bleibt in diesem Fall in einer plausiblen
+    Groessenordnung."""
     effekte = []
     for feld, label in _OPTIMIERUNGS_LABELS.items():
         variante = replace(strategy.optimierungen, **{feld: False})
-        ohne_rendite_pct = _rendite_pct(simulate(rows, strategy, variante), strategy)
-        delta_pp = basis_rendite_pct - ohne_rendite_pct
+        ohne_result = simulate(rows, strategy, variante)
+        ohne_rendite_pct = _rendite_pct(ohne_result, strategy)
+        ohne_cagr_pct = _cagr_pct(_f(ohne_rendite_pct), tage)
+        delta_pp = basis_cagr_pct - ohne_cagr_pct
         effekte.append(
             {
                 "name": label,
-                "delta_pp": _f(delta_pp),
+                "delta_pp": delta_pp,
                 "delta_label": f"{delta_pp:+.2f}",
                 "ohne_rendite_label": f"{ohne_rendite_pct:+.2f}",
+                "ohne_cagr_label": f"{ohne_cagr_pct:+.2f}",
             }
         )
     return effekte
@@ -410,9 +494,9 @@ def _build_strategy_view(
                 "abweichung_pp_label": f"{abweichung_pp:+.1f}",
                 # Warnung bei starker Abweichung eines EINZELNEN Instruments vom
                 # Zielgewicht (#41) - der Rebalancing-Trigger prueft nur die
-                # Topf-A-Abweichung, nicht die Konzentration innerhalb eines Topfs.
-                # Nutzt bewusst dieselbe Schwelle wie das Topf-Rebalancing statt einer
-                # neu erfundenen Zahl.
+                # Topf-Ebene je Topf (5/25-Regel, #63), nicht die Konzentration
+                # innerhalb eines Topfs. Nutzt bewusst dieselbe (absolute) Schwelle
+                # wie das Topf-Rebalancing statt einer neu erfundenen Zahl.
                 "konzentration_warnung": abs(abweichung_pp) > strategy.rebalancing_schwelle_pp,
                 "carry_forward_wochen": carry_forward_wochen,
             }
@@ -420,6 +504,21 @@ def _build_strategy_view(
 
     gewinn = last.total_value - strategy.startkapital
     rendite_pct = _rendite_pct(result, strategy)
+    tage = _tage_zwischen(result)
+    cagr_pct = _cagr_pct(_f(rendite_pct), tage)
+    # F6a (#63): geschaetzte Nettorendite neben der Bruttorendite. engine.py fuehrt
+    # kumulierte_steuer bewusst nur als Tracking-Groesse (siehe engine.py-Kommentar
+    # "reines Tracking") und zieht sie NICHT vom simulierten Depotwert ab - die
+    # Bruttorendite oben ist deshalb eine Vor-Steuer-Zahl. Diese Naeherung zieht die
+    # kumulierte Steuer einmalig am Ende vom Endwert ab, statt die Engine
+    # umzubauen: eine Vereinfachung, weil tatsaechliche Steuerzahlungen unterjaehrig
+    # und nicht als einmaliger Abzug am Simulationsende faellig werden.
+    if strategy.startkapital > 0:
+        netto_endwert = last.total_value - result.tax_status.kumulierte_steuer
+        netto_rendite_pct = (netto_endwert - strategy.startkapital) / strategy.startkapital * 100
+    else:
+        netto_rendite_pct = Decimal(0)
+    netto_cagr_pct = _cagr_pct(_f(netto_rendite_pct), tage)
     volatilitaet_pct = _volatilitaet_pct(total_values)
     max_drawdown_pct = _max_drawdown_pct(total_values)
     sharpe_ratio = _sharpe_ratio(total_values)
@@ -434,17 +533,21 @@ def _build_strategy_view(
     )
     zeitraum_presets = _zeitraum_presets(rows, strategy)
 
-    # Leave-one-out: Einzeleffekt jeder Teilregel als Differenz zur Variante ohne sie.
+    # Leave-one-out: Einzeleffekt jeder Teilregel als Differenz zur Variante ohne sie,
+    # auf CAGR-Basis (F6c, #63) - siehe _optimierungs_effekte() fuer die Begruendung.
     beitraege = []
     for beitrag in strategy.beitraege:
-        ohne_rendite_pct = _rendite_pct(simulate(rows, beitrag.ohne), beitrag.ohne)
-        delta_pp = rendite_pct - ohne_rendite_pct
+        ohne_result = simulate(rows, beitrag.ohne)
+        ohne_rendite_pct = _rendite_pct(ohne_result, beitrag.ohne)
+        ohne_cagr_pct = _cagr_pct(_f(ohne_rendite_pct), tage)
+        delta_pp = cagr_pct - ohne_cagr_pct
         beitraege.append(
             {
                 "name": beitrag.name,
-                "delta_pp": _f(delta_pp),
+                "delta_pp": delta_pp,
                 "delta_label": f"{delta_pp:+.2f}",
                 "ohne_rendite_label": f"{ohne_rendite_pct:+.2f}",
+                "ohne_cagr_label": f"{ohne_cagr_pct:+.2f}",
             }
         )
 
@@ -454,6 +557,10 @@ def _build_strategy_view(
         "beschreibung": strategy.beschreibung,
         "rendite_pct": _f(rendite_pct),
         "rendite_pct_label": f"{rendite_pct:+.2f}",
+        "cagr_pct": cagr_pct,
+        "cagr_label": f"{cagr_pct:+.2f}",
+        "netto_rendite_pct_label": f"{netto_rendite_pct:+.2f}",
+        "netto_cagr_label": f"{netto_cagr_pct:+.2f}",
         "gewinn_label": f"{gewinn:+.2f}",
         "volatilitaet_pct": volatilitaet_pct,
         "volatilitaet_label": f"{volatilitaet_pct:.2f}",
@@ -466,6 +573,8 @@ def _build_strategy_view(
         "cash_max_pct": cash_max_pct,
         "cash_max_label": f"{cash_max_pct:.1f}",
         "cash_max_datum": cash_max_datum or "–",
+        "sim_beginn": points[0].date.isoformat(),
+        "sim_ende": points[-1].date.isoformat(),
         "teil_von": strategy.teil_von,
         "labels_json": json.dumps(labels),
         "total_values": total_values,
@@ -494,7 +603,7 @@ def _build_strategy_view(
         "last_rebalance_date": result.last_rebalance_date.isoformat() if result.last_rebalance_date else "-",
         "last_harvest_date": result.last_harvest_date.isoformat() if result.last_harvest_date else "-",
         "beitraege": beitraege,
-        "optimierungs_effekte": _optimierungs_effekte(strategy, rows, rendite_pct),
+        "optimierungs_effekte": _optimierungs_effekte(strategy, rows, cagr_pct, tage),
         "walk_forward_segmente": walk_forward_segmente,
         "walk_forward_spread_label": f"{walk_forward_spread_pp:.2f}",
         "zeitraum_presets": zeitraum_presets,
@@ -580,6 +689,7 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
                 "id": slug,
                 "startkapital": f"{s.startkapital:.2f}",
                 "schwelle": f"{s.rebalancing_schwelle_pp}",
+                "schwelle_relativ": f"{s.rebalancing_schwelle_relativ * 100:.0f}",
                 "ziel_topf": s.ziel_topf,
                 "ziel_gewicht": f"{s.ziel_gewicht * 100:.0f}",
                 "dynamisch": "ja" if s.gewichte_fn is not None else "nein",
@@ -588,6 +698,7 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
                 ],
                 "cash_max_label": view.get("cash_max_label", "0.0"),
                 "cash_max_datum": view.get("cash_max_datum", "–"),
+                "sim_beginn": view.get("sim_beginn", "–"),
             }
         )
     cash_werte = [s["cash_max_label"] for s in strategie_liste]
@@ -612,6 +723,7 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
         "walk_forward_segmente": _WALK_FORWARD_SEGMENTE,
         "walk_forward_min_wochen": _WALK_FORWARD_MIN_WOCHEN_PRO_SEGMENT,
         "cash_ueberall_null": cash_ueberall_null,
+        "btc_fruehphase_ende": _BTC_FRUEHPHASE_ENDE.isoformat(),
     }
 
 
@@ -634,8 +746,21 @@ def build_dashboard(
     rows = sorted(price_history, key=lambda r: r.date)
     carry_forward = _carry_forward_streaks(rows, fetch_log or [])
 
-    views = [_build_strategy_view(s, simulate(rows, s), rows, carry_forward) for s in strategies]
-    summary = sorted(views, key=lambda v: v["rendite_pct"], reverse=True)
+    # F4 (#63): BTC-Fruehphase ausklammern, dann je Strategie erst dort simulieren,
+    # wo ihr komplettes Instrumentenset tatsaechlich handelbar war - siehe
+    # _ohne_btc_fruehphase()/_real_investierbarer_zeitraum(). carry_forward bleibt
+    # bewusst auf der vollen, unveraenderten Historie berechnet (betrifft nur die
+    # juengsten Wochen).
+    rows_ohne_btc_fruehphase = _ohne_btc_fruehphase(rows)
+    strategie_rows = {s.name: _real_investierbarer_zeitraum(rows_ohne_btc_fruehphase, s) for s in strategies}
+
+    views = [
+        _build_strategy_view(s, simulate(strategie_rows[s.name], s), strategie_rows[s.name], carry_forward)
+        for s in strategies
+    ]
+    # Sortierung nach CAGR statt Gesamtrendite (F6b, #63): CAGR ist die Leitkennzahl
+    # der Uebersichtstabelle, die Reihenfolge soll dazu konsistent sein.
+    summary = sorted(views, key=lambda v: v["cagr_pct"], reverse=True)
     learnings = derive_learnings(views)
     teilszenario_gruppen = _teilszenario_gruppen(views, strategies)
 

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -673,14 +673,7 @@ def simulate(
             values = current_values(prices)
             total_value = sum(values.values(), Decimal(0)) + total_cash()
             if total_value > 0:
-                ziel_topf = next(t for t in strategy.toepfe if t.name == strategy.ziel_topf)
                 current_weights = handelbare_gewichte(weights_at(i), prices)
-                # Die Schwelle vergleicht Ist gegen Ziel - beide muessen sich auf
-                # dieselbe (umgelegte) Zielverteilung beziehen, sonst schlaegt der
-                # Trigger dauerhaft an, solange Instrumente fehlen.
-                ziel_gewicht_effektiv = sum(
-                    (current_weights.get(t, Decimal(0)) for t in ziel_topf.sub_gewichte), Decimal(0)
-                )
                 # Ein Instrument, das erstmals einen Kurs hat (Boersengang, Start
                 # der verfuegbaren Historie), gehoert ab jetzt ins Zielportfolio.
                 # Das ist ein Erstkauf, kein Korrigieren von Drift - deshalb
@@ -713,14 +706,33 @@ def simulate(
                         last_rebalance_date = row.date
                     values = current_values(prices)
                     total_value = sum(values.values(), Decimal(0)) + total_cash()
-                ziel_topf_value = sum(
-                    (values.get(t, Decimal(0)) for t in ziel_topf.sub_gewichte), Decimal(0)
-                )
-                ist_gewicht = ziel_topf_value / total_value
-                abweichung_pp = abs(ist_gewicht - ziel_gewicht_effektiv) * 100
-                if opt.rebalancing and abweichung_pp > strategy.rebalancing_schwelle_pp:
-                    if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
-                        last_rebalance_date = row.date
+                # Rebalancing-Trigger (#63, F5): "5/25-Regel" je Topf statt nur fuer
+                # ziel_topf - rebalanciert wird, sobald IRGENDEIN Topf entweder um mehr
+                # als rebalancing_schwelle_pp Prozentpunkte ABSOLUT vom eigenen
+                # (umgelegten) Zielgewicht abweicht, oder um mehr als
+                # rebalancing_schwelle_relativ RELATIV zu diesem Zielgewicht - je
+                # nachdem, welche der beiden Schwellen zuerst greift (Marktstandard).
+                # Vorher wurde ausschliesslich ziel_topf (Topf A) geprueft: mit nur
+                # zwei komplementaeren Toepfen (A+B=100%) ist die Abweichung von A immer
+                # exakt die von B, bei drei oder mehr Toepfen (z. B. dem
+                # Einzelaktien-Satellit) kann ein einzelner Topf aber unbemerkt driften,
+                # waehrend Topf A zufaellig im Band bleibt.
+                if opt.rebalancing:
+                    for topf in strategy.toepfe:
+                        topf_ziel_effektiv = sum(
+                            (current_weights.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0)
+                        )
+                        topf_ist_wert = sum((values.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0))
+                        topf_ist_gewicht = topf_ist_wert / total_value
+                        abweichung_pp = abs(topf_ist_gewicht - topf_ziel_effektiv) * 100
+                        schwelle_pp = strategy.rebalancing_schwelle_pp
+                        if topf_ziel_effektiv > 0:
+                            relativ_schwelle_pp = topf_ziel_effektiv * 100 * strategy.rebalancing_schwelle_relativ
+                            schwelle_pp = min(schwelle_pp, relativ_schwelle_pp)
+                        if abweichung_pp > schwelle_pp:
+                            if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
+                                last_rebalance_date = row.date
+                            break
 
         if row.date in harvest_dates:
             apply_dividende()

--- a/src/boersenspiel/scenarios.py
+++ b/src/boersenspiel/scenarios.py
@@ -128,6 +128,7 @@ SELL_IN_MAY = Strategy(
     # Kleinere Schwelle als beim reinen Rebalancing, damit der saisonale
     # Regimewechsel (Mai <-> Oktober) zuverlässig eine Umschichtung auslöst.
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=sell_in_may_gewichte,
     beschreibung=(
         "Von Mai bis September (inklusive) 100% defensiv (Topf A), sonst normale "
@@ -165,7 +166,8 @@ BUY_AND_HOLD = Strategy(
     toepfe=BARBELL_20_80.toepfe,
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
-    rebalancing_schwelle_pp=Decimal("10"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=None,
     # Rebalancing bewusst über den Optimierungs-Schalter (#17) statt einer künstlich
     # unerreichbaren Schwelle abgeschaltet - "gar nicht rebalancieren" ist damit ehrlich
@@ -212,6 +214,7 @@ SANTA_CLAUS_RALLY = Strategy(
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=santa_claus_rally_gewichte,
     beschreibung=(
         "In Dezember und Januar Wachstumsquote auf 95% hochgefahren ('Santa Claus "
@@ -259,6 +262,7 @@ BUY_THE_DIP = Strategy(
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=buy_the_dip_gewichte,
     beschreibung=(
         "Liegt der MSCI-World-ETF mehr als 10% unter seinem 20-Wochen-Hoch, "
@@ -319,6 +323,7 @@ CUT_LOSSES = Strategy(
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=cut_losses_gewichte,
     beschreibung=(
         "Trailing-Stop je Wachstums-Instrument: fällt eines mehr als 15% unter sein "
@@ -407,6 +412,7 @@ def _weisheiten_strategy(name: str, weisheiten: tuple[Weisheit, ...], **kwargs) 
         ziel_topf=BARBELL_20_80.ziel_topf,
         ziel_gewicht=BARBELL_20_80.ziel_gewicht,
         rebalancing_schwelle_pp=Decimal("5"),
+        rebalancing_schwelle_relativ=Decimal("0.25"),
         gewichte_fn=kombinierte_weisheiten_gewichte(weisheiten),
         **kwargs,
     )
@@ -466,6 +472,7 @@ CHART_SMA_CROSSOVER = Strategy(
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=chart_sma_crossover_gewichte,
     beschreibung=(
         "Charttechnischer Trendindikator auf dem MSCI-World-ETF: liegt der 10-Wochen- "
@@ -504,6 +511,7 @@ CHART_SMA_CROSSOVER_KURZ = Strategy(
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=chart_sma_crossover_kurz_gewichte,
     beschreibung=(
         "Wie 'SMA-Crossover (10/40 Wochen)', aber mit kürzeren Fenstern (4/20 statt "
@@ -568,6 +576,7 @@ MOMENTUM_ROTATION = Strategy(
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=momentum_rotation_gewichte,
     beschreibung=(
         "Innerhalb des Wachstums-Topfs (80%) werden nur die 2 Instrumente mit der "
@@ -635,6 +644,7 @@ VOLATILITY_TARGET = Strategy(
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
     rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=volatility_target_gewichte,
     beschreibung=(
         "Die Wachstumsquote wird abhängig von der realisierten 12-Wochen-Volatilität "
@@ -672,7 +682,8 @@ COST_AVERAGE_ENTRY = Strategy(
     toepfe=BARBELL_20_80.toepfe,
     ziel_topf=BARBELL_20_80.ziel_topf,
     ziel_gewicht=BARBELL_20_80.ziel_gewicht,
-    rebalancing_schwelle_pp=Decimal("3"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     gewichte_fn=cost_average_gewichte,
     beschreibung=(
         "Statt das Startkapital sofort komplett zu investieren, wird die "

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -73,6 +73,16 @@ class Strategy:
     ziel_topf: str  # Name des Topfs, dessen Gewicht am Gesamtdepot überwacht wird (Rebalancing-Trigger)
     ziel_gewicht: Decimal  # Zielgewicht dieses Topfs, z. B. Decimal("0.20")
     rebalancing_schwelle_pp: Decimal  # Abweichung in Prozentpunkten, ab der rebalanciert wird
+    # Relative Zusatzschwelle zur "5/25-Regel" (#63, F5): rebalanciert wird, sobald EIN
+    # Topf entweder um mehr als rebalancing_schwelle_pp Prozentpunkte ABSOLUT vom
+    # eigenen (umgelegten) Zielgewicht abweicht ODER um mehr als diesen Anteil RELATIV
+    # zu seinem Zielgewicht (z. B. 0.25 = 25%, Marktstandard-"5/25-Regel") - je nachdem,
+    # welche der beiden Schwellen zuerst greift. Default 1 (100% relativ) macht die
+    # relative Schwelle faktisch wirkungslos (ein Zielgewicht kann nie um mehr als 100%
+    # seiner selbst abweichen), sodass Strategien/Tests ohne explizit gesetzten Wert
+    # sich weiterhin exakt wie vor #63 verhalten (nur die absolute Schwelle zählt).
+    # Produktivstrategien setzen hier bewusst 0.25.
+    rebalancing_schwelle_relativ: Decimal = Decimal("1")
     # Optional: macht die Ziel-Gewichte zeitabhängig statt konstant (z. B. saisonale
     # Regeln oder charttechnische Signale wie "Sell in May" / SMA-Crossover). Bekommt
     # die komplette (chronologisch sortierte) Kurshistorie plus den Index der aktuellen
@@ -146,11 +156,13 @@ BARBELL_20_80 = Strategy(
     ],
     ziel_topf="Topf A - Sicherheit",
     ziel_gewicht=Decimal("0.20"),
-    rebalancing_schwelle_pp=Decimal("10"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     beschreibung=(
         "20% Sicherheit (breite Anleihen/Gold-ETFs), 80% Wachstum (breite Aktien-ETFs "
-        "plus Bitcoin). Rebalancing auf die Zielgewichte, sobald der Sicherheits-Topf "
-        "um mehr als 10 Prozentpunkte abweicht."
+        "plus Bitcoin). Rebalancing auf die Zielgewichte, sobald EIN Topf um mehr als "
+        "5 Prozentpunkte absolut oder 25% relativ vom eigenen Zielgewicht abweicht "
+        "(5/25-Regel, marktüblich)."
     ),
 )
 
@@ -182,11 +194,11 @@ BARBELL_30_70 = Strategy(
     ],
     ziel_topf="Topf A - Sicherheit",
     ziel_gewicht=Decimal("0.30"),
-    rebalancing_schwelle_pp=Decimal("15"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     beschreibung=(
         "Defensivere Variante des Barbell-Ansatzes: 30% Sicherheit statt 20%, dafür "
-        "70% Wachstum. Größere Rebalancing-Schwelle (15 statt 10 Prozentpunkte), weil "
-        "der breitere Sicherheits-Topf natürlicherweise stärker schwankt."
+        "70% Wachstum. Rebalancing-Trigger wie bei Barbell 20/80 (5/25-Regel je Topf)."
     ),
 )
 
@@ -246,7 +258,8 @@ BARBELL_20_60_20_SATELLIT = Strategy(
     ],
     ziel_topf="Topf A - Sicherheit",
     ziel_gewicht=Decimal("0.20"),
-    rebalancing_schwelle_pp=Decimal("10"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
     beschreibung=(
         "Wie Barbell 20/80, aber der Wachstums-Topf sinkt von 80% auf 60% zugunsten "
         "eines dritten, gleichgewichteten Topfs aus 10 Einzelaktien (20%) - das "

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -44,25 +44,32 @@
   <section class="strategy" id="uebersicht">
     <h2>Übersicht: Rendite im Vergleich</h2>
     <p class="hint">
-      Volatilität (annualisierte Standardabweichung der Wochenrenditen) und Max
-      Drawdown (größter Wertverlust vom bisherigen Höchststand) stehen bewusst neben
-      der Rendite: eine hohe Rendite bei konzentrierten oder ungetesteten Regeln
-      (z. B. Chartsignale) kann mit entsprechend höherem Risiko erkauft sein, das die
-      Rendite allein nicht zeigt. Sharpe- und Sortino-Ratio fassen das in eine
-      Rendite-pro-Risiko-Kennzahl: Sharpe teilt die annualisierte Rendite durch die
-      gesamte Streuung, Sortino nur durch die Streuung der Verlustwochen (Streuung
-      nach oben zählt dort nicht als Risiko). Höher ist besser; negativ heißt, das
-      eingegangene Risiko hat sich nicht gelohnt. Ein risikofreier Zins von 0% ist
-      dabei ein bewusster Platzhalter, kein realer Referenzzins.
+      CAGR (annualisierte Rendite, "% p.a.") ist die Leitkennzahl: über viele Jahre
+      ist eine Gesamtrendite kaum lesbar und schlecht zwischen unterschiedlich langen
+      Zeiträumen vergleichbar, eine jährliche Rate ist es. Die Gesamtrendite steht
+      als Nebenspalte daneben. Volatilität (annualisierte Standardabweichung der
+      Wochenrenditen) und Max Drawdown (größter Wertverlust vom bisherigen
+      Höchststand) stehen bewusst ebenfalls neben der Rendite: eine hohe Rendite bei
+      konzentrierten oder ungetesteten Regeln (z. B. Chartsignale) kann mit
+      entsprechend höherem Risiko erkauft sein, das die Rendite allein nicht zeigt.
+      Sharpe- und Sortino-Ratio fassen das in eine Rendite-pro-Risiko-Kennzahl:
+      Sharpe teilt die annualisierte Rendite durch die gesamte Streuung, Sortino nur
+      durch die Streuung der Verlustwochen (Streuung nach oben zählt dort nicht als
+      Risiko). Höher ist besser; negativ heißt, das eingegangene Risiko hat sich
+      nicht gelohnt. Ein risikofreier Zins von 0% ist dabei ein bewusster
+      Platzhalter, kein realer Referenzzins. Alle Renditewerte hier sind
+      Bruttowerte (vor Steuer) - die geschätzte Nettorendite je Strategie
+      steht auf der jeweiligen Detailseite.
     </p>
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
     <div class="overflow-x">
       <table class="summary-table">
-        <thead><tr><th>Strategie / Szenario</th><th>Rendite %</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
+        <thead><tr><th>Strategie / Szenario</th><th>CAGR % p.a. (brutto)</th><th>Gesamtrendite % (brutto)</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
         <tbody>
         {% for s in summary %}
           <tr>
             <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
+            <td class="{{ 'positive' if s.cagr_pct >= 0 else 'negative' }}">{{ s.cagr_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
             <td>{{ s.volatilitaet_label }}</td>
             <td class="{{ 'negative' if s.max_drawdown_pct else '' }}">{{ s.max_drawdown_label }}</td>
@@ -136,15 +143,15 @@
     data: {
       labels: {{ summary | map(attribute='name') | list | tojson }},
       datasets: [{
-        label: 'Rendite %',
-        data: {{ summary | map(attribute='rendite_pct') | list | tojson }},
-        backgroundColor: {{ summary | map(attribute='rendite_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+        label: 'CAGR % p.a.',
+        data: {{ summary | map(attribute='cagr_pct') | list | tojson }},
+        backgroundColor: {{ summary | map(attribute='cagr_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
       }],
     },
     options: {
       indexAxis: 'y',
       responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'Rendite seit Simulationsbeginn (%)', color: colors.text } },
+      plugins: { legend: { display: false }, title: { display: true, text: 'Annualisierte Rendite (CAGR, % p.a.)', color: colors.text } },
       scales: {
         x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
         y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -28,7 +28,17 @@
         Kursentwicklung bereits bekannt war. Eine rückgerechnete Rendite
         beantwortet deshalb nicht die Frage „was hätte ich verdient?“, sondern
         bestenfalls „wie hätten sich diese Regeln auf diese, im Nachhinein
-        ausgewählten Werte ausgewirkt?“.
+        ausgewählten Werte ausgewirkt?“. Zwei Effekte werden deshalb bewusst aus
+        der Simulation herausgehalten (Owner-Entscheidung zu
+        <a href="https://github.com/S540d/Boersenspiel/issues/63">#63</a>, F4):
+        Bitcoin gilt vor {{ btc_fruehphase_ende }} als nicht handelbar, weil ein
+        deutscher Privatanleger vorher keinen realistischen EUR-Zugang zu
+        Bitcoin hatte; und jede Strategie/jedes Szenario startet ihre Simulation
+        erst dort, wo ihr komplettes Instrumentenset tatsächlich handelbar war -
+        siehe „Simulationsbeginn" in der Strategien-Tabelle unten -, statt die
+        anteilige Umlegung auf früh existierende Instrumente (nächster Abschnitt)
+        auch für die veröffentlichten Kennzahlen wirken zu lassen. Beides bleibt
+        eine Vereinfachung, kein Beweis für Investierbarkeit zu jedem Zeitpunkt.
       </li>
       <li>
         <strong>Die Regeln sind nicht optimiert und nicht gebacktestet.</strong>
@@ -128,25 +138,31 @@
       BTC-EUR zahlen ebenfalls keine Dividende.
     </p>
     <p class="hint">
-      Rebalanciert wird nur, wenn der überwachte Topf um mehr als die Schwelle
-      der jeweiligen Strategie vom Zielgewicht abweicht; dann werden
-      <em>alle</em> Instrumente auf ihr Zielgewicht zurückgeführt. Der Auslöser
-      prüft also die Topf-Ebene, nicht die Konzentration einzelner Instrumente
-      innerhalb eines Topfs &ndash; darauf weist ⚠ in der Instrumententabelle der
-      Detailseiten hin.
+      Rebalanciert wird, sobald IRGENDEIN Topf entweder um mehr als die
+      absolute Schwelle der jeweiligen Strategie in Prozentpunkten oder um
+      mehr als deren relative Schwelle vom eigenen Zielgewicht abweicht, je
+      nachdem was zuerst greift ("5/25-Regel", Marktstandard,
+      Owner-Entscheidung zu
+      <a href="https://github.com/S540d/Boersenspiel/issues/63">#63</a>, F5);
+      dann werden <em>alle</em> Instrumente auf ihr Zielgewicht zurückgeführt.
+      Der Auslöser prüft die Topf-Ebene für JEDEN Topf der Strategie, nicht
+      die Konzentration einzelner Instrumente innerhalb eines Topfs &ndash;
+      darauf weist ⚠ in der Instrumententabelle der Detailseiten hin.
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Strategie</th><th>Startkapital &euro;</th><th>Rebalancing-Schwelle pp</th><th class="text-left">Überwachter Topf</th><th>Zielgewicht %</th><th>Zeitabhängige Gewichte</th></tr></thead>
+        <thead><tr><th>Strategie</th><th>Startkapital &euro;</th><th>Schwelle pp (absolut)</th><th>Schwelle % (relativ)</th><th class="text-left">Überwachter Topf</th><th>Zielgewicht %</th><th>Zeitabhängige Gewichte</th><th>Simulationsbeginn</th></tr></thead>
         <tbody>
         {% for s in strategien %}
           <tr>
             <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
             <td>{{ s.startkapital }}</td>
             <td>{{ s.schwelle }}</td>
+            <td>{{ s.schwelle_relativ }}</td>
             <td class="text-left">{{ s.ziel_topf }}</td>
             <td>{{ s.ziel_gewicht }}</td>
             <td>{{ s.dynamisch }}</td>
+            <td>{{ s.sim_beginn }}</td>
           </tr>
         {% endfor %}
         </tbody>

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -15,11 +15,22 @@
       <div class="stat-tile"><div class="label">Letzter Dez.-Harvest</div><div class="value">{{ s.last_harvest_date }}</div></div>
     </div>
     <div class="stat-row">
+      <div class="stat-tile"><div class="label">Bruttorendite % (CAGR p.a.)</div><div class="value">{{ s.cagr_label }}</div></div>
+      <div class="stat-tile"><div class="label">Geschätzte Nettorendite % (CAGR p.a.)</div><div class="value">{{ s.netto_cagr_label }}</div></div>
       <div class="stat-tile"><div class="label">Freibetrag verbraucht ({{ s.tax.year }})</div><div class="value">{{ s.tax.freibetrag_verbraucht }} &euro;</div></div>
       <div class="stat-tile"><div class="label">Freibetrag verbleibend</div><div class="value">{{ s.tax.freibetrag_verbleibend }} &euro;</div></div>
       <div class="stat-tile"><div class="label">Verlustvortrag</div><div class="value">{{ s.tax.verlustvortrag }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Kumulierte Steuer</div><div class="value">{{ s.tax.kumulierte_steuer }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Kumulierte Steuer (nur nachrichtlich)</div><div class="value">{{ s.tax.kumulierte_steuer }} &euro;</div></div>
     </div>
+    <p class="hint">
+      Alle Rendite- und Wertangaben auf dieser Seite sind
+      <strong>Bruttowerte (vor Steuer)</strong> &ndash; die kumulierte Steuer
+      wird nachrichtlich mitgeführt, aber nirgends vom simulierten Depotwert
+      abgezogen. Die "Geschätzte Nettorendite" oben zieht die kumulierte
+      Steuer einmalig vom Endwert ab, um eine grobe Größenordnung zu geben;
+      real fallen Steuern unterjährig zu unterschiedlichen Zeitpunkten an,
+      nicht als einmaliger Abzug am Ende (#63, F6a).
+    </p>
     {% if s.zeitraum_presets %}
     <h3>Kennzahlen nach Betrachtungszeitraum</h3>
     <p class="hint">
@@ -33,7 +44,7 @@
       {% endfor %}
     </div>
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Rendite %</div><div class="value" id="zeitraum-rendite">{{ s.rendite_pct_label }}</div></div>
+      <div class="stat-tile"><div class="label">Rendite % (brutto, im Zeitraum)</div><div class="value" id="zeitraum-rendite">{{ s.rendite_pct_label }}</div></div>
       <div class="stat-tile"><div class="label">Volatilität % (ann.)</div><div class="value" id="zeitraum-volatilitaet">{{ s.volatilitaet_label }}</div></div>
       <div class="stat-tile"><div class="label">Max Drawdown %</div><div class="value" id="zeitraum-max-drawdown">{{ s.max_drawdown_label }}</div></div>
       <div class="stat-tile"><div class="label">Sharpe</div><div class="value" id="zeitraum-sharpe">{{ s.sharpe_label }}</div></div>
@@ -56,20 +67,25 @@
     <div class="beitraege">
       <h3>Effekt der einzelnen Börsenweisheiten</h3>
       <p class="hint">
-        Leave-one-out: Rendite dieser Strategie minus Rendite derselben Strategie
-        <em>ohne</em> den jeweiligen Spruch. Positiv = der Spruch hat Rendite gebracht,
-        negativ = er hat gekostet. Die Regeln beeinflussen sich gegenseitig, die
-        Einzelbeiträge summieren sich deshalb nicht exakt zur Gesamtrendite.
+        Leave-one-out: CAGR (annualisierte Rendite) dieser Strategie minus CAGR
+        derselben Strategie <em>ohne</em> den jeweiligen Spruch. Positiv = der Spruch
+        hat Rendite gebracht, negativ = er hat gekostet. Auf CAGR- statt
+        Gesamtrendite-Basis, weil die Differenz zweier Gesamtrenditen keine sinnvolle
+        Prozentpunkt-Angabe mehr ist, sobald sich Basis- und Vergleichslauf um
+        Größenordnungen unterscheiden (#63). Die Regeln beeinflussen sich
+        gegenseitig, die Einzelbeiträge summieren sich deshalb nicht exakt zum
+        Gesamt-CAGR.
       </p>
       <div class="chart-box"><canvas id="beitrag-chart"></canvas></div>
       <div class="overflow-x">
         <table>
-          <thead><tr><th>Börsenweisheit</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Spruch %</th></tr></thead>
+          <thead><tr><th>Börsenweisheit</th><th>Effekt (CAGR-Prozentpunkte p.a.)</th><th>CAGR ohne diesen Spruch % p.a.</th><th>Gesamtrendite ohne diesen Spruch %</th></tr></thead>
           <tbody>
           {% for b in s.beitraege %}
             <tr>
               <td>{{ b.name }}</td>
               <td class="{{ 'positive' if b.delta_pp >= 0 else 'negative' }}">{{ b.delta_label }}</td>
+              <td>{{ b.ohne_cagr_label }}</td>
               <td>{{ b.ohne_rendite_label }}</td>
             </tr>
           {% endfor %}
@@ -81,20 +97,26 @@
     <div class="beitraege">
       <h3>Effekt der Optimierungs-Schalter</h3>
       <p class="hint">
-        Leave-one-out je Mechanismus: Rendite dieser Strategie minus Rendite derselben
-        Strategie mit genau diesem einen Mechanismus ausgeschaltet (Dezember-Harvest,
-        Rebalancing, Ordergebühren, Besteuerung). Positiv = der Mechanismus hat Rendite
-        gebracht, negativ = er hat gekostet.
+        Leave-one-out je Mechanismus: CAGR (annualisierte Rendite) dieser Strategie
+        minus CAGR derselben Strategie mit genau diesem einen Mechanismus
+        ausgeschaltet (Dezember-Harvest, Rebalancing, Ordergebühren, Besteuerung).
+        Positiv = der Mechanismus hat Rendite gebracht, negativ = er hat gekostet.
+        Auf CAGR- statt Gesamtrendite-Basis, weil die Differenz zweier
+        Gesamtrenditen keine sinnvolle Prozentpunkt-Angabe mehr ist, sobald sich
+        Basis- und Vergleichslauf um Größenordnungen unterscheiden - etwa wenn
+        Rebalancing eine dominante Position wie Bitcoin immer wieder auf ihr
+        Zielgewicht zurückführt (#63).
       </p>
       <div class="chart-box"><canvas id="opt-chart"></canvas></div>
       <div class="overflow-x">
         <table>
-          <thead><tr><th>Mechanismus</th><th>Effekt (Prozentpunkte)</th><th>Rendite ohne diesen Mechanismus %</th></tr></thead>
+          <thead><tr><th>Mechanismus</th><th>Effekt (CAGR-Prozentpunkte p.a.)</th><th>CAGR ohne diesen Mechanismus % p.a.</th><th>Gesamtrendite ohne diesen Mechanismus %</th></tr></thead>
           <tbody>
           {% for o in s.optimierungs_effekte %}
             <tr>
               <td>{{ o.name }}</td>
               <td class="{{ 'positive' if o.delta_pp >= 0 else 'negative' }}">{{ o.delta_label }}</td>
+              <td>{{ o.ohne_cagr_label }}</td>
               <td>{{ o.ohne_rendite_label }}</td>
             </tr>
           {% endfor %}
@@ -134,9 +156,10 @@
       "Abw. pp" ist die Abweichung des Ist- vom Ziel-Gewicht dieses Instruments in
       Prozentpunkten; ⚠ markiert eine Abweichung über der Rebalancing-Schwelle dieser
       Strategie ({{ s.rebalancing_schwelle_pp }} pp) - der Rebalancing-Trigger selbst
-      prüft nur die Abweichung von Topf A, nicht die Konzentration einzelner
-      Instrumente innerhalb eines Topfs. "Kursstatus" zeigt, wenn der zuletzt
-      verwendete Kurs mangels frischem Abruf fortgeschrieben statt neu ermittelt wurde.
+      prüft die Abweichung jedes Topfs (5/25-Regel, #63), nicht die Konzentration
+      einzelner Instrumente innerhalb eines Topfs. "Kursstatus" zeigt, wenn der
+      zuletzt verwendete Kurs mangels frischem Abruf fortgeschrieben statt neu
+      ermittelt wurde.
     </p>
     <div class="overflow-x">
       <table>
@@ -279,7 +302,7 @@
     data: {
       labels: {{ s.beitraege | map(attribute='name') | list | tojson }},
       datasets: [{
-        label: 'Effekt (Prozentpunkte)',
+        label: 'Effekt (CAGR-Prozentpunkte p.a.)',
         data: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }},
         backgroundColor: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
       }],
@@ -287,7 +310,7 @@
     options: {
       indexAxis: 'y',
       responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Börsenweisheit (Prozentpunkte)', color: colors.text } },
+      plugins: { legend: { display: false }, title: { display: true, text: 'CAGR-Beitrag je Börsenweisheit (Prozentpunkte p.a.)', color: colors.text } },
       scales: {
         x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
         y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
@@ -301,7 +324,7 @@
     data: {
       labels: {{ s.optimierungs_effekte | map(attribute='name') | list | tojson }},
       datasets: [{
-        label: 'Effekt (Prozentpunkte)',
+        label: 'Effekt (CAGR-Prozentpunkte p.a.)',
         data: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }},
         backgroundColor: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
       }],
@@ -309,7 +332,7 @@
     options: {
       indexAxis: 'y',
       responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'Renditebeitrag je Optimierungs-Schalter (Prozentpunkte)', color: colors.text } },
+      plugins: { legend: { display: false }, title: { display: true, text: 'CAGR-Beitrag je Optimierungs-Schalter (Prozentpunkte p.a.)', color: colors.text } },
       scales: {
         x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
         y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -13,9 +13,15 @@ from decimal import Decimal
 from pathlib import Path
 
 from boersenspiel.dashboard import (
+    _BTC_FRUEHPHASE_ENDE,
+    _BTC_TICKER,
+    _build_strategy_view,
+    _cagr_pct,
     _downside_deviation,
     _jahre_zurueck,
     _max_drawdown_pct,
+    _ohne_btc_fruehphase,
+    _real_investierbarer_zeitraum,
     _sharpe_ratio,
     _slug,
     _sortino_ratio,
@@ -616,3 +622,117 @@ def test_praemissen_seite_zeigt_cash_hoechststand_wenn_kein_zielinstrument_hande
     assert "hält aktuell nicht jede" in html
     assert "100.0" in html
     assert "2024-01-01" in html.split("Cash und ungenutztes Kapital", 1)[1]
+
+
+# --- F6b/c (#63): CAGR als Leitkennzahl -------------------------------------------
+
+
+def test_cagr_pct_verdoppelt_sich_ueber_ein_jahr_ergibt_100_prozent():
+    # Exakte Dezimalfaelle: 1461 Tage = 4 * 365,25 (exakt in float darstellbar) ->
+    # jahre=4. Ein Faktor von 16 (rendite_pct=1500%) verteilt sich gleichmaessig
+    # ueber vier Jahre auf 16**(1/4)=2, also CAGR=100%.
+    assert abs(_cagr_pct(1500.0, 1461) - 100.0) < 1e-9
+
+
+def test_cagr_pct_totalverlust_ist_minus_hundert_prozent():
+    assert _cagr_pct(-100.0, 365) == -100.0
+
+
+def test_cagr_pct_ohne_tage_ist_null():
+    assert _cagr_pct(50.0, 0) == 0.0
+
+
+def test_summary_table_sortiert_nach_cagr_und_zeigt_gesamtrendite_daneben(tmp_path: Path):
+    output = build_dashboard(_mehrjaehrige_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+    assert "CAGR % p.a." in html
+    assert "Gesamtrendite %" in html
+
+
+# --- F4 (#63): Rueckschaufehler mit Hebel ------------------------------------------
+
+
+def test_ohne_btc_fruehphase_entfernt_nur_btc_vor_dem_cutoff():
+    rows = [
+        PriceRow(
+            _BTC_FRUEHPHASE_ENDE - timedelta(weeks=1),
+            {_BTC_TICKER: Decimal("1"), "T1": Decimal("100")},
+        ),
+        PriceRow(
+            _BTC_FRUEHPHASE_ENDE,
+            {_BTC_TICKER: Decimal("2"), "T1": Decimal("100")},
+        ),
+    ]
+    bereinigt = _ohne_btc_fruehphase(rows)
+
+    assert _BTC_TICKER not in bereinigt[0].prices
+    assert bereinigt[0].prices["T1"] == Decimal("100")  # andere Ticker unangetastet
+    assert _BTC_TICKER in bereinigt[1].prices  # ab dem Cutoff-Datum wieder handelbar
+
+
+def test_real_investierbarer_zeitraum_schneidet_auf_vollstaendiges_instrumentenset_zu():
+    strategy = Strategy(
+        name="Zwei-Instrumente",
+        startkapital=Decimal("1000"),
+        toepfe=[
+            Topf(
+                name="Topf",
+                gewicht_gesamt=Decimal("1"),
+                sub_gewichte={"T1": Decimal("0.5"), "T2": Decimal("0.5")},
+            )
+        ],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100")}),  # T2 fehlt noch
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("100"), "T2": Decimal("50")}),  # ab hier vollstaendig
+        PriceRow(date(2024, 1, 15), {"T1": Decimal("110"), "T2": Decimal("55")}),
+    ]
+    geschnitten = _real_investierbarer_zeitraum(rows, strategy)
+    assert [r.date for r in geschnitten] == [date(2024, 1, 8), date(2024, 1, 15)]
+
+
+def test_real_investierbarer_zeitraum_ohne_treffer_gibt_alle_rows_unveraendert():
+    strategy = Strategy(
+        name="Fehlt-immer",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T2": Decimal("1")})],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+    rows = [PriceRow(date(2024, 1, 1), {"T1": Decimal("100")})]  # T2 nie vorhanden
+    assert _real_investierbarer_zeitraum(rows, strategy) == rows
+
+
+# --- F6a (#63): geschaetzte Nettorendite --------------------------------------------
+
+GROSSER_GEWINN_STRATEGY = Strategy(
+    name="Grosser-Gewinn",
+    startkapital=Decimal("100000"),
+    toepfe=[
+        Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T1": Decimal("1")}),
+        Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"T2": Decimal("1")}),
+    ],
+    ziel_topf="TopfX",
+    ziel_gewicht=Decimal("0.5"),
+    rebalancing_schwelle_pp=Decimal("1"),
+)
+
+
+def test_netto_rendite_liegt_unter_der_bruttorendite_wenn_steuer_anfaellt():
+    # T1 verzehnfacht sich -> das Rebalancing realisiert einen Gewinn weit über
+    # dem Sparerpauschbetrag (1000 EUR) -> kumulierte_steuer > 0.
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("1000"), "T2": Decimal("100")}),
+    ]
+    result = simulate(rows, GROSSER_GEWINN_STRATEGY)
+    assert result.tax_status.kumulierte_steuer > Decimal("0")
+
+    view = _build_strategy_view(GROSSER_GEWINN_STRATEGY, result, rows)
+    brutto = float(view["cagr_label"].replace(",", "."))
+    netto = float(view["netto_cagr_label"].replace(",", "."))
+    assert netto < brutto

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -624,3 +624,95 @@ def test_erstkauf_mit_rebalancing_holt_weiterhin_alles_auf_zielgewicht():
     assert result.holdings["T2"] == Decimal("6")  # 600 / 100
     assert result.holdings["T3"] == Decimal("6")  # 300 / 50
     assert result.value_history[-1].total_value == Decimal("1500")
+
+
+# --- Rebalancing-Trigger: "5/25-Regel" je Topf (#63, F5) ---------------------------
+#
+# Vorher pruefte der Trigger ausschliesslich ziel_topf (Topf A) mit einer rein
+# absoluten Schwelle. Zwei Regressionstests dafuer, dass jetzt (a) JEDER Topf
+# geprueft wird, nicht nur ziel_topf, und (b) eine relative Zusatzschwelle
+# greift, die bei rebalancing_schwelle_relativ=1 (Default, unveraendertes
+# Altverhalten) wirkungslos bleibt.
+
+DREI_TOEPFE_STRATEGY = Strategy(
+    name="Test-Drei-Toepfe",
+    startkapital=Decimal("1000"),
+    toepfe=[
+        Topf(name="TopfA", gewicht_gesamt=Decimal("0.4"), sub_gewichte={"A": Decimal("1")}),
+        Topf(name="TopfB", gewicht_gesamt=Decimal("0.4"), sub_gewichte={"B": Decimal("1")}),
+        Topf(name="TopfC", gewicht_gesamt=Decimal("0.2"), sub_gewichte={"C": Decimal("1")}),
+    ],
+    ziel_topf="TopfA",
+    ziel_gewicht=Decimal("0.4"),
+    rebalancing_schwelle_pp=Decimal("10"),
+    # rebalancing_schwelle_relativ bewusst NICHT gesetzt (Default 1) - dieser Test
+    # isoliert die "jeder Topf statt nur ziel_topf"-Aenderung von der neuen
+    # relativen Schwelle.
+)
+
+
+def test_5_25_regel_prueft_jeden_topf_nicht_nur_ziel_topf():
+    rows = [
+        # Initialkauf 1000 EUR (gebuehrenfrei) auf 40/40/20 -> A=400, B=400, C=200.
+        PriceRow(date(2024, 1, 1), {"A": Decimal("100"), "B": Decimal("100"), "C": Decimal("100")}),
+        # A unveraendert (400), B halbiert sich (200), C verdreifacht sich (600).
+        # Gesamt 1200. Ist-Gewichte: A=400/1200=33.33% (Abweichung von 40% Ziel nur
+        # 6.67pp, UNTER der 10pp-Schwelle - der alte, nur-ziel_topf-Trigger haette
+        # HIER NICHT ausgeloest). B=200/1200=16.67% (Abweichung 23.33pp) und
+        # C=600/1200=50% (Abweichung 30pp) liegen beide klar ueber 10pp.
+        PriceRow(date(2024, 1, 8), {"A": Decimal("100"), "B": Decimal("50"), "C": Decimal("300")}),
+    ]
+    result = simulate(rows, DREI_TOEPFE_STRATEGY, Optimierungen(**_OHNE_REIBUNG))
+
+    assert result.last_rebalance_date == date(2024, 1, 8)
+    # Nach dem Rebalancing wieder exakt auf den Zielgewichten: 1200 * 40/40/20%.
+    last = result.value_history[-1]
+    assert last.ticker_values["A"] == Decimal("480")
+    assert last.ticker_values["B"] == Decimal("480")
+    assert last.ticker_values["C"] == Decimal("240")
+
+
+KLEINER_TOPF_STRATEGY_BASIS = dict(
+    name="Test-Kleiner-Topf",
+    startkapital=Decimal("1000"),
+    toepfe=[
+        Topf(name="TopfA", gewicht_gesamt=Decimal("0.1"), sub_gewichte={"A": Decimal("1")}),
+        Topf(name="TopfB", gewicht_gesamt=Decimal("0.9"), sub_gewichte={"B": Decimal("1")}),
+    ],
+    ziel_topf="TopfA",
+    ziel_gewicht=Decimal("0.1"),
+    rebalancing_schwelle_pp=Decimal("5"),
+)
+
+
+def _kleiner_topf_rows() -> list[PriceRow]:
+    return [
+        # Initialkauf 1000 EUR (gebuehrenfrei) auf 10/90 -> A=100 (1 Stk zu 100),
+        # B=900 (10 Stk zu 90).
+        PriceRow(date(2024, 1, 1), {"A": Decimal("100"), "B": Decimal("90")}),
+        # A steigt auf 130 (Wert 130), B faellt auf 87 (Wert 870) -> Gesamt 1000,
+        # ist_A=13%. Abweichung vom 10%-Ziel: 3pp - unter der absoluten 5pp-Schwelle,
+        # aber 3pp / 10% Ziel = 30% relative Abweichung.
+        PriceRow(date(2024, 1, 8), {"A": Decimal("130"), "B": Decimal("87")}),
+    ]
+
+
+def test_5_25_regel_relative_schwelle_loest_aus_wo_absolute_schwelle_nicht_reicht():
+    # rebalancing_schwelle_relativ=0.25 (25%, Marktstandard-Anteil): fuer den
+    # 10%-Topf ergibt das eine effektive Schwelle von min(5pp, 10%*25%=2.5pp) =
+    # 2.5pp - die 3pp-Abweichung oben liegt darueber.
+    strategy_mit_relativ = Strategy(
+        **KLEINER_TOPF_STRATEGY_BASIS, rebalancing_schwelle_relativ=Decimal("0.25")
+    )
+    result = simulate(_kleiner_topf_rows(), strategy_mit_relativ, Optimierungen(**_OHNE_REIBUNG))
+    assert result.last_rebalance_date == date(2024, 1, 8)
+
+
+def test_5_25_regel_relativ_default_aendert_altverhalten_nicht():
+    # Gegenprobe mit demselben Kursverlauf, aber OHNE gesetzte relative Schwelle
+    # (Default 1 = 100%, faktisch wirkungslos): effektive Schwelle bleibt bei den
+    # vollen 5pp absolut, die 3pp-Abweichung loest deshalb KEIN Rebalancing aus -
+    # exakt das Verhalten vor #63.
+    strategy_ohne_relativ = Strategy(**KLEINER_TOPF_STRATEGY_BASIS)
+    result = simulate(_kleiner_topf_rows(), strategy_ohne_relativ, Optimierungen(**_OHNE_REIBUNG))
+    assert result.last_rebalance_date is None


### PR DESCRIPTION
Closes #63.

## Summary

Umsetzung der drei Owner-Entscheidungen zu den Methodenfragen F4–F6 aus dem 20-Jahres-Audit (siehe #63 für den vollständigen Befund):

- **F4 (Rückschaufehler mit Hebel):** Bitcoin gilt vor 2017-01-01 als nicht handelbar (kein realistischer EUR-Zugang für deutsche Privatanleger, Platzhalter-Stichtag analog `VORABPAUSCHALE_BASISZINS_PLATZHALTER`). Zusätzlich simuliert jede Strategie/jedes Szenario erst ab dem Zeitpunkt, an dem ihr komplettes Instrumentenset tatsächlich verfügbar war (`_ohne_btc_fruehphase()` / `_real_investierbarer_zeitraum()` in `dashboard.py`), statt die anteilige Umlegung auf früh existierende Instrumente (#55) die veröffentlichten Kennzahlen verzerren zu lassen. Beides ausschließlich in der Darstellungsschicht — `engine.py` bleibt unverändert, die bestehenden hand-gerechneten Engine-Tests sind nicht betroffen. Ergebnis gegen die reale 20-Jahres-Historie: CAGR-Spanne über alle 14 Regeln/Strategien schrumpft von 25,9–84,8 % p.a. auf plausible 12,4–19,5 % p.a.
- **F5 (Rebalancing-Trigger):** prüft jetzt **jeden** Topf (nicht mehr nur `ziel_topf`) gegen die marktübliche "5/25-Regel" (`Strategy.rebalancing_schwelle_pp`/neues Feld `rebalancing_schwelle_relativ`, Default `1` = deaktiviert, damit bestehende Strategien/Tests ohne explizit gesetzten Wert unverändert bleiben). Alle Produktivstrategien/-szenarien setzen jetzt einheitlich 5 pp / 25 %. Ergebnis: "Barbell 20/80" und "Buy & Hold" liefern nicht mehr bit-identische Renditen.
- **F6 (Kennzahlen-Darstellung):**
  - (b)/(c) CAGR ist jetzt die Leitkennzahl der Übersichtstabelle (Gesamtrendite als Nebenspalte), danach auch sortiert. Die Leave-one-out-Effekte (Optimierungs-Schalter und Börsenweisheiten) rechnen jetzt auf CAGR- statt Gesamtrendite-Basis — vorher lieferten sie bei stark unterschiedlichen Größenordnungen zwischen Basis- und Vergleichslauf absurde Prozentpunkt-Werte (z. B. −25.889.028,79 pp).
  - (a) Jede Detailseite zeigt zusätzlich zur (klar so beschrifteten) Bruttorendite eine geschätzte Nettorendite (Endwert minus kumulierte Steuer, mit Fußnote zur Vereinfachung — `engine.py`s Steuer-Tracking bleibt unverändert reines Tracking).
  - (d) Bewusst **kein** neuer Risikofrei-Zins-Platzhalter — F4 allein sollte die bisherige, verdächtig enge Sharpe/Sortino-Clusterung schon deutlich auflösen; ein echter Referenzzins folgt sinnvollerweise erst mit einem künftigen Geldmarkt-Instrument.

## Test plan

- [x] `pytest -q` (208 Tests, alle grün) — inklusive neuer Regressionstests für F4 (`_ohne_btc_fruehphase`, `_real_investierbarer_zeitraum`), F5 (Drei-Töpfe-Trigger, relative vs. absolute Schwelle) und F6 (`_cagr_pct` Grenzfälle, Nettorendite < Bruttorendite bei realisierter Steuer)
- [x] `python scripts/build_dashboard.py` gegen die echte `data/price_history.csv` gebaut und die resultierenden Kennzahlen (CAGR, Simulationsbeginn je Strategie, Netto- vs. Bruttorendite) manuell geprüft

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDxPqLGm3oxeN3Jf6qurnm)_