### PR TITLE
README + Dashboard nach dem Backfill aktualisieren (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,14 +70,19 @@ inkrementell fortgeschrieben).
   je **genau 25** Requests — das volle Alpha-Vantage-Tageslimit, kein Puffer.
   `tests/test_backfill_history.py` hält das als Test fest, damit ein
   18. Instrument nicht still beide Workflows unmöglich macht.
-  **Bekannter Nacharbeitsbedarf (#66):** `dashboard.html.j2` nennt fest
-  „17 Instrumenten" statt aus `len(TICKERS)`/den tatsächlich allokierten
-  abgeleitet; die Prämissen-Seite listet alle 24 Instrumente undifferenziert
-  in derselben Tabelle wie die 17 allokierten, ohne die 7 Datenreihen als
-  solche zu kennzeichnen; der Hindsight-Bias-Satz dort und in der README
-  trifft auf die 7 Datenreihen nicht zu (kein Rückschaufehler, sondern
-  bewusster neutraler Vergleichsmaßstab). Erst nach dem nächsten Backfill zu
-  beheben, wenn die 7 neuen Ticker echte Erstkurstage haben.
+  **Darstellung der 7 unallokierten Instrumente (#66, behoben):** Weder das
+  Dashboard noch die Prämissen-Seite noch die README nennen mehr eine feste
+  Instrumentenzahl. `dashboard._allokierte_ticker(strategies)` leitet die
+  Menge der tatsächlich einer Strategie/einem Szenario zugeordneten Ticker
+  generisch aus `Strategy.alle_ticker_gewichte()` ab; `dashboard.html.j2`
+  zeigt `{{ instrumente_anzahl }}` (aus `common_context`) statt hart „17".
+  `_praemissen_kontext()` trennt die Instrumententabelle dementsprechend in
+  `instrumente` (nur allokierte) und `nicht_allokierte_instrumente` — Letztere
+  bekommen einen eigenen Abschnitt „Datenreihen ohne Allokation" (nur
+  gerendert, wenn nicht leer), der auf #64 verweist und erklärt, dass
+  `engine.simulate()` sie nie handelt, weil sie in keinem Topf liegen. Der
+  Hindsight-Bias-Absatz (dort und in der README) bezieht sich jetzt explizit
+  nur noch auf die tatsächlich allokierten Instrumente.
 - `strategies.py` — austauschbare `Strategy`-Definitionen (Töpfe,
   Sub-Gewichte, Rebalancing-Schwelle, Startkapital) + strategieübergreifende
   Steuer-/Gebührkonstanten. Die Engine enthält **keine** Barbell-spezifischen
@@ -775,7 +780,13 @@ ersten vollständigen Zeitpunkt zu) sowie den Grenzfall, dass eine Strategie
 mit einem nie handelbaren Instrument die Historie unverändert zurückbekommt,
 und dass die geschätzte Nettorendite unter der Bruttorendite liegt, sobald
 über einen hand-konstruierten großen Rebalancing-Gewinn tatsächlich Steuer
-anfällt.
+anfällt. Für #66: `_allokierte_ticker()` gegen eine Fixture, die nur einen
+Ticker hält, unabhängig davon wie viele `instruments.py` insgesamt kennt;
+dass die Startseite die dynamische Instrumentenzahl statt der fest
+eingetragenen „17" zeigt; dass die Prämissen-Seite allokierte und nicht
+allokierte Instrumente in getrennte Tabellen/Abschnitte einsortiert; und
+dass der „Datenreihen ohne Allokation"-Abschnitt gar nicht erst gerendert
+wird, wenn eine Strategie ausnahmsweise alle Ticker hält.
 `tests/test_learnings.py` fährt jede Learning-Regel gegen
 konstruierte Views mit bekannten Zahlen und prüft, dass die Aussagen den
 Daten folgen statt fest zu sein (inkl. Gegenprobe mit umgedrehter

--- a/README.md
+++ b/README.md
@@ -548,16 +548,22 @@ pytest -q
 
 ## Known limitations
 
-- **Hindsight bias in instrument selection:** the instruments were picked
-  when their price history was already known. A backtested return therefore
-  does not answer "what would I have earned?", only "how would these rules
-  have played out on these, retrospectively chosen, instruments?". The
+- **Hindsight bias in instrument selection:** the 17 instruments actually
+  allocated to a strategy or scenario were picked when their price history
+  was already known. A backtested return therefore does not answer "what
+  would I have earned?", only "how would these rules have played out on
+  these, retrospectively chosen, instruments?". This does *not* apply to the
+  7 additional data series tracked without ever being allocated to a
+  strategy (a broad equity/real-estate/commodity index and a money-market
+  fund, added purely as neutral benchmarks — see #64/#66) — they were picked
+  independent of their price performance, not chosen into a strategy. The
   scenario rules themselves are a first pass, neither optimized nor
   backtested, and everything rests on a single historical price series — no
   Monte Carlo, no confidence intervals. Differences of a few percentage
   points between two strategies are not meaningful. The dashboard's
   **Premises page** (`docs/praemissen.html`, reachable from the three-dot
-  menu on every page) spells this out for readers.
+  menu on every page) spells this out for readers, including a dedicated
+  section listing the unallocated data series separately.
 - **Placeholder constants:** `VORABPAUSCHALE_BASISZINS_PLATZHALTER` (2.0%)
   is not a real annual BMF base rate, and `_RISIKOFREIER_ZINS_PLATZHALTER`
   (0%) used by the Sharpe/Sortino ratios is not a real reference rate. Taxes

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -643,6 +643,19 @@ def _erste_kurse(rows: list[PriceRow]) -> dict[str, str]:
     return erste
 
 
+def _allokierte_ticker(strategies: list[Strategy]) -> set[str]:
+    """Menge aller Ticker, die in mindestens einer Strategie/einem Szenario
+    tatsächlich einem Topf zugeordnet sind (#66) - generisch aus
+    ``Strategy.alle_ticker_gewichte()`` abgeleitet statt hart als Zahl "17"
+    eingetragen, damit ein künftiger Instrumente- oder Strategiewechsel
+    Dashboard und Prämissen-Seite automatisch mitzieht. `instruments.TICKERS`
+    kann mehr Ticker enthalten als hier zurückkommen - die Differenz sind
+    bewusst nicht allokierte Datenreihen (siehe instruments.py-Kommentar zu
+    IUSA/XEON/EXSA/IBCL/IBCI/IQQ6/EXXY, #64/#65): Ticker, die
+    ``engine.simulate()`` nie handelt, weil sie in keinem Topf liegen."""
+    return {t for s in strategies for t in s.alle_ticker_gewichte()}
+
+
 def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views: list[dict]) -> dict:
     """Baut die Daten für die Prämissen-Seite.
 
@@ -660,24 +673,28 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
     #55)."""
     views_by_id = {v["id"]: v for v in views}
     erste = _erste_kurse(rows)
+    allokierte_ticker = _allokierte_ticker(strategies)
     instrumente = []
+    nicht_allokierte_instrumente = []
     for ticker in TICKERS:
         inst = INSTRUMENTS[ticker]
-        instrumente.append(
-            {
-                "ticker": ticker,
-                "name": inst.name,
-                "isin": inst.isin or "–",
-                "teilfreistellung": f"{inst.teilfreistellung * 100:.0f}",
-                "thesaurierend": "ja" if inst.thesaurierend else "nein",
-                "ausschuettend": "ja" if inst.ausschuettend else "nein",
-                "spekulationsfrist": (
-                    f"{inst.spekulationsfrist_tage} Tage" if inst.spekulationsfrist_tage else "–"
-                ),
-                "erster_kurs": erste.get(ticker, "– (nie)"),
-                "fehlt_anfangs": erste.get(ticker) != rows[0].date.isoformat(),
-            }
-        )
+        eintrag = {
+            "ticker": ticker,
+            "name": inst.name,
+            "isin": inst.isin or "–",
+            "teilfreistellung": f"{inst.teilfreistellung * 100:.0f}",
+            "thesaurierend": "ja" if inst.thesaurierend else "nein",
+            "ausschuettend": "ja" if inst.ausschuettend else "nein",
+            "spekulationsfrist": (
+                f"{inst.spekulationsfrist_tage} Tage" if inst.spekulationsfrist_tage else "–"
+            ),
+            "erster_kurs": erste.get(ticker, "– (nie)"),
+            "fehlt_anfangs": erste.get(ticker) != rows[0].date.isoformat(),
+        }
+        if ticker in allokierte_ticker:
+            instrumente.append(eintrag)
+        else:
+            nicht_allokierte_instrumente.append(eintrag)
 
     strategie_liste = []
     for s in strategies:
@@ -706,6 +723,7 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
 
     return {
         "instrumente": instrumente,
+        "nicht_allokierte_instrumente": nicht_allokierte_instrumente,
         "strategien": strategie_liste,
         "zeitraum_von": rows[0].date.isoformat(),
         "zeitraum_bis": rows[-1].date.isoformat(),
@@ -774,6 +792,10 @@ def build_dashboard(
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
         row_count=len(price_history),
         last_date=price_history[-1].date.isoformat(),
+        # #66: aus den tatsächlich allokierten Tickern abgeleitet statt hart
+        # eingetragen, damit die Zahl auf jeder Seite automatisch mit einem
+        # künftigen Instrumente-/Strategiewechsel mitzieht.
+        instrumente_anzahl=len(_allokierte_ticker(strategies)),
     )
 
     env = Environment(

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -3,7 +3,7 @@
   <section class="strategy" id="portfolio">
     <h2>Das Portfolio</h2>
     <p class="hint">
-      Alle Strategien und Szenarien speisen sich aus denselben 17 Instrumenten;
+      Alle Strategien und Szenarien speisen sich aus denselben {{ instrumente_anzahl }} Instrumenten;
       welche davon eine Strategie tatsächlich hält und wie stark, entscheidet
       erst die jeweilige Gewichtung. Zwei Töpfe gibt es in jeder Strategie:
       <strong>Topf A – Sicherheit</strong> (breiter Anleihen-ETF, physisches

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -39,6 +39,16 @@
         anteilige Umlegung auf früh existierende Instrumente (nächster Abschnitt)
         auch für die veröffentlichten Kennzahlen wirken zu lassen. Beides bleibt
         eine Vereinfachung, kein Beweis für Investierbarkeit zu jedem Zeitpunkt.
+        Der Rückschaufehler betrifft ausschließlich diese
+        {{ instrumente|length }} tatsächlich einer Strategie zugeordneten
+        Instrumente.
+        {% if nicht_allokierte_instrumente %}
+        Die {{ nicht_allokierte_instrumente|length }} zusätzlich erfassten
+        Datenreihen (Abschnitt „Datenreihen ohne Allokation" unten) sind kein
+        Rückschaufehler, weil sie unabhängig von ihrer Kursentwicklung als
+        neutraler Vergleichsmaßstab ergänzt wurden, nicht in eine Strategie
+        hinein ausgewählt.
+        {% endif %}
       </li>
       <li>
         <strong>Die Regeln sind nicht optimiert und nicht gebacktestet.</strong>
@@ -110,6 +120,46 @@
         </tbody>
       </table>
     </div>
+
+    {% if nicht_allokierte_instrumente %}
+    <h3>Datenreihen ohne Allokation</h3>
+    <p class="hint">
+      Die folgenden {{ nicht_allokierte_instrumente|length }} Instrumente
+      liegen bewusst in <strong>keinem Topf</strong> einer Strategie oder
+      eines Szenarios &ndash; <code>engine.simulate()</code> liest
+      ausschließlich die Ziel-Gewichte der Strategien und handelt deshalb
+      keine dieser Datenreihen, egal wie sich ihr Kurs entwickelt. Sie wurden
+      unabhängig von ihrer Kursentwicklung als neutraler Vergleichsmaßstab
+      (breite Indizes, Geldmarkt, Immobilien, Rohstoffe) aufgenommen, nicht
+      in eine Strategie hinein ausgewählt &ndash; siehe
+      <a href="https://github.com/S540d/Boersenspiel/issues/64">#64</a>. Erst
+      eine künftige Allokation (siehe
+      <a href="https://github.com/S540d/Boersenspiel/issues/63">#63</a>)
+      würde sie in die Simulation einbeziehen; bis dahin stehen Teilfreistellung/
+      Thesaurierungs-/Ausschüttungsstatus hier nur informativ und sind, anders
+      als bei den allokierten Instrumenten oben, noch nicht gegen die
+      Fondsprospekte verifiziert.
+    </p>
+    <div class="overflow-x">
+      <table>
+        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Spekulationsfrist</th></tr></thead>
+        <tbody>
+        {% for i in nicht_allokierte_instrumente %}
+          <tr>
+            <td>{{ i.ticker }}</td>
+            <td class="text-left">{{ i.name }}</td>
+            <td class="text-left">{{ i.isin }}</td>
+            <td class="{{ 'warn' if i.fehlt_anfangs else '' }}">{{ i.erster_kurs }}{% if i.fehlt_anfangs %} &#9888;{% endif %}</td>
+            <td>{{ i.teilfreistellung }}</td>
+            <td>{{ i.thesaurierend }}</td>
+            <td>{{ i.ausschuettend }}</td>
+            <td>{{ i.spekulationsfrist }}</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
 
     <h3>Handelsregeln</h3>
     <div class="stat-row">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 from pathlib import Path
 
 from boersenspiel.dashboard import (
+    _allokierte_ticker,
     _BTC_FRUEHPHASE_ENDE,
     _BTC_TICKER,
     _build_strategy_view,
@@ -736,3 +737,58 @@ def test_netto_rendite_liegt_unter_der_bruttorendite_wenn_steuer_anfaellt():
     brutto = float(view["cagr_label"].replace(",", "."))
     netto = float(view["netto_cagr_label"].replace(",", "."))
     assert netto < brutto
+
+
+# --- #66: veraltete Instrumentenzahl, unallokierte Instrumente unerklaert ----------
+
+
+def test_allokierte_ticker_ist_die_vereinigung_ueber_alle_strategien():
+    # ZWEI_STRATEGIEN haelt beide nur "T1" - unabhaengig davon, wie viele
+    # Ticker instruments.py insgesamt kennt.
+    assert _allokierte_ticker(ZWEI_STRATEGIEN) == {"T1"}
+
+
+def test_build_dashboard_zeigt_dynamische_instrumentenzahl_statt_hartkodierter_17(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+    # ZWEI_STRATEGIEN allokiert genau 1 Ticker ("T1") - die feste "17" aus dem
+    # Template ist damit hier nicht mehr korrekt, dynamisch schon.
+    assert "denselben 1 Instrumenten" in html
+    assert "denselben 17 Instrumenten" not in html
+
+
+def test_praemissen_seite_trennt_allokierte_von_nicht_allokierten_instrumenten(tmp_path: Path):
+    # ZWEI_STRATEGIEN allokiert nur "T1" - alle "echten" TICKERS aus
+    # instruments.py landen deshalb in der neuen "Datenreihen ohne
+    # Allokation"-Sektion statt in der Haupttabelle.
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    assert "<h3>Datenreihen ohne Allokation</h3>" in html
+    vor_abschnitt, nach_abschnitt = html.split("<h3>Datenreihen ohne Allokation</h3>", 1)
+    assert "EUNL" not in vor_abschnitt.split("Instrumente und ab wann es sie gab", 1)[1]
+    assert "EUNL" in nach_abschnitt
+
+
+def test_praemissen_seite_versteckt_abschnitt_wenn_alles_allokiert_ist(tmp_path: Path):
+    # Eine Strategie, die ALLE TICKERS haelt -> keine unallokierten Instrumente
+    # -> der Abschnitt darf gar nicht erst gerendert werden.
+    alles_strategy = Strategy(
+        name="Alles",
+        startkapital=Decimal("1000"),
+        toepfe=[
+            Topf(
+                name="Topf",
+                gewicht_gesamt=Decimal("1"),
+                sub_gewichte={t: Decimal(1) / Decimal(len(TICKERS)) for t in TICKERS},
+            )
+        ],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+    rows = [PriceRow(date(2024, 1, 1), {t: Decimal("100") for t in TICKERS})]
+    build_dashboard(rows, [alles_strategy], output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    assert "<h3>Datenreihen ohne Allokation</h3>" not in html


### PR DESCRIPTION
Closes #66.

## Summary

- **Dashboard-Startseite:** `Alle Strategien und Szenarien speisen sich aus denselben 17 Instrumenten` war fest im Template verdrahtet. Neu: `dashboard._allokierte_ticker(strategies)` leitet die Menge der tatsächlich einer Strategie/einem Szenario zugeordneten Ticker aus `Strategy.alle_ticker_gewichte()` ab; das Template zeigt `{{ instrumente_anzahl }}` (aus `common_context`, für jeden Seitentyp verfügbar).
- **Prämissen-Seite:** die Instrumententabelle listete bisher alle 24 `TICKERS` undifferenziert, inklusive der 7 aus #65 aufgenommenen, bewusst nicht allokierten Datenreihen (`IUSA`, `XEON`, `EXSA`, `IBCL`, `IBCI`, `IQQ6`, `EXXY`). `_praemissen_kontext()` trennt jetzt in `instrumente` (allokiert) und `nicht_allokierte_instrumente`; Letztere bekommen einen eigenen Abschnitt „Datenreihen ohne Allokation" (nur gerendert, wenn nicht leer) mit Verweis auf #64 und der Erklärung, dass `engine.simulate()` sie nie handelt, weil sie in keinem Topf liegen — dieselbe Erklärung, die bereits als Kommentar in `instruments.py` steht, jetzt auch für Leser der Seite sichtbar.
- **Hindsight-Bias-Formulierung:** der Satz auf der Prämissen-Seite und in der README bezog sich pauschal auf „die Instrumente". Beide Stellen beziehen sich jetzt explizit nur noch auf die tatsächlich allokierten Instrumente — die 7 Datenreihen wurden unabhängig von ihrer Kursentwicklung als neutraler Vergleichsmaßstab ergänzt, nicht in eine Strategie hinein ausgewählt.

Rein redaktionell/darstellend, keine Simulationslogik betroffen (`engine.py` unverändert).

## Test plan

- [x] `pytest -q` (212 Tests, alle grün) — inklusive neuer Tests für `_allokierte_ticker()`, die dynamische Instrumentenzahl im Dashboard, die Trennung der Instrumententabellen auf der Prämissen-Seite und den Grenzfall, dass der neue Abschnitt bei vollständiger Allokation gar nicht gerendert wird
- [x] `python scripts/build_dashboard.py` gegen die echte `data/price_history.csv` gebaut und geprüft: Startseite zeigt „17 Instrumenten", Prämissen-Seite listet die 7 unallokierten Datenreihen (mit ihren echten Erstkurstagen aus dem 20-Jahres-Backfill) im neuen Abschnitt statt unauffällig zwischen den 17 allokierten

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDxPqLGm3oxeN3Jf6qurnm)_