### PR TITLE
weekly-update.yml: Push-Race beim Kurshistorie-Commit blockiert nicht mehr das Deploy

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -39,6 +39,14 @@ jobs:
         run: python scripts/build_dashboard.py
 
       - name: Kurshistorie committen
+        # continue-on-error (bewusst): ein Push-Race gegen einen zeitgleichen
+        # Merge auf main darf den bereits fertig gebauten Dashboard-Build
+        # nicht am Deploy hindern - sonst haengt eine unbeteiligte Pages-
+        # Aktualisierung an einem git-Konflikt in price_history.csv fest.
+        # record_week() ist wochen-idempotent (siehe history_store.py), ein
+        # verpasster Commit holt sich beim naechsten erfolgreichen Lauf von
+        # selbst nach, es geht also keine Kurswoche verloren.
+        continue-on-error: true
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -689,6 +689,19 @@ Kursabruf (Alpha Vantage) → Dashboard-Build → Commit von
 GitHub-Pages-Deploy. Braucht die Secrets/Settings: Repo-Secret
 `ALPHAVANTAGE_API_KEY`; Settings → Actions → Workflow permissions → "Read
 and write permissions"; Settings → Pages → Source → "GitHub Actions".
+**Der Commit-Schritt trägt bewusst `continue-on-error: true`:** ein
+zeitgleicher Merge auf `main` (z. B. während der Workflow läuft) kann den
+`git push` der Kurshistorie in einen echten Merge-Konflikt laufen lassen
+(beobachtet am 22.08.2026, Lauf #16 — Fetch und Dashboard-Build liefen
+beide durch, nur der anschließende Push/Rebase scheiterte). Ohne
+`continue-on-error` riss das den gesamten Job ab und übersprang damit
+„Pages-Artefakt hochladen" sowie den `deploy`-Job — ein für den Pages-Deploy
+irrelevanter git-Konflikt verhinderte so die Veröffentlichung eines bereits
+fertig gebauten Dashboards. `record_week()` ist wochen-idempotent (siehe
+`history_store.py`), ein bei einem Konflikt verpasster Commit holt sich beim
+nächsten erfolgreichen Lauf von selbst nach — es geht keine Kurswoche
+verloren, nur die Veröffentlichung dieses einen Laufs würde sonst unnötig
+blockiert.
 
 ### Tests
 


### PR DESCRIPTION
## Summary

Ausgelöst durch den fehlgeschlagenen manuellen Lauf [#16](https://github.com/S540d/Boersenspiel/actions/runs/32551045871) (22.08.2026): Fetch (Alpha Vantage) und Dashboard-Build liefen beide erfolgreich durch, aber der `git push` der Kurshistorie geriet in eine Race Condition gegen einen zeitgleichen Merge auf `main` (PR #67/#68) und lief nach dem Rebase-Fallback in einen echten Merge-Konflikt in `price_history.csv`. Dadurch riss der gesamte `fetch-and-build`-Job ab — und übersprang damit auch „Pages-Artefakt hochladen" sowie den `deploy`-Job, obwohl der Dashboard-Build (inkl. der Fixes aus #63/#66) bereits fertig auf der Runner-Disk lag.

**Fix:** `continue-on-error: true` auf dem Commit-Schritt entkoppelt den (für den Pages-Deploy irrelevanten) git-Push vom Deploy. `history_store.record_week()` ist wochen-idempotent — ein bei einem Konflikt verpasster Commit holt sich beim nächsten erfolgreichen Lauf von selbst nach, es geht also keine Kurswoche verloren. Der fehlgeschlagene Schritt bleibt im Actions-UI sichtbar (gelb markiert), blockiert aber nicht mehr den restlichen Job.

## Test plan

- [x] YAML-Syntax lokal geprüft (`yaml.safe_load`)
- [ ] Nächster Workflow-Lauf sollte trotz eines eventuellen Push-Konflikts erfolgreich deployen — lässt sich nur live in Actions beobachten

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDxPqLGm3oxeN3Jf6qurnm)_