### PR TITLE
#64: S&P-500-Benchmark und diversifizierte Barbell-Variante

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,40 +49,41 @@ inkrementell fortgeschrieben).
 ### Trennung der Verantwortlichkeiten (wichtig beim Erweitern)
 
 - `instruments.py` — die 24 Instrumente (7 Barbell-Basisinstrumente + 10
-  Einzelaktien-Satellit + 7 nicht allokierte Datenreihen, s.u.), **quellenunabhängig**. Kein
-  Provider-Symbol-Mapping hier.
-  **Datenreihen ohne Allokation (#64):** Die sieben zuletzt ergänzten
-  Instrumente (`IUSA`, `XEON`, `EXSA`, `IBCL`, `IBCI`, `IQQ6`, `EXXY`) stehen
-  bewusst in **keinem Topf**. `engine.simulate()` liest ausschließlich
-  `strategy.alle_ticker_gewichte()` — ein Instrument ohne Topf wird nie
-  gehandelt und verändert keine veröffentlichte Zahl (per Test abgesichert,
-  Renditen sind vor und nach der Aufnahme bit-identisch). Es landet nur in
-  `price_history.csv`. Grund: erst Daten sammeln, dann allokieren — die
-  Zuordnung hängt an den Methodenentscheidungen aus #63, ohne die Kurse jetzt
-  mitzuerheben bräuchte es später aber einen zweiten kompletten Backfill an
-  einem zweiten Tag. Alle sieben sind XETRA-Symbole in EUR, kosten also keinen
-  zusätzlichen FX-Request und umgehen das Währungsproblem aus #62 vollständig.
-  Ihre Steuerattribute (`teilfreistellung`/`thesaurierend`/`ausschuettend`)
-  sind aus Fondsgattung und Namenszusatz abgeleitet, **nicht** gegen die
-  Prospekte geprüft — solange die Instrumente in keinem Topf liegen, wertet die
-  Engine sie nie aus; vor einer Allokation gehören sie verifiziert.
+  Einzelaktien-Satellit + 7 im Zuge von #64 ergänzte Instrumente),
+  **quellenunabhängig**. Kein Provider-Symbol-Mapping hier.
+  **Sieben zusätzliche Instrumente (#64):** `IUSA`, `XEON`, `EXSA`, `IBCL`,
+  `IBCI`, `IQQ6`, `EXXY` wurden ergänzt, um das tägliche Alpha-Vantage-Budget
+  von 18 auf 25 Requests auszuschöpfen. Alle sieben sind XETRA-Symbole in
+  EUR, kosten also keinen zusätzlichen FX-Request und umgehen das
+  Währungsproblem aus #62 vollständig. Sie standen zunächst bewusst in
+  keinem Topf (erst Daten sammeln, dann allokieren) — mittlerweile sind alle
+  sieben einer Strategie zugeordnet: `IUSA` dient ausschließlich als
+  Benchmark (`strategies.SP500_BENCHMARK`), die übrigen sechs sind Teil von
+  `strategies.BARBELL_20_80_DIVERSIFIZIERT` (siehe unten). Ihre
+  Steuerattribute (`teilfreistellung`/`thesaurierend`/`ausschuettend`) sind
+  gegen öffentliche Fondsanbieter-Fact-Sheets (justETF/extraETF/onvista/DAS
+  INVESTMENT) verifiziert — dabei wurde ein Fehler gefunden und korrigiert:
+  `IBCI` und `EXXY` sind tatsächlich thesaurierende Acc-Anteilsklassen,
+  waren aber zunächst fälschlich als ausschüttend markiert (relevant, weil
+  sie jetzt tatsächlich alloziert sind und die Vorabpauschale-/
+  Dividendenmodellierung dadurch beeinflusst wird).
   **Request-Budget:** Mit 24 Instrumenten brauchen Backfill *und* Wochenabruf
   je **genau 25** Requests — das volle Alpha-Vantage-Tageslimit, kein Puffer.
   `tests/test_backfill_history.py` hält das als Test fest, damit ein
   18. Instrument nicht still beide Workflows unmöglich macht.
-  **Darstellung der 7 unallokierten Instrumente (#66, behoben):** Weder das
-  Dashboard noch die Prämissen-Seite noch die README nennen mehr eine feste
+  **Darstellung nicht allokierter Instrumente (#66):** Weder das Dashboard
+  noch die Prämissen-Seite noch die README nennen eine feste
   Instrumentenzahl. `dashboard._allokierte_ticker(strategies)` leitet die
   Menge der tatsächlich einer Strategie/einem Szenario zugeordneten Ticker
   generisch aus `Strategy.alle_ticker_gewichte()` ab; `dashboard.html.j2`
-  zeigt `{{ instrumente_anzahl }}` (aus `common_context`) statt hart „17".
-  `_praemissen_kontext()` trennt die Instrumententabelle dementsprechend in
-  `instrumente` (nur allokierte) und `nicht_allokierte_instrumente` — Letztere
-  bekommen einen eigenen Abschnitt „Datenreihen ohne Allokation" (nur
-  gerendert, wenn nicht leer), der auf #64 verweist und erklärt, dass
-  `engine.simulate()` sie nie handelt, weil sie in keinem Topf liegen. Der
-  Hindsight-Bias-Absatz (dort und in der README) bezieht sich jetzt explizit
-  nur noch auf die tatsächlich allokierten Instrumente.
+  zeigt `{{ instrumente_anzahl }}` (aus `common_context`) statt einer
+  hartkodierten Zahl. `_praemissen_kontext()` trennt die Instrumententabelle
+  dementsprechend in `instrumente` (nur allokierte) und
+  `nicht_allokierte_instrumente` — Letztere bekommen einen eigenen Abschnitt
+  „Datenreihen ohne Allokation" (nur gerendert, wenn nicht leer). Seit der
+  vollständigen Allokation der sieben #64-Instrumente ist diese Menge aktuell
+  leer und der Abschnitt entfällt entsprechend — der Mechanismus bleibt aber
+  bestehen, falls künftig wieder Instrumente ohne Topf ergänzt werden.
 - `strategies.py` — austauschbare `Strategy`-Definitionen (Töpfe,
   Sub-Gewichte, Rebalancing-Schwelle, Startkapital) + strategieübergreifende
   Steuer-/Gebührkonstanten. Die Engine enthält **keine** Barbell-spezifischen
@@ -112,6 +113,25 @@ inkrementell fortgeschrieben).
   Simulationsmechanismen `engine.simulate()` für diese Strategie anwendet —
   `BUY_AND_HOLD` nutzt z. B. `Optimierungen(rebalancing=False)` statt einer
   künstlich unerreichbaren Rebalancing-Schwelle.
+  **`BARBELL_20_80_DIVERSIFIZIERT` und `SP500_BENCHMARK` (#64):** zwei
+  weitere, zusätzliche Strategien neben den bestehenden drei — sie
+  verändern `BARBELL_20_80`/`BARBELL_30_70`/`BARBELL_20_60_20_SATELLIT`
+  nicht, damit sich deren veröffentlichte Kennzahlen durch #64 nicht
+  verschieben. `SP500_BENCHMARK` ist die einfachste mögliche Strategie: ein
+  einziger Topf, 100% `IUSA`, nie rebalanciert (`Optimierungen
+  (rebalancing=False)`, analog zu `BUY_AND_HOLD` — bei nur einem Instrument
+  wäre der Rebalancing-Trigger ohnehin wirkungslos, aber ehrlich benannt
+  statt implizit über eine unerreichbare Schwelle abgeschaltet). Dient als
+  reine Vergleichslinie "einfach den Index kaufen", die dem Dashboard vorher
+  fehlte. `BARBELL_20_80_DIVERSIFIZIERT` behält das 20/80-Risikoprofil von
+  `BARBELL_20_80`, mischt aber die übrigen sechs #64-Instrumente ein, um
+  zwei im Issue benannte Lücken zu schließen: Topf A verliert `EUNL`
+  (Aktien-ETF) zugunsten von echtem EUR-Cash (`XEON`) sowie Anleihen anderer
+  Duration/Realzins-Eigenschaft (`IBCL`/`IBCI`) neben `EUNA`/`4GLD`; Topf B
+  bekommt `EUNL` sowie `EXSA` (Europa, senkt die USA/Tech-Konzentration von
+  LYMS+SEMI), `IQQ6` (Immobilien) und `EXXY` (breite Rohstoffe). Erster
+  Ansatz, Gewichte nicht optimiert/gebacktestet — wie bei allen Szenarien in
+  `scenarios.py`.
   **Rebalancing-Trigger, "5/25-Regel je Topf" (#63, F5):** Optionales Feld
   `Strategy.rebalancing_schwelle_relativ` (Decimal, Default `1` = 100%)
   ergänzt `rebalancing_schwelle_pp` um eine relative Zusatzschwelle. Die
@@ -834,4 +854,15 @@ mit ungleichen Zielgewichten (40/40/20), bei der das dritte Instrument erst
 später an den Markt kommt — mit `rebalancing=False` bleibt das
 Wertverhältnis des Altbestands (2:1) exakt erhalten und nur das neue
 Instrument wird auf sein Zielgewicht gekauft, mit `rebalancing=True` landen
-weiterhin alle drei auf ihren Zielgewichten.
+weiterhin alle drei auf ihren Zielgewichten. `tests/test_neue_strategien.py`
+prüft die beiden #64-Strategien: Sub-Gewichte je Topf summieren zu 1,
+`BARBELL_20_80_DIVERSIFIZIERT` hält das 20/80-Risikoprofil und einen echten
+Cash-Baustein statt eines Aktien-ETF in Topf A, `SP500_BENCHMARK` hält
+ausschließlich `IUSA` und rebalanciert nie, beide laufen End-to-End durch —
+sowie einen Regressionstest, dass `IBCI`/`EXXY` tatsächlich thesaurierend
+statt ausschüttend sind (die im Zuge von #64 korrigierten Steuerattribute).
+`tests/test_backfill_history.py::test_neue_datenreihen_bleiben_ausserhalb_
+der_urspruenglichen_strategien` (vormals „…liegen_in_keinem_topf", seit die
+sieben Instrumente alloziert sind umbenannt) sichert ab, dass die drei
+ursprünglichen Barbell-Strategien und alle Szenarien weiterhin unberührt
+bleiben — nur die beiden neuen Strategien allokieren die #64-Instrumente.

--- a/src/boersenspiel/instruments.py
+++ b/src/boersenspiel/instruments.py
@@ -95,29 +95,26 @@ INSTRUMENTS: dict[str, Instrument] = {
         Instrument("RIVN", "Rivian Automotive", "US76954A1034", ausschuettend=True),
         Instrument("KO", "Coca-Cola (defensiver Blue Chip)", "US1912161007", ausschuettend=True),
         Instrument("RHHBY", "Roche Holding (ADR, defensiver Blue Chip)", "US7711951043", ausschuettend=True),
-        # --- Datenreihen ohne Allokation (#64) ---------------------------------
-        # Sieben zusaetzliche Instrumente, die das taegliche Alpha-Vantage-Budget
-        # von 25 Requests ausschoepfen (vorher 18). Sie stehen BEWUSST in KEINEM
-        # Topf einer Strategie: `engine.simulate()` liest ausschliesslich
-        # `strategy.alle_ticker_gewichte()`, ein Instrument ohne Topf wird also
-        # nie gehandelt und veraendert keine einzige veroeffentlichte Zahl. Es
-        # landet nur in `price_history.csv`.
+        # --- Sieben zusaetzliche Instrumente (#64) ------------------------------
+        # Ergaenzt am 22.08.2026, um das taegliche Alpha-Vantage-Budget von 25
+        # Requests auszuschoepfen (vorher 18). Alle sieben sind XETRA-Symbole in
+        # EUR, kosten also keinen zusaetzlichen FX-Request.
         #
-        # Das ist Absicht: erst Daten sammeln, dann allokieren. Die Zuordnung zu
-        # Toepfen haengt an den Methodenentscheidungen aus #63 (insbesondere dem
-        # Rebalancing-Trigger) - bis dahin waere jede Gewichtung geraten. Ohne
-        # die Kurse jetzt mitzuerheben braeuchte es spaeter aber einen zweiten
-        # kompletten Backfill an einem zweiten Tag.
+        # Steuerattribute verifiziert: `teilfreistellung`/`thesaurierend`/
+        # `ausschuettend` wurden gegen oeffentliche Fondsanbieter-Fact-Sheets
+        # (justETF/extraETF/onvista/DAS INVESTMENT) abgeglichen, nicht nur aus
+        # Fondsgattung/Namenszusatz geraten. Dabei zwei Fehler gefunden und
+        # korrigiert: IBCI und EXXY sind tatsaechlich thesaurierende
+        # Acc-Anteilsklassen, waren aber faelschlich als ausschuettend markiert.
         #
-        # ACHTUNG bei der spaeteren Allokation: `teilfreistellung`,
-        # `thesaurierend` und `ausschuettend` unten sind aus Fondsgattung und
-        # Namenszusatz (Dist/Acc) abgeleitet, NICHT gegen die Fondsprospekte
-        # geprueft. Solange die Instrumente in keinem Topf liegen, wertet die
-        # Engine sie nie aus - sobald sie allokiert werden, gehoeren sie
-        # verifiziert, sonst rechnet das Steuermodell mit falschen Annahmen.
+        # IUSA dient ausschliesslich als Benchmark (`SP500_BENCHMARK` in
+        # strategies.py, 100% Einzelinstrument, nie rebalanciert) - es ist
+        # NICHT zusaetzlich Bestandteil einer der Barbell-Topf-Allokationen.
+        # Die uebrigen sechs (XEON, EXSA, IBCL, IBCI, IQQ6, EXXY) sind Teil von
+        # `BARBELL_20_80_DIVERSIFIZIERT`.
         Instrument(
             "IUSA",
-            "S&P 500 ETF (iShares Core, aussch.) - Benchmark, nicht allokiert",
+            "S&P 500 ETF (iShares Core, aussch.) - nur Benchmark",
             "IE0031442068",
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             ausschuettend=True,
@@ -144,9 +141,11 @@ INSTRUMENTS: dict[str, Instrument] = {
         ),
         Instrument(
             "IBCI",
-            "Inflationsindexierte Euro-Staatsanleihen ETF (iShares)",
+            "Inflationsindexierte Euro-Staatsanleihen ETF (iShares, thes.)",
             "IE00B0M62X26",
-            ausschuettend=True,
+            # Acc-Anteilsklasse (WKN A0HGV1), nicht Dist - siehe Verifikations-
+            # Hinweis oben.
+            thesaurierend=True,
         ),
         Instrument(
             "IQQ6",
@@ -154,16 +153,17 @@ INSTRUMENTS: dict[str, Instrument] = {
             "IE00B1FZS350",
             # Haelt boersennotierte Immobiliengesellschaften/REITs, also >51%
             # Aktien -> Aktienfonds-Teilfreistellung, nicht die Immobilienfonds-
-            # Quote. Bei der Allokation gegen den Prospekt pruefen.
+            # Quote.
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             ausschuettend=True,
         ),
         Instrument(
             "EXXY",
-            "Rohstoff-ETF breit (iShares Diversified Commodity Swap)",
+            "Rohstoff-ETF breit (iShares Diversified Commodity Swap, thes.)",
             "DE000A0H0728",
-            # Rohstofffonds -> keine Teilfreistellung.
-            ausschuettend=True,
+            # Rohstofffonds -> keine Teilfreistellung. Acc-Anteilsklasse, nicht
+            # Dist - siehe Verifikations-Hinweis oben.
+            thesaurierend=True,
         ),
     ]
 }

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -267,7 +267,110 @@ BARBELL_20_60_20_SATELLIT = Strategy(
     ),
 )
 
-STRATEGIES: list[Strategy] = [BARBELL_20_80, BARBELL_30_70, BARBELL_20_60_20_SATELLIT]
+# --- Strategie 4: Barbell 20/80, breiter diversifiziert (#64) --------------
+#
+# Adressiert zwei im Rahmen von #64 identifizierte Luecken der bestehenden
+# Barbell-Strategien: Topf A ("Sicherheit") besteht bei BARBELL_20_80 zur
+# Haelfte aus EUNL (Aktien-ETF) - kein echter Cash-Baustein. Und Topf B
+# ("Wachstum") ist stark auf USA/Tech konzentriert (LYMS Nasdaq-100 + SEMI
+# Halbleiter = 70% des Topfs), Europa fehlt komplett, ebenso Immobilien und
+# breite Rohstoffe. Diese Variante nutzt sechs der sieben in #64 ergaenzten
+# Instrumente (alle ausser IUSA, das ausschliesslich als Benchmark dient,
+# siehe SP500_BENCHMARK unten), um beide Luecken zu schliessen, OHNE
+# BARBELL_20_80 selbst zu veraendern - eine zusaetzliche Strategie neben den
+# bestehenden, nach demselben Muster wie BARBELL_20_60_20_SATELLIT.
+#
+# Topf A behaelt 20% des Gesamtdepots, verliert aber EUNL zugunsten von
+# echtem EUR-Cash (XEON) sowie Anleihen mit anderer Duration/Realzins-
+# Eigenschaft (IBCL/IBCI) neben EUNA/4GLD. Topf B behaelt 80%, EUNL wandert
+# hierher, EXSA (Europa) senkt den USA/Tech-Anteil, IQQ6/EXXY ergaenzen
+# Immobilien und breite Rohstoffe. Erster Ansatz, Gewichte nicht optimiert
+# oder gebacktestet (wie alle Szenarien in scenarios.py).
+
+BARBELL_20_80_DIVERSIFIZIERT = Strategy(
+    name="Barbell 20/80 (breiter diversifiziert)",
+    startkapital=Decimal("10000"),
+    toepfe=[
+        Topf(
+            name="Topf A - Sicherheit",
+            gewicht_gesamt=Decimal("0.20"),
+            sub_gewichte={
+                "EUNA": Decimal("0.25"),
+                "4GLD": Decimal("0.15"),
+                "XEON": Decimal("0.25"),
+                "IBCL": Decimal("0.15"),
+                "IBCI": Decimal("0.20"),
+            },
+        ),
+        Topf(
+            name="Topf B - Wachstum",
+            gewicht_gesamt=Decimal("0.80"),
+            sub_gewichte={
+                "EUNL": Decimal("0.25"),
+                "EXSA": Decimal("0.15"),
+                "LYMS": Decimal("0.20"),
+                "SEMI": Decimal("0.10"),
+                "EIMI": Decimal("0.15"),
+                "IQQ6": Decimal("0.05"),
+                "EXXY": Decimal("0.05"),
+                "BTC-EUR": Decimal("0.05"),
+            },
+        ),
+    ],
+    ziel_topf="Topf A - Sicherheit",
+    ziel_gewicht=Decimal("0.20"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
+    beschreibung=(
+        "Wie Barbell 20/80 (20% Sicherheit / 80% Wachstum), aber mit breiterer "
+        "Streuung der sechs in #64 ergänzten Instrumente: Topf A bekommt mit XEON "
+        "(EUR-Geldmarkt) einen echten Cash-Baustein statt eines Aktien-ETF-Anteils, "
+        "dazu IBCL/IBCI (Anleihen anderer Duration/Realzins-Eigenschaft). Topf B "
+        "reduziert die USA/Tech-Konzentration durch EXSA (Europa) und ergänzt "
+        "Immobilien (IQQ6) und breite Rohstoffe (EXXY). Erster Ansatz, nicht "
+        "optimiert/gebacktestet."
+    ),
+)
+
+# --- Strategie 5: Benchmark S&P 500 (#64) -----------------------------------
+#
+# Reine Vergleichslinie: "einfach den Index kaufen", das Dashboard hatte
+# bislang keine solche Referenz gegen die aktiven Strategien/Szenarien. Ein
+# einziger Topf mit 100% IUSA, nie rebalanciert - bei nur einem Instrument
+# waere ein Rebalancing-Trigger ohnehin wirkungslos, aber wie bei
+# scenarios.BUY_AND_HOLD wird das bewusst ehrlich ueber den
+# Optimierungs-Schalter (#17) abgeschaltet statt implizit ueber eine
+# unerreichbare Schwelle.
+
+SP500_BENCHMARK = Strategy(
+    name="Benchmark: S&P 500 (Buy & Hold)",
+    startkapital=Decimal("10000"),
+    toepfe=[
+        Topf(
+            name="Topf A - Benchmark",
+            gewicht_gesamt=Decimal("1"),
+            sub_gewichte={"IUSA": Decimal("1")},
+        ),
+    ],
+    ziel_topf="Topf A - Benchmark",
+    ziel_gewicht=Decimal("1"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    optimierungen=Optimierungen(rebalancing=False),
+    beschreibung=(
+        "Reine Vergleichslinie: einmaliger Kauf von IUSA (S&P 500, USD, EUR-notiert "
+        "an der Xetra), nie aktiv umgeschichtet. Dient als Referenz 'einfach den "
+        "Index kaufen' gegenüber den Barbell-Strategien und Szenarien, kein "
+        "eigenständiger Anlagevorschlag."
+    ),
+)
+
+STRATEGIES: list[Strategy] = [
+    BARBELL_20_80,
+    BARBELL_30_70,
+    BARBELL_20_60_20_SATELLIT,
+    BARBELL_20_80_DIVERSIFIZIERT,
+    SP500_BENCHMARK,
+]
 
 STRATEGIES_BY_NAME: dict[str, Strategy] = {s.name: s for s in STRATEGIES}
 

--- a/tests/test_backfill_history.py
+++ b/tests/test_backfill_history.py
@@ -466,14 +466,21 @@ def test_neue_datenreihen_sind_in_euro_notiert():
         assert ticker not in USD_TICKERS, f"{ticker} braeuchte sonst FX-Umrechnung"
 
 
-def test_neue_datenreihen_liegen_in_keinem_topf():
-    """Solange die Zuordnung an #63 haengt, duerfen die neuen Instrumente keine
-    Strategie beeinflussen: engine.simulate() liest nur
-    strategy.alle_ticker_gewichte(), ein Ticker ohne Topf wird nie gehandelt."""
+def test_neue_datenreihen_bleiben_ausserhalb_der_urspruenglichen_strategien():
+    """Die drei ursprünglichen Barbell-Strategien und alle Szenarien (die
+    strukturell BARBELL_20_80.toepfe wiederverwenden) duerfen von den sieben in
+    #64 ergaenzten Instrumenten weiterhin unberuehrt bleiben - nur die beiden
+    dafuer neu geschaffenen Strategien (BARBELL_20_80_DIVERSIFIZIERT,
+    SP500_BENCHMARK) allokieren sie (#64, zweiter Umsetzungsschritt)."""
     from boersenspiel.scenarios import SCENARIOS
-    from boersenspiel.strategies import STRATEGIES
+    from boersenspiel.strategies import (
+        BARBELL_20_60_20_SATELLIT,
+        BARBELL_20_80,
+        BARBELL_30_70,
+    )
 
     neue = {"IUSA", "XEON", "EXSA", "IBCL", "IBCI", "IQQ6", "EXXY"}
-    for strategie in list(STRATEGIES) + list(SCENARIOS):
+    unveraendert = [BARBELL_20_80, BARBELL_30_70, BARBELL_20_60_20_SATELLIT, *SCENARIOS]
+    for strategie in unveraendert:
         allokiert = set(strategie.alle_ticker_gewichte())
         assert not (allokiert & neue), f"{strategie.name} allokiert {allokiert & neue}"

--- a/tests/test_neue_strategien.py
+++ b/tests/test_neue_strategien.py
@@ -1,0 +1,114 @@
+"""Tests für die beiden in #64 ergänzten Strategien.
+
+``BARBELL_20_80_DIVERSIFIZIERT`` nutzt sechs der sieben in #64 aufgenommenen
+Datenreihen (XEON, EXSA, IBCL, IBCI, IQQ6, EXXY) für ein breiter gestreutes
+Barbell-Portfolio; ``SP500_BENCHMARK`` nutzt die siebte (IUSA) als reine
+Vergleichslinie ("einfach den Index kaufen"). Beide sind zusätzliche
+Strategien neben den bestehenden - Regressionsschutz, dass Sub-Gewichte zu 1
+summieren und die Simulation End-to-End durchläuft.
+
+Zusätzlich: Regressionstest für die im Zuge von #64 korrigierten
+Steuerattribute von IBCI/EXXY (tatsächlich thesaurierende Acc-Anteilsklassen,
+vorher fälschlich als ausschüttend markiert).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from boersenspiel.engine import simulate
+from boersenspiel.history_store import PriceRow
+from boersenspiel.instruments import INSTRUMENTS
+from boersenspiel.strategies import (
+    BARBELL_20_80_DIVERSIFIZIERT,
+    SP500_BENCHMARK,
+    STRATEGIES,
+)
+
+
+def test_neue_strategien_sind_in_strategies_list_registriert():
+    assert BARBELL_20_80_DIVERSIFIZIERT in STRATEGIES
+    assert SP500_BENCHMARK in STRATEGIES
+
+
+def test_diversifiziert_ticker_gewichte_summieren_zu_eins():
+    gewichte = BARBELL_20_80_DIVERSIFIZIERT.alle_ticker_gewichte()
+    assert sum(gewichte.values()) == Decimal("1")
+
+
+def test_diversifiziert_haelt_barbell_risikoprofil_20_80():
+    sicherheit_topf = BARBELL_20_80_DIVERSIFIZIERT.toepfe[0]
+    wachstum_topf = BARBELL_20_80_DIVERSIFIZIERT.toepfe[1]
+    assert sicherheit_topf.gewicht_gesamt == Decimal("0.20")
+    assert wachstum_topf.gewicht_gesamt == Decimal("0.80")
+    assert sum(sicherheit_topf.sub_gewichte.values()) == Decimal("1")
+    assert sum(wachstum_topf.sub_gewichte.values()) == Decimal("1")
+
+
+def test_diversifiziert_topf_a_hat_echten_cash_baustein_statt_aktien_etf():
+    sicherheit_topf = BARBELL_20_80_DIVERSIFIZIERT.toepfe[0]
+    assert "XEON" in sicherheit_topf.sub_gewichte
+    assert "EUNL" not in sicherheit_topf.sub_gewichte
+
+
+def test_diversifiziert_nutzt_sechs_der_sieben_neuen_instrumente():
+    gewichte = BARBELL_20_80_DIVERSIFIZIERT.alle_ticker_gewichte()
+    for ticker in ["XEON", "EXSA", "IBCL", "IBCI", "IQQ6", "EXXY"]:
+        assert ticker in gewichte
+    assert "IUSA" not in gewichte
+
+
+def test_benchmark_haelt_ausschliesslich_iusa():
+    gewichte = SP500_BENCHMARK.alle_ticker_gewichte()
+    assert gewichte == {"IUSA": Decimal("1")}
+
+
+def test_benchmark_rebalanciert_nie():
+    assert SP500_BENCHMARK.optimierungen.rebalancing is False
+
+
+def _rows_fuer_diversifiziert() -> list[PriceRow]:
+    ticker_kurse_1 = {
+        "EUNA": Decimal("5"),
+        "4GLD": Decimal("60"),
+        "XEON": Decimal("100"),
+        "IBCL": Decimal("150"),
+        "IBCI": Decimal("200"),
+        "EUNL": Decimal("80"),
+        "EXSA": Decimal("50"),
+        "LYMS": Decimal("20"),
+        "SEMI": Decimal("45"),
+        "EIMI": Decimal("30"),
+        "IQQ6": Decimal("25"),
+        "EXXY": Decimal("35"),
+        "BTC-EUR": Decimal("40000"),
+    }
+    ticker_kurse_2 = {t: v * Decimal("1.1") for t, v in ticker_kurse_1.items()}
+    return [
+        PriceRow(date(2024, 1, 1), dict(ticker_kurse_1)),
+        PriceRow(date(2024, 6, 1), ticker_kurse_2),
+    ]
+
+
+def test_diversifiziert_runs_end_to_end():
+    result = simulate(_rows_fuer_diversifiziert(), BARBELL_20_80_DIVERSIFIZIERT)
+    assert result.strategy_name == "Barbell 20/80 (breiter diversifiziert)"
+    assert result.value_history[-1].total_value > 0
+
+
+def test_benchmark_runs_end_to_end():
+    rows = [
+        PriceRow(date(2024, 1, 1), {"IUSA": Decimal("60")}),
+        PriceRow(date(2024, 6, 1), {"IUSA": Decimal("66")}),
+    ]
+    result = simulate(rows, SP500_BENCHMARK)
+    assert result.strategy_name == "Benchmark: S&P 500 (Buy & Hold)"
+    assert result.value_history[-1].total_value > 0
+
+
+def test_ibci_und_exxy_sind_tatsaechlich_thesaurierend_nicht_ausschuettend():
+    assert INSTRUMENTS["IBCI"].thesaurierend is True
+    assert INSTRUMENTS["IBCI"].ausschuettend is False
+    assert INSTRUMENTS["EXXY"].thesaurierend is True
+    assert INSTRUMENTS["EXXY"].ausschuettend is False


### PR DESCRIPTION
Setzt den letzten offenen Teil von #64 um: die sieben dort aufgenommenen Instrumente (`IUSA`, `XEON`, `EXSA`, `IBCL`, `IBCI`, `IQQ6`, `EXXY`) lagen bislang in keinem Topf und wirkten nur als reine Datenreihen. Zwei neue, **zusätzliche** Strategien nutzen sie jetzt, ohne die drei bestehenden (`Barbell 20/80`, `Barbell 30/70`, `Barbell 20/60/20 + Einzelaktien-Satellit`) zu verändern — deren veröffentlichte Kennzahlen bleiben also unangetastet.

## Neue Strategien

- **`SP500_BENCHMARK`** ("Benchmark: S&P 500 (Buy & Hold)"): reiner Kauf-und-Halten auf `IUSA` (100%, nie rebalanciert), als Vergleichslinie "einfach den Index kaufen" — genau die im Issue benannte Lücke ("Das Dashboard vergleicht 14 Regeln nur untereinander, nie gegen einen Index").
- **`BARBELL_20_80_DIVERSIFIZIERT`** ("Barbell 20/80 (breiter diversifiziert)"): gleiches 20/80-Risikoprofil wie Barbell 20/80, aber:
  - Topf A verliert `EUNL` (Aktien-ETF) zugunsten von echtem EUR-Cash (`XEON`) sowie Anleihen anderer Duration/Realzins-Eigenschaft (`IBCL`/`IBCI`) — löst "Der Sparerbaustein ist ein globaler Aktien-ETF".
  - Topf B bekommt `EUNL` sowie `EXSA` (Europa, senkt die USA/Tech-Konzentration von LYMS+SEMI), `IQQ6` (Immobilien) und `EXXY` (breite Rohstoffe) — löst "Klumpen USA/Tech" und "Fehlende Anlageklassen".
  - Erster Ansatz, Gewichte nicht optimiert/gebacktestet (wie bei allen Szenarien im Projekt).

## Steuerattribut-Korrektur (vor der Allokation nötig)

Gegen öffentliche Fondsanbieter-Fact-Sheets geprüft (justETF/extraETF/onvista/DAS INVESTMENT): `IBCI` und `EXXY` sind tatsächlich **thesaurierende Acc-Anteilsklassen**, waren in `instruments.py` aber fälschlich als `ausschuettend=True` markiert. Da beide jetzt tatsächlich alloziert werden, wäre das ein realer Modellfehler (Vorabpauschale vs. Dividendenmodellierung) gewesen — korrigiert. Alle anderen fünf Steuerattribute (IUSA/EXSA/IQQ6 ausschüttend, XEON/IBCL bereits korrekt thesaurierend/ausschüttend) waren bereits richtig.

## Tests

Neue Datei `tests/test_neue_strategien.py`: Sub-Gewichte je Topf summieren zu 1, `BARBELL_20_80_DIVERSIFIZIERT` hält das 20/80-Risikoprofil und einen echten Cash-Baustein, `SP500_BENCHMARK` hält ausschließlich `IUSA` und rebalanciert nie, beide laufen End-to-End durch, plus Regressionstest für die IBCI/EXXY-Korrektur.

`tests/test_backfill_history.py::test_neue_datenreihen_bleiben_ausserhalb_der_urspruenglichen_strategien` (umbenannt von `…_liegen_in_keinem_topf`) prüft jetzt, dass die drei ursprünglichen Strategien und alle Szenarien weiterhin unberührt bleiben.

222 Tests grün. `python scripts/build_dashboard.py` lokal gegen die reale `price_history.csv` gelaufen — beide neuen Seiten (`benchmark-s-p-500-buy-hold.html`, `barbell-20-80-breiter-diversifiziert.html`) werden korrekt erzeugt, `docs/praemissen.html` zeigt für IBCI/EXXY jetzt „thesaurierend: ja / ausschüttend: nein".

Kein Eingriff in `engine.py` — beide neuen Strategien sind reine `Strategy`-Konfiguration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgEDAJBBsFGNzy9g8zBTgD)_