### PR TITLE
Vier Modellierungsfehler, die zu falschen Anlageentscheidungen führen (#73, #74, #75, #76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,9 @@ inkrementell fortgeschrieben).
   Optimierung/Backtesting der Auswahl oder Gewichtung. Optionales Feld
   `Strategy.beschreibung` liefert die Kurzbeschreibung, die das Dashboard je
   Strategie/Szenario anzeigt (leer = keine Beschreibung). Optionales Feld
-  `Strategy.optimierungen` (Instanz von `Optimierungen`, vier Bool-Schalter
-  `steueroptimierung`/`rebalancing`/`ordergebuehren`/`besteuerung`, alle
-  standardmäßig `True`) bestimmt, welche der vier strategieübergreifenden
+  `Strategy.optimierungen` (Instanz von `Optimierungen`, fünf Bool-Schalter
+  `steueroptimierung`/`rebalancing`/`ordergebuehren`/`besteuerung`/`fondskosten`, alle
+  standardmäßig `True`) bestimmt, welche der fünf strategieübergreifenden
   Simulationsmechanismen `engine.simulate()` für diese Strategie anwendet —
   `BUY_AND_HOLD` nutzt z. B. `Optimierungen(rebalancing=False)` statt einer
   künstlich unerreichbaren Rebalancing-Schwelle.
@@ -381,7 +381,7 @@ inkrementell fortgeschrieben).
   verbleibende Sparerpauschbetrag des Jahres gedeckt ist, mit sofortigem
   Rückkauf zum selben Kurs. `simulate(price_history, strategy,
   optimierungen=None)` nimmt optional eine `Optimierungen`-Instanz entgegen
-  (Default: `strategy.optimierungen`) und schaltet damit die vier
+  (Default: `strategy.optimierungen`) und schaltet damit die fünf
   strategieübergreifenden Mechanismen einzeln ab: `ordergebuehren=False`
   macht alle Trades gebührenfrei (lokale `gebuehr`-Variable statt der
   Konstante `ORDERGEBUEHR`), `besteuerung=False` lässt `process_realized_gain`
@@ -389,9 +389,10 @@ inkrementell fortgeschrieben).
   unverändert — der simulierte Portfoliowert selbst wird nirgends um Steuer
   gemindert, das ist reines Tracking), `rebalancing=False` überspringt die
   periodische Rückführung auf die Zielgewichte, `steueroptimierung=False`
-  überspringt den kompletten Dezember-Harvest-Block. Diese Schalter dienen
-  dazu, den isolierten Renditebeitrag jedes Mechanismus messbar zu machen
-  (#17) — siehe `dashboard._optimierungs_effekte()`.
+  überspringt den kompletten Dezember-Harvest-Block, `fondskosten=False`
+  lässt die laufenden Fondskosten (`Instrument.ter`, #76) weg. Diese Schalter
+  dienen dazu, den isolierten Renditebeitrag jedes Mechanismus messbar zu
+  machen (#17) — siehe `dashboard._optimierungs_effekte()`.
   **Steuerkorrekturen (#37/#38/#39, Paket A aus #46)**, alle über
   `Instrument`-Felder in `instruments.py` gesteuert, nicht über
   `Optimierungen` (das sind Modellfehler-Korrekturen, keine ein-/
@@ -489,7 +490,7 @@ inkrementell fortgeschrieben).
   Tabelle): je Teilregel die Leave-one-out-Differenz in Prozentpunkten.
   Jede Detailseite bekommt außerdem unbedingt den Abschnitt "Effekt der
   Optimierungs-Schalter" (`dashboard._optimierungs_effekte()`): je einer der
-  vier `Optimierungen`-Mechanismen (#17) als Leave-one-out-Differenz zur
+  fünf `Optimierungen`-Mechanismen (#17) als Leave-one-out-Differenz zur
   Rendite mit genau diesem Mechanismus aus. Für beide Abschnitte simuliert
   die Darstellungsschicht die Vergleichsvarianten zusätzlich — auch das
   bleibt reine Anwendung von `engine.simulate()`, keine eigene
@@ -514,9 +515,9 @@ inkrementell fortgeschrieben).
   Überrendite ÷ annualisierte Volatilität bzw. ÷ Downside-Deviation nur der
   Verlustwochen, `_downside_deviation()`) — eine hohe Rendite bei ebenso
   hoher Streuung ist kein besseres Ergebnis als eine niedrigere Rendite bei
-  wenig Risiko. `_RISIKOFREIER_ZINS_PLATZHALTER = 0.0` ist ein bewusster
-  Platzhalter nach demselben Muster wie
-  `VORABPAUSCHALE_BASISZINS_PLATZHALTER`, kein echter Referenzzins. Jede
+  wenig Risiko. Der risikofreie Zins dafür kommt seit #75 aus dem
+  Geldmarkt-ETF statt aus einer Konstante (siehe „Risikofreier Zins" weiter
+  unten); `_RISIKOFREIER_ZINS_PLATZHALTER` ist nur noch Rückfallwert. Jede
   Detailseite bekommt zusätzlich (sofern genug Kurshistorie vorliegt) den
   Abschnitt "Robustheit über Teilperioden (Walk-Forward)"
   (`_walk_forward_segmente()`): die Kurshistorie wird in bis zu drei
@@ -562,10 +563,13 @@ inkrementell fortgeschrieben).
   denen alle Zahlen beruhen — Datenbasis und Zeitraum, Instrumententabelle
   mit **erstem Kurstag je Ticker** (⚠ bei später verfügbaren), Handels- und
   Steuerregeln, die Kennzahl-Definitionen sowie eine explizite Liste des
-  nicht Modellierten (unternehmensspezifische Dividendenhöhen — Einzelaktien
-  nutzen seit #57 einheitlich eine pauschale Platzhalter-Dividendenrendite,
-  siehe `strategies.DIVIDENDENRENDITE_PLATZHALTER` —, Inflation,
-  Spread/Slippage, TER, Zinsen auf Cash). Ein eigener Abschnitt "Cash und
+  nicht Modellierten (jahresgenaue Dividendenhistorien — je Instrument gilt
+  ein konstanter Satz aus `Instrument.dividendenrendite`, #74 —, Inflation,
+  Spread/Slippage, Depotgebühren/Ausgabeaufschläge, Zinsen auf Cash). Die
+  TER steht seit #76 NICHT mehr auf dieser Liste, sie wird modelliert; die
+  Seite weist sie je Instrument in der Instrumententabelle aus, ebenso die
+  Ausschüttungsrendite (#74) und den je Strategie abgeleiteten risikofreien
+  Zins (#75). Ein eigener Abschnitt "Cash und
   ungenutztes Kapital"
   begründet, warum Strategien keine eigene Cash-Zielallokation kennen (Topf
   A übernimmt die Cash-Rolle, #35) und zeigt zusätzlich
@@ -717,7 +721,7 @@ ADR-Verhältniswechsel). `_split_bereinigte_close_series()` leitet aus
 Nominalkurse dadurch. Bewusst split-only statt des vollen `adjusted close`:
 der ist eine Total-Return-Reihe und enthält auch Dividenden, die die
 Simulation bereits separat als Barertrag modelliert (`ausschuettend` /
-`DIVIDENDENRENDITE_PLATZHALTER`, #57) — sonst zählten sie doppelt. Liefert
+`Instrument.dividendenrendite`, #57/#74) — sonst zählten sie doppelt. Liefert
 ein Symbol gar keinen `adjusted close`, bleibt es beim Nominalkurs.
 
 **Handgepflegte Ergänzungen (#62):** Der Backfill setzt
@@ -932,6 +936,30 @@ eingetragenen „17" zeigt; dass die Prämissen-Seite allokierte und nicht
 allokierte Instrumente in getrennte Tabellen/Abschnitte einsortiert; und
 dass der „Datenreihen ohne Allokation"-Abschnitt gar nicht erst gerendert
 wird, wenn eine Strategie ausnahmsweise alle Ticker hält.
+Für den gemeinsamen Vergleichszeitraum (#73): `_gemeinsamer_beginn()` gegen
+zwei Strategien mit unterschiedlichem Startdatum, `_vergleichs_cagr_pct()`
+gegen eine Reihe, die erst spät zu steigen beginnt (der Ausschnitt muss eine
+deutlich andere CAGR liefern als die volle Historie) sowie den Grenzfall unter
+`_VERGLEICH_MIN_WOCHEN` (liefert `None`), und End-to-End, dass die
+Übersichtstabelle Vergleichszeitraum plus beide eigenen Zeiträume rendert —
+und dass die Überrendite-Spalte ohne Benchmark-Strategie unter den angezeigten
+Strategien gar nicht erst erscheint. Für den risikofreien Zins (#75):
+`_risikofreier_zins_pct()` gegen eine konstruierte 4%-Geldmarktreihe, gegen
+eine Historie ganz ohne `XEON` und gegen einen zu kurzen Zeitraum (beide →
+Platzhalter), dass ein positiver Zins Sharpe *und* Sortino gegenüber 0 senkt
+(vorher gar nicht möglich) und dass ein Aufruf ohne Zinsangabe unverändert den
+Platzhalter nutzt. In `tests/test_engine.py` für #74: dass die sieben
+Nicht-Zahler `ausschuettend=False` sind und ohne Dividende auch keinen
+Cash-Zufluss bekommen, dass zwei Instrumente mit unterschiedlicher Rendite
+unterschiedlich viel ausschütten (handgerechnet), und dass ein ausschüttendes
+Instrument ohne eigenen Satz weiterhin auf den Platzhalter fällt. Für die TER
+(#76): handgerechneter Abzug gegen `(1 − TER/52)^52` über 52 Wochen,
+`fondskosten=False` reproduziert exakt den Wert ohne Kosten, Instrumente ohne
+TER (Einzelaktien, 4GLD, BTC) bleiben unberührt, und ein teurer Fonds wird
+stärker belastet als ein günstiger. Die TER-Tests nutzen bewusst
+**thesaurierende** ETFs (EXXY/IBCI), damit die Jahresausschüttung den Endwert
+nicht überlagert; bestehende handgerechnete Tests mit ETFs setzen
+`fondskosten=False`.
 `tests/test_learnings.py` fährt jede Learning-Regel gegen
 konstruierte Views mit bekannten Zahlen und prüft, dass die Aussagen den
 Daten folgen statt fest zu sein (inkl. Gegenprobe mit umgedrehter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,22 @@ inkrementell fortgeschrieben).
     Maßnahmen ausschließlich den Abgeltungsteuer-Topf optimieren.
     Vereinfachung: Besteuerung mit dem pauschalen `STEUERSATZ` statt dem
     tatsächlich anzuwendenden persönlichen Einkommensteuersatz.
+  **Ausschüttungsrendite je Instrument (#74):** `Instrument.dividendenrendite`
+  (optional, `None` → Rückfall auf `DIVIDENDENRENDITE_PLATZHALTER`) löst den
+  einen Pauschalsatz für alle ausschüttenden Instrumente ab. Sieben
+  Satelliten-Aktien (TSLA, RIVN, PLTR, MSTR, SEDG, LITE, S92) stehen jetzt auf
+  `ausschuettend=False`, weil sie real keine Dividende zahlen — vorher bekamen
+  sie jährlich 2,5% geschenkt; umgekehrt waren die Anleihen-/Immobilien-ETFs
+  und `IUSA` (die Benchmark-Vergleichslinie) zu niedrig angesetzt. Beim
+  Ergänzen eines ausschüttenden Instruments also einen belegten Satz setzen,
+  statt den Platzhalter greifen zu lassen.
+  **Laufende Fondskosten (#76):** `Instrument.ter` (Default `0`), in
+  `engine.simulate()` wöchentlich pro rata (`ter/52`) als Reduktion der
+  **Stückzahl** abgezogen, nicht als Barabfluss — die Kostenbasis bleibt
+  bewusst unverändert (die TER ist keine steuerlich abzugsfähige Position).
+  Steuerbar über den fünften `Optimierungen`-Schalter `fondskosten`. Bestehende
+  handgerechnete Engine-Tests, die ETFs verwenden, setzen `fondskosten=False`,
+  damit sie weiterhin genau ihren eigenen Mechanismus prüfen.
 - `dashboard.py` + `templates/` — reine Darstellungsschicht, rendert
   `engine.simulate()`-Ergebnisse für alle (oder eine ausgewählte)
   Strategie(n) aus `STRATEGIES`. Seit #31 mehrere Seitentypen statt einer
@@ -630,6 +646,31 @@ inkrementell fortgeschrieben).
   einzige Möglichkeit, überhaupt eine Netto-Größenordnung auszuweisen. Beide
   Werte stehen nebeneinander auf jeder Detailseite, mit Fußnote; die
   Übersichtstabelle bleibt bei den (klar so beschrifteten) Bruttowerten.
+  **Gemeinsamer Vergleichszeitraum (#73):** `_real_investierbarer_zeitraum()`
+  schneidet je Strategie unterschiedlich zu — der S&P-500-Benchmark läuft über
+  20 Jahre (ab 2006), jede Barbell-Strategie erst ab 2021. Eine nach CAGR
+  sortierte Übersichtstabelle stellte damit Unvergleichbares nebeneinander,
+  ausgerechnet in der Zeile, an der jede Anlageentscheidung hängt.
+  `_gemeinsamer_beginn()` liefert das späteste Startdatum aller angezeigten
+  Strategien, `_vergleichs_cagr_pct()` simuliert jede Strategie ab diesem
+  Datum frisch (analog `_walk_forward_segmente()`/`_zeitraum_presets()`);
+  `build_dashboard()` legt daraus `vergleich_cagr_*` und `alpha_pp_*` (gegen
+  die erste verfügbare Strategie aus `BENCHMARK_STRATEGIEN`) in jede View und
+  sortiert die Übersicht danach. Unter `_VERGLEICH_MIN_WOCHEN` entfällt die
+  Spalte still, statt aus wenigen Wochen zu annualisieren. **Wichtig:** Die
+  Risikospalten (Volatilität/Max-Drawdown/Sharpe/Sortino) beziehen sich
+  weiterhin auf den jeweils eigenen Zeitraum — die Tabelle weist ihn deshalb
+  je Zeile mit aus.
+  **Risikofreier Zins (#75):** `_risikofreier_zins_pct(rows)` leitet ihn aus
+  dem EUR-Geldmarkt-ETF `_GELDMARKT_TICKER` (`XEON`, durchgehende Historie
+  seit 2007) über exakt den ausgewerteten Zeitraum ab, statt ihn zu
+  hinterlegen — dasselbe Prinzip wie bei `_praemissen_kontext()`: nichts
+  hinterlegen, was gegenüber den Daten veralten kann.
+  `_RISIKOFREIER_ZINS_PLATZHALTER` ist nur noch Rückfallwert (fehlender Ticker
+  oder Zeitraum unter `_ZINS_MIN_WOCHEN`). **Einheiten-Falle:**
+  `_wochenrenditen()` liefert Brüche, `_sharpe_ratio()`/`_sortino_ratio()`
+  rechnen intern in Brüchen (trotz der `_pct`-Namen), der Zins kommt dagegen
+  in Prozentpunkten herein und wird vor dem Abzug durch 100 geteilt.
 - `learnings.py` — leitet die Sektion "Key Learnings" (ganz oben im Dashboard)
   bei jedem Build neu aus den Strategie-Views ab. **Keine hinterlegten
   Erkenntnis-Texte:** fest ist nur die Fragestellung je Regel (reine Funktion

--- a/README.md
+++ b/README.md
@@ -513,15 +513,34 @@ pytest -q
   deployed. If no target instrument is tradeable at all, everything stays
   parked — deliberately: "out of the market" with no defensive instrument
   available *is* cash.
-- **Company-specific dividend amounts are not modeled.** The 10 single-stock
-  satellite instruments (`Instrument.ausschuettend`) use a flat placeholder
-  dividend yield (`DIVIDENDENRENDITE_PLATZHALTER`, 2.5% p.a.) instead of
-  their real historical dividend history – some of the 10 don't actually pay
-  a dividend, others pay more or less than the placeholder
-  ([#57](https://github.com/S540d/Boersenspiel/issues/57)). The dividend is
-  booked as real cash once a year, reinvested via the existing cash-parking
-  mechanism, and taxed like a real capital gain. The ETFs, the bond fund,
-  physical gold, and BTC-EUR still pay no dividend at all in the simulation.
+- **Distributions are modeled per instrument, at a constant rate.** Every
+  instrument marked `ausschuettend` carries its own `Instrument.dividendenrendite`
+  (rounded from public fact sheets), applied once a year to its value at the
+  start of that year
+  ([#57](https://github.com/S540d/Boersenspiel/issues/57), per instrument
+  since [#74](https://github.com/S540d/Boersenspiel/issues/74)). The
+  distribution is booked as real cash, reinvested via the existing
+  cash-parking mechanism, and taxed like a real capital gain.
+  `DIVIDENDENRENDITE_PLATZHALTER` remains only as the fallback for an
+  instrument with no rate of its own. Until #74 that single flat rate applied
+  to *every* distributing instrument, which was a directional distortion, not
+  just an imprecision: seven satellite stocks that pay no dividend at all
+  received one anyway, while bond and property ETFs — whose running return
+  consists largely *of* the distribution — were set far too low, as was
+  `IUSA`, the benchmark line every strategy is measured against. The
+  remaining simplification is that each rate is constant across the whole
+  history rather than the dividend actually paid in a given year.
+- **Ongoing fund costs (TER) are modeled** as a weekly pro-rata reduction of
+  units (`Instrument.ter`, TER ÷ 52), switchable via the `fondskosten` flag in
+  `Optimierungen` so its isolated effect is reported per strategy like the
+  other mechanisms ([#76](https://github.com/S540d/Boersenspiel/issues/76)).
+  It reduces the holding, not cash, and leaves the cost basis untouched.
+  Single stocks, physical gold, and BTC-EUR carry none. Omitting the TER was
+  not a neutral omission: the rates span an order of magnitude (IUSA 0.07% vs.
+  IQQ6 0.59%), the benchmark is the cheapest instrument in the field, and the
+  single-stock satellite carries no fund fee at all — so the omission favoured
+  precisely the most concentrated variant. Custody fees and front-end loads
+  are still not modeled.
 - **December harvest:** On the last price row of a completed calendar year,
   exactly one of two mutually exclusive measures applies, depending on how
   the tax year has gone so far (see
@@ -589,11 +608,28 @@ pytest -q
   **Premises page** (`docs/praemissen.html`, reachable from the three-dot
   menu on every page) spells this out for readers.
 - **Placeholder constants:** `VORABPAUSCHALE_BASISZINS_PLATZHALTER` (2.0%)
-  is not a real annual BMF base rate, and `_RISIKOFREIER_ZINS_PLATZHALTER`
-  (0%) used by the Sharpe/Sortino ratios is not a real reference rate. Taxes
-  use the flat withholding rate rather than a personal income tax rate, and
-  the simulated portfolio value itself is never reduced by tax — the tax
-  figures are tracking only.
+  is not a real annual BMF base rate. Taxes use the flat withholding rate
+  rather than a personal income tax rate, and the simulated portfolio value
+  itself is never reduced by tax — the tax figures are tracking only.
+  `_RISIKOFREIER_ZINS_PLATZHALTER` is no longer the source of the risk-free
+  rate used by Sharpe/Sortino; since
+  [#75](https://github.com/S540d/Boersenspiel/issues/75) that rate is derived
+  from the EUR money-market ETF `XEON` over the exact period being evaluated
+  (0.76% p.a. over 2006–2026, 2.05% over 2021–2026), and the constant is only
+  the fallback when `XEON` has no usable history in that window. The former
+  fixed 0% made Sharpe "return ÷ risk" rather than "*excess* return ÷ risk",
+  so it could never show that a strategy failed to beat the money market —
+  and it lifted low-volatility strategies most, i.e. exactly the defensive
+  ones.
+- **Returns are only comparable within the common comparison period.** Each
+  strategy is simulated over the window in which its full instrument set was
+  actually tradeable, and those windows differ substantially (the S&P 500
+  benchmark needs only `IUSA` and runs from 2006; every barbell strategy
+  starts in 2021). The overview table's lead column therefore re-simulates
+  every strategy from the latest of those start dates and sorts by that
+  ([#73](https://github.com/S540d/Boersenspiel/issues/73)); the per-strategy
+  CAGR and the risk columns still refer to each strategy's own window, which
+  the table shows alongside them.
 - **`BTC-EUR` history is far shorter than requested:** the 20-year backfill
   yields only ~50 weeks (from 2025-09-14), so Bitcoin is first bought near
   its high rather than across the full period — see

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ All 24 tracked instruments, and which strategy actually holds each one:
 
 `engine.simulate()` only ever reads `strategy.alle_ticker_gewichte()` — an
 instrument only moves the numbers of the strategies that actually list it.
+`XEON` carries a second, allocation-independent role: as the EUR
+money-market series it supplies the risk-free rate for the Sharpe and Sortino
+ratios of *every* strategy, derived over each one's own evaluation window
+([#75](https://github.com/S540d/Boersenspiel/issues/75)).
 All Xetra-listed instruments above are quoted in EUR directly, so they need
 no FX conversion and sidestep the currency problem described further below;
 only the 10 single-stock satellite tickers (all but `S92`) trade in USD and
@@ -194,18 +198,24 @@ Three properties that are easy to miss:
 **Cutting across all strategies and scenarios** are mechanisms that the
 engine always applies identically to every run:
 
-| Mechanism | Effect |
-|---|---|
-| Rebalancing | Restores target weights once the threshold is exceeded |
-| Year-end tax optimization | Realizes losses or gains at the year boundary |
-| Order fees | €1 per buy and sell |
-| Taxation | Loss carryforward → tax-free allowance → 26.375% |
+| Mechanism | `Optimierungen` flag | Effect |
+|---|---|---|
+| Rebalancing | `rebalancing` | Restores target weights once the threshold is exceeded |
+| Year-end tax optimization | `steueroptimierung` | Realizes losses or gains at the year boundary |
+| Order fees | `ordergebuehren` | €1 per buy and sell |
+| Taxation | `besteuerung` | Loss carryforward → tax-free allowance → 26.375% |
+| Ongoing fund costs (TER) | `fondskosten` | `Instrument.ter` ÷ 52 deducted from the holding each week |
 
-These mechanisms are currently **not toggleable**. The dashboard comparison
-therefore only answers "which weighting rule performed better?", not "how
-much did the tax optimization actually contribute?". A proposal to make them
-individually toggleable, and thus measure their contribution as a difference,
-is tracked as [#17](https://github.com/S540d/Boersenspiel/issues/17).
+Each mechanism is **individually toggleable** via the `Optimierungen` flags
+([#17](https://github.com/S540d/Boersenspiel/issues/17); `fondskosten` added
+in [#76](https://github.com/S540d/Boersenspiel/issues/76)), and every detail
+page reports each one's isolated contribution as a leave-one-out difference
+in CAGR percentage points ("Effekt der Optimierungs-Schalter"). The dashboard
+comparison therefore answers not only "which weighting rule performed
+better?" but also "how much did the tax optimization actually contribute?".
+A strategy may set its own defaults — `BUY_AND_HOLD` uses
+`Optimierungen(rebalancing=False)` rather than an artificially unreachable
+rebalancing threshold.
 
 **Guiding principle:** Only raw data (prices) is persisted long-term. Everything derived (position values,
 rebalancing, tax, tax-free allowance, loss carryforward) is recomputed
@@ -223,7 +233,7 @@ strategy always yields the identical result.
 | `src/boersenspiel/history_store.py` | Only write path to `data/price_history.csv` / `data/fetch_log.csv` |
 | `src/boersenspiel/sources/` | Interchangeable price sources (default: `alphavantage.py`) |
 | `src/boersenspiel/engine.py` | Pure simulation function: (price history, strategy) → portfolio/tax state |
-| `src/boersenspiel/dashboard.py` | Renders simulation results as `docs/index.html`, one `docs/<slug>.html` detail page per strategy, and `docs/praemissen.html` (premises and assumptions). Every value-history chart on the start and detail pages also gets a client-side observation-period switcher (1/3/5 years back or full history), backed by four fully re-simulated presets per strategy computed at build time ([#54](https://github.com/S540d/Boersenspiel/issues/54)) |
+| `src/boersenspiel/dashboard.py` | Renders simulation results as `docs/index.html`, one `docs/<slug>.html` detail page per strategy, and `docs/praemissen.html` (premises and assumptions). Every value-history chart on the start and detail pages also gets a client-side observation-period switcher (1/3/5 years back or full history), backed by four fully re-simulated presets per strategy computed at build time ([#54](https://github.com/S540d/Boersenspiel/issues/54)). The overview table's lead column re-simulates every strategy over a **common comparison period** and reports each one's excess return over the benchmark ([#73](https://github.com/S540d/Boersenspiel/issues/73)) |
 | `src/boersenspiel/templates/` | Jinja templates: `base.html.j2` (shared shell incl. the three-dot menu), `dashboard.html.j2`, `strategy_detail.html.j2`, `praemissen.html.j2` |
 | `src/boersenspiel/learnings.py` | Re-derives the key-learnings text on every build from the simulation results (no stored insights) |
 | `scripts/run_fetch.py` | Automated weekly price fetch (GitHub Actions) |

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -455,6 +455,53 @@ def _cagr_pct(rendite_pct: float, tage: int) -> float:
     return (faktor ** (1 / jahre) - 1) * 100
 
 
+# --- Gemeinsamer Vergleichszeitraum (#73) -----------------------------------------
+#
+# _real_investierbarer_zeitraum() (F4, #63) schneidet die Historie JE STRATEGIE auf
+# den Zeitraum zu, ab dem deren komplettes Instrumentenset handelbar war. Das ist fuer
+# sich genommen richtig - es nimmt den Look-ahead-Bias heraus -, erzeugt aber ein
+# zweites, ebenso entscheidungsrelevantes Problem: die Zeitraeume unterscheiden sich
+# dann zwischen den Strategien erheblich. Der S&P-500-Benchmark braucht nur IUSA und
+# laeuft deshalb ueber die vollen 20 Jahre (ab 2006), waehrend jede Barbell-Strategie
+# erst 2021 beginnt, weil ein einziges ihrer Instrumente nicht frueher existiert.
+#
+# Eine nach CAGR sortierte Uebersichtstabelle stellte damit eine 20-Jahres-Rendite
+# (inkl. Finanzkrise und anschliessender Erholung) neben 5-Jahres-Renditen (inkl.
+# Baerenmarkt 2022) - und ausgerechnet die eine Zeile, an der jede Anlageentscheidung
+# haengt ("schlaegt die Strategie einfach den Index?"), war die nicht vergleichbare.
+# Gemessen an der realen Historie drehte das die Aussage fuer sechs von 15
+# Strategien/Szenarien.
+#
+# Diese Funktionen simulieren deshalb JEDE Strategie zusaetzlich auf dem spaetesten
+# gemeinsamen Startdatum aller angezeigten Strategien - frisch, mit eigenem
+# Startkapital, exakt nach demselben Muster wie _walk_forward_segmente() und
+# _zeitraum_presets(). Die Uebersichtstabelle sortiert danach.
+
+# Unter dieser Laenge ist ein gemeinsamer Zeitraum keine belastbare Aussage mehr -
+# dann entfaellt die Spalte, statt eine aus wenigen Wochen annualisierte Zahl zu
+# zeigen (dieselbe Zurueckhaltung wie bei _walk_forward_segmente()).
+_VERGLEICH_MIN_WOCHEN = 26
+
+
+def _gemeinsamer_beginn(strategie_rows: dict[str, list[PriceRow]]) -> date | None:
+    """Spaetestes Simulations-Startdatum ueber alle angezeigten Strategien - ab
+    diesem Datum hat JEDE von ihnen Kurse und ist damit vergleichbar."""
+    beginne = [rows[0].date for rows in strategie_rows.values() if rows]
+    return max(beginne) if beginne else None
+
+
+def _vergleichs_cagr_pct(
+    strategy: Strategy, rows: list[PriceRow], beginn: date
+) -> float | None:
+    """CAGR dieser Strategie, frisch simuliert ab ``beginn``. ``None``, wenn der
+    verbleibende Zeitraum zu kurz fuer eine belastbare Annualisierung ist."""
+    ausschnitt = [r for r in rows if r.date >= beginn]
+    if len(ausschnitt) < _VERGLEICH_MIN_WOCHEN:
+        return None
+    result = simulate(ausschnitt, strategy)
+    return _cagr_pct(_f(_rendite_pct(result, strategy)), _tage_zwischen(result))
+
+
 def _optimierungs_effekte(
     strategy: Strategy, rows: list[PriceRow], basis_cagr_pct: float, tage: int
 ) -> list[dict]:
@@ -609,6 +656,11 @@ def _build_strategy_view(
         "cash_max_label": f"{cash_max_pct:.1f}",
         "cash_max_datum": cash_max_datum or "–",
         "sim_beginn": points[0].date.isoformat(),
+        # #73: der tatsaechliche Zeitraum gehoert neben jede Renditezahl - ohne ihn
+        # ist nicht erkennbar, dass zwei Zeilen derselben Tabelle unterschiedlich
+        # lange und unterschiedliche Marktphasen abdecken koennen.
+        "sim_ende": points[-1].date.isoformat(),
+        "sim_jahre_label": f"{tage / 365.25:.1f}".replace(".", ","),
         "sim_ende": points[-1].date.isoformat(),
         "teil_von": strategy.teil_von,
         "labels_json": json.dumps(labels),
@@ -838,9 +890,59 @@ def build_dashboard(
         _build_strategy_view(s, simulate(strategie_rows[s.name], s), strategie_rows[s.name], carry_forward)
         for s in strategies
     ]
-    # Sortierung nach CAGR statt Gesamtrendite (F6b, #63): CAGR ist die Leitkennzahl
-    # der Uebersichtstabelle, die Reihenfolge soll dazu konsistent sein.
-    summary = sorted(views, key=lambda v: v["cagr_pct"], reverse=True)
+    # Gemeinsamer Vergleichszeitraum (#73): jede Strategie zusaetzlich ab dem
+    # spaetesten Startdatum aller angezeigten Strategien simulieren, damit die
+    # Uebersichtstabelle Gleiches mit Gleichem vergleicht. Siehe _gemeinsamer_beginn().
+    beginn = _gemeinsamer_beginn(strategie_rows)
+    benchmark_namen = {b.name for b in BENCHMARK_STRATEGIEN}
+    vergleich_cagr: dict[str, float | None] = {}
+    if beginn is not None:
+        for s in strategies:
+            vergleich_cagr[s.name] = _vergleichs_cagr_pct(s, strategie_rows[s.name], beginn)
+    # Referenzlinie fuer die Ueberrendite: die erste Benchmark-Strategie, die im
+    # gemeinsamen Zeitraum ueberhaupt eine Zahl liefert. Steht keine zur Verfuegung
+    # (kein Benchmark unter den angezeigten Strategien), entfaellt die Spalte still,
+    # statt gegen eine willkuerliche andere Strategie zu vergleichen.
+    benchmark_cagr: float | None = None
+    benchmark_label: str | None = None
+    for s in strategies:
+        if s.name in benchmark_namen and vergleich_cagr.get(s.name) is not None:
+            benchmark_cagr = vergleich_cagr[s.name]
+            benchmark_label = s.name
+            break
+
+    for view in views:
+        wert = vergleich_cagr.get(view["name"])
+        view["vergleich_cagr_pct"] = wert
+        view["vergleich_cagr_label"] = f"{wert:+.2f}" if wert is not None else "–"
+        if wert is None or benchmark_cagr is None or view["name"] in benchmark_namen:
+            view["alpha_pp"] = None
+            view["alpha_pp_label"] = "–"
+        else:
+            view["alpha_pp"] = wert - benchmark_cagr
+            view["alpha_pp_label"] = f"{wert - benchmark_cagr:+.2f}"
+
+    vergleich_kontext = {
+        "vergleich_beginn": beginn.isoformat() if beginn is not None else None,
+        "vergleich_ende": rows[-1].date.isoformat(),
+        "vergleich_benchmark": benchmark_label,
+        "vergleich_benchmark_label": (
+            f"{benchmark_cagr:+.2f}" if benchmark_cagr is not None else None
+        ),
+        "vergleich_verfuegbar": any(v["vergleich_cagr_pct"] is not None for v in views),
+    }
+
+    # Sortierung nach der Rendite im GEMEINSAMEN Zeitraum (#73), sonst - solange
+    # keiner ermittelbar ist - weiterhin nach CAGR ueber den jeweils eigenen
+    # Zeitraum (F6b, #63).
+    if vergleich_kontext["vergleich_verfuegbar"]:
+        summary = sorted(
+            views,
+            key=lambda v: (v["vergleich_cagr_pct"] is not None, v["vergleich_cagr_pct"] or 0.0),
+            reverse=True,
+        )
+    else:
+        summary = sorted(views, key=lambda v: v["cagr_pct"], reverse=True)
     learnings = derive_learnings(views)
     teilszenario_gruppen = _teilszenario_gruppen(views, strategies)
 
@@ -877,6 +979,7 @@ def build_dashboard(
         # künftigen Instrumente-/Strategiewechsel mitzieht.
         instrumente_anzahl=len(_allokierte_ticker(strategies)),
         benchmark_optionen=[{"id": k, "label": v} for k, v in benchmark_optionen.items()],
+        **vergleich_kontext,
     )
 
     env = Environment(

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -42,12 +42,13 @@ _STALE_STATUS = {"carried_forward", "missing"}
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 DEFAULT_OUTPUT = Path(__file__).resolve().parents[2] / "docs" / "index.html"
 
-# Anzeigenamen der vier Optimierungs-Schalter (siehe strategies.Optimierungen / #17).
+# Anzeigenamen der fuenf Optimierungs-Schalter (siehe strategies.Optimierungen / #17).
 _OPTIMIERUNGS_LABELS: dict[str, str] = {
     "steueroptimierung": "Steueroptimierung (Dezember-Harvest)",
     "rebalancing": "Rebalancing",
     "ordergebuehren": "Ordergebühren",
     "besteuerung": "Besteuerung",
+    "fondskosten": "Laufende Fondskosten (TER)",
 }
 
 
@@ -554,7 +555,7 @@ def _vergleichs_cagr_pct(
 def _optimierungs_effekte(
     strategy: Strategy, rows: list[PriceRow], basis_cagr_pct: float, tage: int
 ) -> list[dict]:
-    """Effekt jedes der vier Optimierungs-Schalter (#17) als Leave-one-out-Differenz
+    """Effekt jedes der fuenf Optimierungs-Schalter (#17) als Leave-one-out-Differenz
     auf CAGR-Basis (F6c, #63): CAGR mit allen Schaltern wie konfiguriert minus CAGR
     mit genau diesem einen Schalter aus. Eine Differenz zweier Gesamtrenditen ist
     hier keine sinnvolle Prozentpunkt-Angabe, sobald sich Basis- und Vergleichslauf
@@ -852,6 +853,9 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
                 else "–"
             ),
             "dividendenrendite_platzhalter": inst.ausschuettend and inst.dividendenrendite is None,
+            # #76: laufende Fondskosten. "-" fuer Instrumente ohne Fondsmantel
+            # (Einzelaktien, physisches Gold, BTC).
+            "ter": f"{float(inst.ter) * 100:.2f}".replace(".", ",") if inst.ter else "–",
             "spekulationsfrist": (
                 f"{inst.spekulationsfrist_tage} Tage" if inst.spekulationsfrist_tage else "–"
             ),

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -173,14 +173,51 @@ def _max_drawdown_pct(total_values: list[float]) -> float:
 # schweren Verlustwochen) ist kein besseres Ergebnis als eine niedrigere Rendite bei
 # geringem Risiko - genau das zeigt die nominale Rendite allein nicht.
 #
-# Bewusster Platzhalter (analog VORABPAUSCHALE_BASISZINS_PLATZHALTER in
-# strategies.py): ein echter risikofreier Zins (z. B. laufzeitnahe
-# Bundesanleihen-Rendite) ist hier noch nicht hinterlegt, 0% ist eine
-# vereinfachende Annahme.
+# Rueckfallwert, wenn sich aus der Kurshistorie kein Zins ableiten laesst (siehe
+# _risikofreier_zins_pct()). Bis #75 war dieser Wert die einzige Quelle - und mit
+# 0,0 keine harmlose Vereinfachung: Sharpe/Sortino waren damit faktisch
+# "Rendite ÷ Risiko" statt "UEBERrendite ÷ Risiko", und die Frage, die eine
+# Sharpe-Ratio ueberhaupt beantwortet - werde ich fuer das eingegangene Risiko
+# besser bezahlt als fuers risikolose Parken? - konnte per Konstruktion nie mit
+# "nein" beantwortet werden. Der Fehler wirkte zudem ungleich: er hob Strategien
+# mit geringer Volatilitaet (kleiner Nenner) staerker an, also gerade die
+# defensiven, deren Rendite dem Geldmarkt am naechsten liegt.
+# Einheit: Prozentpunkte p.a. (wie der Rueckgabewert von _risikofreier_zins_pct()).
 _RISIKOFREIER_ZINS_PLATZHALTER = 0.0
 
+# EUR-Geldmarkt-ETF (Xtrackers II EUR Overnight Rate, thesaurierend). Bildet per
+# Definition den EUR-Tagesgeldsatz ab und liegt mit durchgehender Historie seit
+# 2007 ohnehin in price_history.csv - seine eigene CAGR ueber exakt den
+# ausgewerteten Zeitraum IST der passende risikofreie Zins. Das haelt die Kennzahl
+# automatisch am jeweiligen Zinsumfeld (2006-2008 3-4%, 2012-2022 nahe 0%, ab 2023
+# wieder 3-4%), statt einen festen Wert zu hinterlegen, der dagegen veraltet -
+# dasselbe Prinzip wie auf der Praemissen-Seite (_praemissen_kontext()).
+_GELDMARKT_TICKER = "XEON"
 
-def _sharpe_ratio(total_values: list[float]) -> float:
+# Unter dieser Laenge ist eine annualisierte Geldmarktrendite aus so wenigen
+# Wochen kein belastbarer Zins mehr - dann gilt der Rueckfallwert.
+_ZINS_MIN_WOCHEN = 26
+
+
+def _risikofreier_zins_pct(rows: list[PriceRow]) -> float:
+    """Risikofreier Zins in % p.a., abgeleitet aus dem Geldmarkt-ETF ueber
+    denselben Zeitraum, ueber den auch die Strategie ausgewertet wird (#75).
+
+    Faellt auf ``_RISIKOFREIER_ZINS_PLATZHALTER`` zurueck, wenn der Ticker im
+    Zeitraum fehlt oder der Zeitraum zu kurz ist - der Platzhalter bleibt also
+    Rueckfallwert, ist aber nicht mehr die einzige Quelle.
+    """
+    kurse = [(r.date, r.prices[_GELDMARKT_TICKER]) for r in rows if _GELDMARKT_TICKER in r.prices]
+    if len(kurse) < _ZINS_MIN_WOCHEN:
+        return _RISIKOFREIER_ZINS_PLATZHALTER
+    (erstes_datum, erster_kurs), (letztes_datum, letzter_kurs) = kurse[0], kurse[-1]
+    if erster_kurs <= 0:
+        return _RISIKOFREIER_ZINS_PLATZHALTER
+    gesamt_pct = _f((letzter_kurs - erster_kurs) / erster_kurs) * 100
+    return _cagr_pct(gesamt_pct, (letztes_datum - erstes_datum).days)
+
+
+def _sharpe_ratio(total_values: list[float], risikofreier_zins_pct: float | None = None) -> float:
     """Annualisierte Ueberrendite je Einheit annualisierter Volatilitaet
     (Standardabweichung aller Wochenrenditen, positive wie negative)."""
     renditen = _wochenrenditen(total_values)
@@ -189,8 +226,13 @@ def _sharpe_ratio(total_values: list[float]) -> float:
     std_pct = statistics.pstdev(renditen) * (52**0.5)
     if std_pct == 0:
         return 0.0
+    # ACHTUNG Einheiten: _wochenrenditen() liefert BRUECHE (0,01 = 1%), std_pct und
+    # ann_mean_pct sind trotz ihrer Namen ebenfalls Brueche. Der uebergebene Zins
+    # kommt dagegen in Prozentpunkten p.a. herein (wie ueberall sonst in dieser
+    # Datei) und muss deshalb vor dem Abzug umgerechnet werden.
+    zins = _RISIKOFREIER_ZINS_PLATZHALTER if risikofreier_zins_pct is None else risikofreier_zins_pct
     ann_mean_pct = statistics.fmean(renditen) * 52
-    return (ann_mean_pct - _RISIKOFREIER_ZINS_PLATZHALTER) / std_pct
+    return (ann_mean_pct - zins / 100) / std_pct
 
 
 def _downside_deviation(renditen: list[float], ziel: float = 0.0) -> float:
@@ -202,7 +244,7 @@ def _downside_deviation(renditen: list[float], ziel: float = 0.0) -> float:
     return (sum(quadrate) / len(quadrate)) ** 0.5
 
 
-def _sortino_ratio(total_values: list[float]) -> float:
+def _sortino_ratio(total_values: list[float], risikofreier_zins_pct: float | None = None) -> float:
     """Wie ``_sharpe_ratio``, aber nur Verlustwochen fliessen ins Risikomass ein -
     Streuung nach oben (Gewinnwochen) wird nicht als Risiko gewertet."""
     renditen = _wochenrenditen(total_values)
@@ -211,8 +253,10 @@ def _sortino_ratio(total_values: list[float]) -> float:
     downside_pct = _downside_deviation(renditen) * (52**0.5)
     if downside_pct == 0:
         return 0.0
+    # Einheiten wie bei _sharpe_ratio(): Brueche gegen Prozentpunkte, siehe dort.
+    zins = _RISIKOFREIER_ZINS_PLATZHALTER if risikofreier_zins_pct is None else risikofreier_zins_pct
     ann_mean_pct = statistics.fmean(renditen) * 52
-    return (ann_mean_pct - _RISIKOFREIER_ZINS_PLATZHALTER) / downside_pct
+    return (ann_mean_pct - zins / 100) / downside_pct
 
 
 # --- Walk-Forward-Robustheit ueber Teilperioden -----------------------------------
@@ -339,6 +383,10 @@ def _zeitraum_presets(rows: list[PriceRow], strategy: Strategy) -> list[dict]:
         if len(preset_rows) < 1:
             continue
         result = simulate(preset_rows, strategy)
+        # Risikofreier Zins aus dem Geldmarkt-ETF ueber genau DIESEN Preset-Zeitraum
+        # (#75) - ein 1-Jahres-Preset im Hochzinsumfeld hat einen anderen Referenzzins
+        # als die volle Historie.
+        zins_pct = _risikofreier_zins_pct(preset_rows)
         total_values = [_f(vp.total_value) for vp in result.value_history]
         labels = [vp.date.isoformat() for vp in result.value_history]
         rendite_pct = _rendite_pct(result, strategy)
@@ -350,8 +398,9 @@ def _zeitraum_presets(rows: list[PriceRow], strategy: Strategy) -> list[dict]:
                 "rendite_label": f"{rendite_pct:+.2f}",
                 "volatilitaet_label": f"{_volatilitaet_pct(total_values):.2f}",
                 "max_drawdown_label": f"{-_max_drawdown_pct(total_values):.2f}",
-                "sharpe_label": f"{_sharpe_ratio(total_values):.2f}",
-                "sortino_label": f"{_sortino_ratio(total_values):.2f}",
+                "sharpe_label": f"{_sharpe_ratio(total_values, zins_pct):.2f}",
+                "sortino_label": f"{_sortino_ratio(total_values, zins_pct):.2f}",
+                "risikofreier_zins_label": f"{zins_pct:.2f}".replace(".", ","),
                 "labels": labels,
                 "total_values": total_values,
                 "chart_max": max(total_values) if total_values else 0.0,
@@ -602,8 +651,9 @@ def _build_strategy_view(
     netto_cagr_pct = _cagr_pct(_f(netto_rendite_pct), tage)
     volatilitaet_pct = _volatilitaet_pct(total_values)
     max_drawdown_pct = _max_drawdown_pct(total_values)
-    sharpe_ratio = _sharpe_ratio(total_values)
-    sortino_ratio = _sortino_ratio(total_values)
+    risikofreier_zins_pct = _risikofreier_zins_pct(rows)
+    sharpe_ratio = _sharpe_ratio(total_values, risikofreier_zins_pct)
+    sortino_ratio = _sortino_ratio(total_values, risikofreier_zins_pct)
     cash_max_pct, cash_max_datum = _cash_anteil_max(points)
     walk_forward_segmente = _walk_forward_segmente(rows, strategy)
     walk_forward_spread_pp = (
@@ -652,6 +702,9 @@ def _build_strategy_view(
         "sharpe_label": f"{sharpe_ratio:.2f}",
         "sortino_ratio": sortino_ratio,
         "sortino_label": f"{sortino_ratio:.2f}",
+        # #75: je Strategie ausgewiesen, weil er aus deren eigenem
+        # Simulationszeitraum abgeleitet wird und deshalb nicht fuer alle gleich ist.
+        "risikofreier_zins_label": f"{risikofreier_zins_pct:.2f}".replace(".", ","),
         "cash_max_pct": cash_max_pct,
         "cash_max_label": f"{cash_max_pct:.1f}",
         "cash_max_datum": cash_max_datum or "–",
@@ -830,6 +883,7 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
                 "cash_max_label": view.get("cash_max_label", "0.0"),
                 "cash_max_datum": view.get("cash_max_datum", "–"),
                 "sim_beginn": view.get("sim_beginn", "–"),
+                "risikofreier_zins_label": view.get("risikofreier_zins_label", "–"),
             }
         )
     cash_werte = [s["cash_max_label"] for s in strategie_liste]
@@ -849,7 +903,10 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
         "vorabpauschale_basiszins": f"{VORABPAUSCHALE_BASISZINS_PLATZHALTER * 100:.1f}".replace(".", ","),
         "vorabpauschale_faktor": f"{VORABPAUSCHALE_FAKTOR * 100:.0f}",
         "dividendenrendite": f"{DIVIDENDENRENDITE_PLATZHALTER * 100:.1f}".replace(".", ","),
-        "risikofreier_zins": f"{_RISIKOFREIER_ZINS_PLATZHALTER * 100:.0f}",
+        # Nur noch der Rueckfallwert (#75) - der tatsaechlich verwendete Zins steht
+        # je Strategie in der Tabelle oben.
+        "risikofreier_zins": f"{_RISIKOFREIER_ZINS_PLATZHALTER:.0f}",
+        "geldmarkt_ticker": _GELDMARKT_TICKER,
         "sma_kurz": _SMA_KURZ_WOCHEN,
         "sma_lang": _SMA_LANG_WOCHEN,
         "walk_forward_segmente": _WALK_FORWARD_SEGMENTE,

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -20,7 +20,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from .engine import SimulationResult, simulate
 from .history_store import FetchLogEntry, PriceRow
-from .instruments import INSTRUMENTS, TICKERS
+from .instruments import INSTRUMENTS, TICKERS, Instrument
 from .learnings import derive_learnings
 from .strategies import (
     BENCHMARK_STRATEGIEN,
@@ -702,6 +702,13 @@ def _allokierte_ticker(strategies: list[Strategy]) -> set[str]:
     return {t for s in strategies for t in s.alle_ticker_gewichte()}
 
 
+def _dividendenrendite_pct(inst: Instrument) -> float:
+    """Ausschuettungsrendite eines Instruments in Prozent (#74) - der
+    instrumenteneigene Wert, sonst der Pauschal-Platzhalter."""
+    rendite = inst.dividendenrendite if inst.dividendenrendite is not None else DIVIDENDENRENDITE_PLATZHALTER
+    return float(rendite) * 100
+
+
 def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views: list[dict]) -> dict:
     """Baut die Daten für die Prämissen-Seite.
 
@@ -731,6 +738,15 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
             "teilfreistellung": f"{inst.teilfreistellung * 100:.0f}",
             "thesaurierend": "ja" if inst.thesaurierend else "nein",
             "ausschuettend": "ja" if inst.ausschuettend else "nein",
+            # #74: je Instrument statt eines Pauschalwerts fuer alle. "-" fuer
+            # Instrumente, die nicht ausschuetten; der Platzhalter erscheint nur
+            # dort, wo tatsaechlich kein instrumenteneigener Wert hinterlegt ist.
+            "dividendenrendite": (
+                f"{_dividendenrendite_pct(inst):.1f}".replace(".", ",")
+                if inst.ausschuettend
+                else "–"
+            ),
+            "dividendenrendite_platzhalter": inst.ausschuettend and inst.dividendenrendite is None,
             "spekulationsfrist": (
                 f"{inst.spekulationsfrist_tage} Tage" if inst.spekulationsfrist_tage else "–"
             ),

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -82,6 +82,11 @@ def _spekulationsfrist_tage(ticker: str) -> int | None:
     return instrument.spekulationsfrist_tage if instrument is not None else None
 
 
+def _ter(ticker: str) -> Decimal:
+    instrument = INSTRUMENTS.get(ticker)
+    return instrument.ter if instrument is not None else Decimal(0)
+
+
 def _ausschuettend(ticker: str) -> bool:
     instrument = INSTRUMENTS.get(ticker)
     return instrument.ausschuettend if instrument is not None else False
@@ -390,6 +395,33 @@ def simulate(
                 continue
             process_realized_gain(dividende, t)
             pending_cash[t] += dividende
+
+    def apply_fondskosten(prices: dict[str, Decimal]) -> None:
+        """Laufende Fondskosten (TER) woechentlich pro rata (#76).
+
+        Real werden die Kosten dem Fondsvermoegen taeglich entnommen und
+        stecken damit bereits im Kurs. Die hier verwendete Kurshistorie ist
+        aber bewusst nur split-, nicht kostenbereinigt aufgebaut (#62), und
+        die Simulation modelliert die Ertragsseite (Ausschuettung,
+        Vorabpauschale) ohnehin separat - die Kostenseite gehoert
+        entsprechend daneben.
+
+        Umsetzung als Reduktion der Stueckzahl statt eines Cash-Abflusses: der
+        Anleger zahlt die TER nicht aus der Tasche, sein Anteil am
+        Fondsvermoegen wird kleiner. Die Kostenbasis bleibt deshalb bewusst
+        unveraendert - die TER ist keine steuerlich abzugsfaehige
+        Werbungskostenposition, sie mindert schlicht den Wert. Der Abzug
+        erfolgt nur, wo in dieser Zeile ein Kurs vorliegt, damit er nicht auf
+        eine Position wirkt, die es noch gar nicht gibt.
+        """
+        for t in tickers:
+            ter = _ter(t)
+            if ter <= 0 or t not in prices:
+                continue
+            pos = positions[t]
+            if pos.units <= 0:
+                continue
+            pos.units -= pos.units * ter / Decimal(52)
 
     def rebalance_to_targets(
         prices: dict[str, Decimal], trade_date: date, reason: str, weights: dict[str, Decimal]
@@ -743,6 +775,13 @@ def simulate(
                             if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
                                 last_rebalance_date = row.date
                             break
+
+        # Laufende Fondskosten fuer diese Woche (#76) - vor Dividende/Vorabpauschale/
+        # Harvest, damit alle nachfolgenden Schritte auf dem bereits um die Kosten
+        # gekuerzten Bestand rechnen. In der ersten Zeile (Initialkauf am
+        # Zeilendatum) faellt noch keine Haltedauer an.
+        if opt.fondskosten and i > 0:
+            apply_fondskosten(prices)
 
         if row.date in harvest_dates:
             apply_dividende()

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -87,6 +87,15 @@ def _ausschuettend(ticker: str) -> bool:
     return instrument.ausschuettend if instrument is not None else False
 
 
+def _dividendenrendite(ticker: str) -> Decimal:
+    """Ausschuettungsrendite dieses Instruments (#74). Ohne hinterlegten
+    instrumenteneigenen Wert gilt weiterhin der Pauschal-Platzhalter."""
+    instrument = INSTRUMENTS.get(ticker)
+    if instrument is None or instrument.dividendenrendite is None:
+        return DIVIDENDENRENDITE_PLATZHALTER
+    return instrument.dividendenrendite
+
+
 @dataclass
 class Trade:
     date: date
@@ -357,10 +366,11 @@ def simulate(
             pos.cost_total += vorabpauschale
 
     def apply_dividende() -> None:
-        """Vereinfachte jährliche Dividendenausschüttung für die
-        Einzelaktien-Satelliten (#57, Platzhalter-Dividendenrendite auf Basis
-        des Portfoliowerts zu Jahresbeginn - dieselbe Näherung wie bei
-        ``apply_vorabpauschale``). Anders als die Vorabpauschale ist das ein
+        """Vereinfachte jährliche Dividendenausschüttung für ausschüttende
+        Instrumente (#57), auf Basis des Portfoliowerts zu Jahresbeginn -
+        dieselbe Näherung wie bei ``apply_vorabpauschale``. Der Satz kommt seit
+        #74 je Instrument aus ``Instrument.dividendenrendite`` statt pauschal
+        für alle aus ``DIVIDENDENRENDITE_PLATZHALTER``. Anders als die Vorabpauschale ist das ein
         REALER Kapitalertrag (kein reiner Steuerkonstrukt): er wird als
         echtes zusätzliches Cash gutgeschrieben, das über den bestehenden
         Cash-Parken-Mechanismus in der nächsten Kurszeile automatisch
@@ -375,7 +385,7 @@ def simulate(
             pos = positions[t]
             if not start_wert or pos.units <= 0:
                 continue
-            dividende = start_wert * DIVIDENDENRENDITE_PLATZHALTER
+            dividende = start_wert * _dividendenrendite(t)
             if dividende <= 0:
                 continue
             process_realized_gain(dividende, t)

--- a/src/boersenspiel/instruments.py
+++ b/src/boersenspiel/instruments.py
@@ -30,12 +30,34 @@ class Instrument:
     # unterliegt - aktuell nur Kryptowährungen (365 Tage). None = normales
     # Abgeltungsteuer-Regime. Siehe #37.
     spekulationsfrist_tage: int | None = None
-    # True für Instrumente, die reale Bar-Ausschüttungen zahlen (Einzelaktien) -
-    # unterliegt in der Simulation der pauschalen Dividendenrendite-Annahme
-    # (`strategies.DIVIDENDENRENDITE_PLATZHALTER`, #57). Die 5 ETFs sind
-    # thesaurierend (keine Ausschüttung, siehe oben), 4GLD und BTC-EUR zahlen
-    # keine Dividende - bei allen dreien bleibt es beim Default False.
+    # True für Instrumente, die reale Bar-Ausschüttungen zahlen (#57). 4GLD und
+    # BTC-EUR zahlen keine, thesaurierende Fonds schütten definitionsgemäß nicht
+    # aus - dort bleibt es beim Default False. Ebenso bei Einzelaktien, die
+    # tatsächlich keine Dividende zahlen (Tesla, Rivian, Palantir, MSTR,
+    # SolarEdge, Lumentum, SMA Solar) - siehe #74.
     ausschuettend: bool = False
+    # Erwartete jährliche Ausschüttungsrendite dieses Instruments (#74). Wirkt
+    # nur bei ``ausschuettend=True``. ``None`` bedeutet "kein instrumenteneigener
+    # Wert hinterlegt" und fällt in der Engine auf
+    # ``strategies.DIVIDENDENRENDITE_PLATZHALTER`` zurück.
+    #
+    # Vorher galt dieser eine Pauschalwert (2,5%) für ALLE ausschüttenden
+    # Instrumente gleichermaßen. Das war nicht bloß ungenau, sondern gerichtet
+    # verzerrend: sieben Einzelaktien, die real gar keine Dividende zahlen,
+    # bekamen jährlich 2,5% geschenkt, während Anleihen- und Immobilien-ETFs -
+    # deren Ertrag zum großen Teil GERADE aus der Ausschüttung besteht - zu
+    # niedrig angesetzt waren. Die Pauschale begünstigte damit systematisch
+    # ausschüttungslose Wachstumswerte gegenüber genau den defensiven
+    # Bausteinen, die eine Barbell-Strategie überhaupt rechtfertigen.
+    #
+    # Die hinterlegten Werte sind gerundete Ausschüttungsrenditen aus
+    # öffentlichen Fondsanbieter-Fact-Sheets bzw. Unternehmensangaben
+    # (justETF/extraETF/onvista, Stand 2026) und bleiben eine Annahme: die
+    # Simulation rechnet mit einem über die ganze Historie KONSTANTEN Satz je
+    # Instrument, nicht mit den tatsächlichen Ausschüttungen des jeweiligen
+    # Jahres. Das ist die verbleibende Vereinfachung - aber eine ungerichtete,
+    # anders als ein einziger Satz für alle.
+    dividendenrendite: Decimal | None = None
 
 
 # Teilfreistellungsquote für Aktienfonds-ETFs (>51% Aktienquote) nach § 20 InvStG.
@@ -85,16 +107,41 @@ INSTRUMENTS: dict[str, Instrument] = {
         # BARBELL_20_60_20_SATELLIT) - bewusst gemischt aus hoch-volatilen
         # Wachstumswerten und zwei defensiven Blue-Chips (Coca-Cola, Roche)
         # als Gegenbeispiel innerhalb desselben Topfs.
-        Instrument("LITE", "Lumentum Holdings (Optik/Photonik)", "US55024U1097", ausschuettend=True),
-        Instrument("BYDDY", "BYD Company (ADR, E-Autos)", "US05606L1008", ausschuettend=True),
-        Instrument("SEDG", "SolarEdge Technologies (Solar-Wechselrichter)", "US83417M1045", ausschuettend=True),
-        Instrument("S92", "SMA Solar Technology AG", "DE000A0DJ6J9", ausschuettend=True),
-        Instrument("TSLA", "Tesla", "US88160R1014", ausschuettend=True),
-        Instrument("PLTR", "Palantir Technologies", "US69608A1088", ausschuettend=True),
-        Instrument("MSTR", "Strategy Inc. (vormals MicroStrategy)", "US5949724083", ausschuettend=True),
-        Instrument("RIVN", "Rivian Automotive", "US76954A1034", ausschuettend=True),
-        Instrument("KO", "Coca-Cola (defensiver Blue Chip)", "US1912161007", ausschuettend=True),
-        Instrument("RHHBY", "Roche Holding (ADR, defensiver Blue Chip)", "US7711951043", ausschuettend=True),
+        # Zahlt keine Dividende (#74).
+        Instrument("LITE", "Lumentum Holdings (Optik/Photonik)", "US55024U1097"),
+        Instrument(
+            "BYDDY",
+            "BYD Company (ADR, E-Autos)",
+            "US05606L1008",
+            ausschuettend=True,
+            dividendenrendite=Decimal("0.010"),
+        ),
+        # Zahlt keine Dividende (#74).
+        Instrument("SEDG", "SolarEdge Technologies (Solar-Wechselrichter)", "US83417M1045"),
+        # Dividende ausgesetzt - keine laufende Ausschuettung (#74).
+        Instrument("S92", "SMA Solar Technology AG", "DE000A0DJ6J9"),
+        # Zahlt keine Dividende (#74).
+        Instrument("TSLA", "Tesla", "US88160R1014"),
+        # Zahlt keine Dividende (#74).
+        Instrument("PLTR", "Palantir Technologies", "US69608A1088"),
+        # Keine Dividende auf die Stammaktie (#74).
+        Instrument("MSTR", "Strategy Inc. (vormals MicroStrategy)", "US5949724083"),
+        # Zahlt keine Dividende (#74).
+        Instrument("RIVN", "Rivian Automotive", "US76954A1034"),
+        Instrument(
+            "KO",
+            "Coca-Cola (defensiver Blue Chip)",
+            "US1912161007",
+            ausschuettend=True,
+            dividendenrendite=Decimal("0.030"),
+        ),
+        Instrument(
+            "RHHBY",
+            "Roche Holding (ADR, defensiver Blue Chip)",
+            "US7711951043",
+            ausschuettend=True,
+            dividendenrendite=Decimal("0.033"),
+        ),
         # --- Sieben zusaetzliche Instrumente (#64) ------------------------------
         # Ergaenzt am 22.08.2026, um das taegliche Alpha-Vantage-Budget von 25
         # Requests auszuschoepfen (vorher 18). Alle sieben sind XETRA-Symbole in
@@ -118,6 +165,10 @@ INSTRUMENTS: dict[str, Instrument] = {
             "IE0031442068",
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             ausschuettend=True,
+            # S&P 500 - niedrige Ausschuettungsrendite, siehe #74. Relevant weit
+            # ueber dieses eine Instrument hinaus: IUSA ist die Vergleichslinie,
+            # an der alle Strategien gemessen werden.
+            dividendenrendite=Decimal("0.013"),
         ),
         Instrument(
             "XEON",
@@ -132,12 +183,16 @@ INSTRUMENTS: dict[str, Instrument] = {
             "DE0002635307",
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             ausschuettend=True,
+            dividendenrendite=Decimal("0.030"),
         ),
         Instrument(
             "IBCL",
             "Euro-Staatsanleihen 15-30 Jahre ETF (iShares, aussch.)",
             "IE00B1FZS913",
             ausschuettend=True,
+            # Lange Euro-Staatsanleihen: der Kupon IST hier praktisch der
+            # gesamte laufende Ertrag (#74).
+            dividendenrendite=Decimal("0.026"),
         ),
         Instrument(
             "IBCI",
@@ -156,6 +211,8 @@ INSTRUMENTS: dict[str, Instrument] = {
             # Quote.
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             ausschuettend=True,
+            # REITs schuetten den Grossteil ihrer Ertraege aus (#74).
+            dividendenrendite=Decimal("0.035"),
         ),
         Instrument(
             "EXXY",

--- a/src/boersenspiel/instruments.py
+++ b/src/boersenspiel/instruments.py
@@ -58,6 +58,18 @@ class Instrument:
     # Jahres. Das ist die verbleibende Vereinfachung - aber eine ungerichtete,
     # anders als ein einziger Satz für alle.
     dividendenrendite: Decimal | None = None
+    # Laufende Fondskosten (Total Expense Ratio) p.a. (#76). 0 fuer Einzelaktien,
+    # physisches Gold und BTC - dort faellt keine Fondsgebuehr an.
+    #
+    # Der Verzicht auf die TER war kein neutraler Verzicht, sondern eine gerichtete
+    # Verzerrung: die Saetze liegen um eine Groessenordnung auseinander (IUSA 0,07%
+    # gegen IQQ6 0,59%), der Benchmark ist das mit Abstand guenstigste Instrument im
+    # Feld, und der Einzelaktien-Satellit traegt gar keine - die Modellierung
+    # beguenstigte also ausgerechnet die konzentrierteste Variante und liess
+    # Themen-/Nischenprodukte guenstiger erscheinen, als sie sind.
+    #
+    # Werte gerundet aus den jeweiligen Anbieter-Fact-Sheets.
+    ter: Decimal = Decimal("0")
 
 
 # Teilfreistellungsquote für Aktienfonds-ETFs (>51% Aktienquote) nach § 20 InvStG.
@@ -72,6 +84,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             "IE00B4L5Y983",
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             thesaurierend=True,
+            ter=Decimal("0.0020"),
         ),
         Instrument(
             "EUNA",
@@ -79,6 +92,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             "IE00BDBRDM35",
             # Rentenfonds - keine Teilfreistellung (nur Aktienfonds).
             thesaurierend=True,
+            ter=Decimal("0.0010"),
         ),
         Instrument("4GLD", "Xetra-Gold", "DE000A0S9GB0"),
         Instrument(
@@ -87,6 +101,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             "LU1829221024",
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             thesaurierend=True,
+            ter=Decimal("0.0023"),
         ),
         Instrument(
             "SEMI",
@@ -94,6 +109,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             "IE000I8KRLL9",
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             thesaurierend=True,
+            ter=Decimal("0.0035"),
         ),
         Instrument(
             "EIMI",
@@ -101,6 +117,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             "IE00BKM4GZ66",
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             thesaurierend=True,
+            ter=Decimal("0.0018"),
         ),
         Instrument("BTC-EUR", "Bitcoin", None, spekulationsfrist_tage=365),
         # Einzelaktien-Satellit (volatile Einzelwerte, siehe strategies.py
@@ -169,6 +186,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             # ueber dieses eine Instrument hinaus: IUSA ist die Vergleichslinie,
             # an der alle Strategien gemessen werden.
             dividendenrendite=Decimal("0.013"),
+            ter=Decimal("0.0007"),
         ),
         Instrument(
             "XEON",
@@ -176,6 +194,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             "LU0290358497",
             # Kein Aktienfonds -> keine Teilfreistellung.
             thesaurierend=True,
+            ter=Decimal("0.0010"),
         ),
         Instrument(
             "EXSA",
@@ -184,6 +203,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
             ausschuettend=True,
             dividendenrendite=Decimal("0.030"),
+            ter=Decimal("0.0020"),
         ),
         Instrument(
             "IBCL",
@@ -193,6 +213,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             # Lange Euro-Staatsanleihen: der Kupon IST hier praktisch der
             # gesamte laufende Ertrag (#74).
             dividendenrendite=Decimal("0.026"),
+            ter=Decimal("0.0020"),
         ),
         Instrument(
             "IBCI",
@@ -201,6 +222,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             # Acc-Anteilsklasse (WKN A0HGV1), nicht Dist - siehe Verifikations-
             # Hinweis oben.
             thesaurierend=True,
+            ter=Decimal("0.0009"),
         ),
         Instrument(
             "IQQ6",
@@ -213,6 +235,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             ausschuettend=True,
             # REITs schuetten den Grossteil ihrer Ertraege aus (#74).
             dividendenrendite=Decimal("0.035"),
+            ter=Decimal("0.0059"),
         ),
         Instrument(
             "EXXY",
@@ -221,6 +244,7 @@ INSTRUMENTS: dict[str, Instrument] = {
             # Rohstofffonds -> keine Teilfreistellung. Acc-Anteilsklasse, nicht
             # Dist - siehe Verifikations-Hinweis oben.
             thesaurierend=True,
+            ter=Decimal("0.0046"),
         ),
     ]
 }

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -52,7 +52,7 @@ class Beitrag:
 
 @dataclass(frozen=True)
 class Optimierungen:
-    """Vier strategieübergreifende Simulationsmechanismen, die ``engine.simulate()``
+    """Fünf strategieübergreifende Simulationsmechanismen, die ``engine.simulate()``
     unabhängig von der jeweiligen Gewichtungsregel anwendet. Einzeln ein-/ausschaltbar,
     damit ihr isolierter Renditebeitrag messbar wird (siehe #17), statt nur geglaubt zu
     werden. Defaults erhalten das bisherige Verhalten exakt - eine Strategie ohne
@@ -63,6 +63,7 @@ class Optimierungen:
     rebalancing: bool = True  # periodische Rückführung auf die Zielgewichte
     ordergebuehren: bool = True  # False -> gebührenfreie Referenzrechnung
     besteuerung: bool = True  # False -> realisierte Gewinne fließen nicht in Freibetrag/Steuer-Tracking
+    fondskosten: bool = True  # False -> laufende Fondskosten (TER) bleiben unberücksichtigt (#76)
 
 
 @dataclass(frozen=True)
@@ -100,7 +101,7 @@ class Strategy:
     # Optional: Kurzbeschreibung der Strategie/des Szenarios fürs Dashboard (#26).
     # Leer bedeutet: keine Beschreibung wird angezeigt.
     beschreibung: str = ""
-    # Welche der vier Mechanismen aus ``Optimierungen`` für diese Strategie standardmäßig
+    # Welche der fünf Mechanismen aus ``Optimierungen`` für diese Strategie standardmäßig
     # greifen. ``engine.simulate()`` übernimmt diese, sofern ihr nicht explizit eine
     # andere ``Optimierungen``-Instanz übergeben wird (siehe #17).
     optimierungen: Optimierungen = field(default_factory=Optimierungen)

--- a/src/boersenspiel/templates/base.html.j2
+++ b/src/boersenspiel/templates/base.html.j2
@@ -110,6 +110,7 @@
   footer { max-width: 1100px; margin: 24px auto 0; color: var(--text-muted); font-size: 0.8rem; }
   .summary-chart-box { position: relative; height: 340px; margin-bottom: 20px; }
   .hint { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 16px; max-width: 68ch; }
+  .hint-cell { color: var(--text-secondary); font-size: 0.74rem; white-space: nowrap; }
   ol.learnings { list-style: none; counter-reset: learning; margin: 0; padding: 0; display: grid; gap: 14px; }
   ol.learnings li {
     counter-increment: learning;

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -81,8 +81,9 @@
       Sharpe teilt die annualisierte Rendite durch die gesamte Streuung, Sortino nur
       durch die Streuung der Verlustwochen (Streuung nach oben zählt dort nicht als
       Risiko). Höher ist besser; negativ heißt, das eingegangene Risiko hat sich
-      nicht gelohnt. Ein risikofreier Zins von 0% ist dabei ein bewusster
-      Platzhalter, kein realer Referenzzins. Alle Renditewerte hier sind
+      gegenüber risikolosem Parken nicht gelohnt. Der risikofreie Zins dafür wird
+      aus dem EUR-Geldmarkt-ETF über den jeweils ausgewerteten Zeitraum abgeleitet
+      (siehe Prämissen), nicht fest angenommen. Alle Renditewerte hier sind
       Bruttowerte (vor Steuer) - die geschätzte Nettorendite je Strategie
       steht auf der jeweiligen Detailseite.
     </p>

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -43,6 +43,31 @@
 {% endif %}
   <section class="strategy" id="uebersicht">
     <h2>Übersicht: Rendite im Vergleich</h2>
+    {% if vergleich_verfuegbar %}
+    <p class="hint">
+      <strong>Vergleichszeitraum:</strong> Jede Strategie wird nur über den Zeitraum
+      simuliert, in dem ihr komplettes Instrumentenset tatsächlich handelbar war
+      (letzte Spalte) &ndash; sonst würde ein 2026 zusammengestelltes Portfolio
+      rückwirkend ab 2006 gekauft. Diese Zeiträume sind aber unterschiedlich lang und
+      decken unterschiedliche Marktphasen ab; ihre CAGR-Werte lassen sich deshalb
+      <em>nicht</em> direkt gegeneinander stellen. Die Leitspalte
+      <strong>„CAGR % p.a. im Vergleichszeitraum"</strong> simuliert deshalb jede
+      Strategie zusätzlich ab <strong>{{ vergleich_beginn }}</strong> &ndash; dem
+      spätesten Startdatum aller hier gezeigten Strategien, ab dem also jede von
+      ihnen Kurse hat &ndash; jeweils frisch mit eigenem Startkapital. Nur diese
+      Spalte vergleicht Gleiches mit Gleichem, und nur nach ihr ist die Tabelle
+      sortiert.
+      {% if vergleich_benchmark %}
+      Die Spalte <strong>„Überrendite pp p.a."</strong> ist die Differenz dazu
+      gegenüber „{{ vergleich_benchmark }}" ({{ vergleich_benchmark_label }} % p.a.
+      im selben Zeitraum) &ndash; ein negativer Wert heißt, die Strategie hätte den
+      Index über diesen Zeitraum <em>nicht</em> geschlagen.
+      {% endif %}
+      Ein kurzer Vergleichszeitraum bleibt eine schmale Datenbasis: er zeigt, wie
+      sich die Strategien im selben Marktumfeld verhalten haben, nicht wie sie sich
+      künftig verhalten werden.
+    </p>
+    {% endif %}
     <p class="hint">
       CAGR (annualisierte Rendite, "% p.a.") ist die Leitkennzahl: über viele Jahre
       ist eine Gesamtrendite kaum lesbar und schlecht zwischen unterschiedlich langen
@@ -64,11 +89,15 @@
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
     <div class="overflow-x">
       <table class="summary-table">
-        <thead><tr><th>Strategie / Szenario</th><th>CAGR % p.a. (brutto)</th><th>Gesamtrendite % (brutto)</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th></tr></thead>
+        <thead><tr><th>Strategie / Szenario</th>{% if vergleich_verfuegbar %}<th>CAGR % p.a. im Vergleichszeitraum</th><th>&Uuml;berrendite pp p.a.</th>{% endif %}<th>CAGR % p.a. (eigener Zeitraum)</th><th>Gesamtrendite % (brutto)</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th><th>Eigener Zeitraum</th></tr></thead>
         <tbody>
         {% for s in summary %}
           <tr>
             <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
+            {% if vergleich_verfuegbar %}
+            <td class="{{ ('positive' if s.vergleich_cagr_pct >= 0 else 'negative') if s.vergleich_cagr_pct is not none else '' }}"><strong>{{ s.vergleich_cagr_label }}</strong></td>
+            <td class="{{ ('positive' if s.alpha_pp >= 0 else 'negative') if s.alpha_pp is not none else '' }}">{{ s.alpha_pp_label }}</td>
+            {% endif %}
             <td class="{{ 'positive' if s.cagr_pct >= 0 else 'negative' }}">{{ s.cagr_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
             <td>{{ s.volatilitaet_label }}</td>
@@ -77,6 +106,7 @@
             <td class="{{ 'positive' if s.sortino_ratio >= 0 else 'negative' }}">{{ s.sortino_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.gewinn_label }}</td>
             <td>{{ s.total_value }}</td>
+            <td class="hint-cell">{{ s.sim_beginn }} &ndash; {{ s.sim_ende }}<br>({{ s.sim_jahre_label }} Jahre)</td>
           </tr>
         {% endfor %}
         </tbody>
@@ -153,14 +183,19 @@
       labels: {{ summary | map(attribute='name') | list | tojson }},
       datasets: [{
         label: 'CAGR % p.a.',
+        {% if vergleich_verfuegbar %}
+        data: {{ summary | map(attribute='vergleich_cagr_pct') | list | tojson }},
+        backgroundColor: {{ summary | map(attribute='vergleich_cagr_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+        {% else %}
         data: {{ summary | map(attribute='cagr_pct') | list | tojson }},
         backgroundColor: {{ summary | map(attribute='cagr_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+        {% endif %}
       }],
     },
     options: {
       indexAxis: 'y',
       responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'Annualisierte Rendite (CAGR, % p.a.)', color: colors.text } },
+      plugins: { legend: { display: false }, title: { display: true, text: {% if vergleich_verfuegbar %}'Annualisierte Rendite (CAGR, % p.a.) im gemeinsamen Vergleichszeitraum ab {{ vergleich_beginn }}'{% else %}'Annualisierte Rendite (CAGR, % p.a.)'{% endif %}, color: colors.text } },
       scales: {
         x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
         y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -103,7 +103,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Spekulationsfrist</th></tr></thead>
+        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>Spekulationsfrist</th></tr></thead>
         <tbody>
         {% for i in instrumente %}
           <tr>
@@ -114,6 +114,7 @@
             <td>{{ i.teilfreistellung }}</td>
             <td>{{ i.thesaurierend }}</td>
             <td>{{ i.ausschuettend }}</td>
+            <td>{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
             <td>{{ i.spekulationsfrist }}</td>
           </tr>
         {% endfor %}
@@ -142,7 +143,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Spekulationsfrist</th></tr></thead>
+        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>Spekulationsfrist</th></tr></thead>
         <tbody>
         {% for i in nicht_allokierte_instrumente %}
           <tr>
@@ -153,6 +154,7 @@
             <td>{{ i.teilfreistellung }}</td>
             <td>{{ i.thesaurierend }}</td>
             <td>{{ i.ausschuettend }}</td>
+            <td>{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
             <td>{{ i.spekulationsfrist }}</td>
           </tr>
         {% endfor %}
@@ -166,7 +168,7 @@
       <div class="stat-tile"><div class="label">Ordergebühr je Trade</div><div class="value">{{ ordergebuehr }} &euro;</div></div>
       <div class="stat-tile"><div class="label">Kostenbasis</div><div class="value">Durchschnitt</div></div>
       <div class="stat-tile"><div class="label">Spread / Slippage</div><div class="value">nicht modelliert</div></div>
-      <div class="stat-tile"><div class="label">Dividendenrendite Einzelaktien</div><div class="value">{{ dividendenrendite }} % (Platzhalter)</div></div>
+      <div class="stat-tile"><div class="label">Ausschüttungsrendite</div><div class="value">je Instrument</div></div>
     </div>
     <p class="hint">
       Gekauft und verkauft wird zum Wochenschlusskurs, in beliebigen
@@ -174,18 +176,26 @@
       Erstkaufs werden vor der Aufteilung vom Startkapital abgezogen; spätere
       Trades mindern beim Verkauf den realisierten Gewinn um die Gebühr und
       schlagen sie beim Kauf auf die Kostenbasis. Die Kostenbasis läuft nach der
-      Durchschnittskosten-Methode, nicht nach FIFO. Für die 10 Einzelaktien-
-      Satelliten wird einmal jährlich eine <strong>pauschale
-      Dividendenrendite von {{ dividendenrendite }} %</strong> auf den
-      Portfoliowert zu Jahresbeginn angesetzt (Owner-Entscheidung, siehe
-      <a href="https://github.com/S540d/Boersenspiel/issues/57">#57</a>) -
-      ein einheitlicher Platzhalter, keine recherchierte, unternehmens-
-      spezifische Dividendenhistorie (manche der 10 Aktien zahlen real gar
-      keine Dividende). Die Dividende wird als echtes zusätzliches Cash
-      gutgeschrieben, automatisch reinvestiert und wie ein realer
-      Kapitalertrag versteuert. Die 5 ETFs sind thesaurierend (siehe Tabelle
-      oben) und schütten korrekt nichts aus; 4GLD (physisches Gold) und
-      BTC-EUR zahlen ebenfalls keine Dividende.
+      Durchschnittskosten-Methode, nicht nach FIFO. Für jedes ausschüttende
+      Instrument wird einmal jährlich eine <strong>Ausschüttung in Höhe seiner
+      eigenen Ausschüttungsrendite</strong> (Spalte in der Instrumententabelle
+      oben) auf den Portfoliowert zu Jahresbeginn angesetzt (<a
+      href="https://github.com/S540d/Boersenspiel/issues/57">#57</a>, je
+      Instrument seit <a
+      href="https://github.com/S540d/Boersenspiel/issues/74">#74</a>). Die
+      Ausschüttung wird als echtes zusätzliches Cash gutgeschrieben,
+      automatisch reinvestiert und wie ein realer Kapitalertrag versteuert.
+      Thesaurierende Fonds schütten definitionsgemäß nichts aus; 4GLD
+      (physisches Gold), BTC-EUR sowie die Einzelaktien ohne Dividende
+      (Tesla, Rivian, Palantir, Strategy, SolarEdge, Lumentum, SMA Solar)
+      erhalten korrekt keine. <strong>Verbleibende Vereinfachung:</strong> der
+      Satz je Instrument ist über die gesamte Historie konstant und aus
+      öffentlichen Fact-Sheets gerundet - es ist keine jahresgenaue
+      Ausschüttungshistorie hinterlegt. Bis #74 galt stattdessen ein
+      einziger Pauschalsatz von {{ dividendenrendite }} % für alle
+      ausschüttenden Instrumente; der begünstigte ausschüttungslose
+      Wachstumswerte auf Kosten von Anleihen- und Immobilien-ETFs, deren
+      Ertrag zum großen Teil gerade aus der Ausschüttung besteht.
     </p>
     <p class="hint">
       Rebalanciert wird, sobald IRGENDEIN Topf entweder um mehr als die
@@ -321,9 +331,9 @@
     <h3>Was nicht modelliert wird</h3>
     <ul class="hint">
       <li>
-        Unternehmensspezifische Dividendenhöhen &ndash; Einzelaktien nutzen
-        einheitlich die pauschale {{ dividendenrendite }}%-Platzhalter-Rendite
-        oben statt recherchierter, individueller Ausschüttungshistorien
+        Jahresgenaue Dividenden-/Ausschüttungshistorien &ndash; je Instrument
+        gilt ein konstanter, aus Fact-Sheets gerundeter Satz (Tabelle oben),
+        nicht die tatsächlich gezahlten Dividenden des jeweiligen Jahres
       </li>
       <li>Inflation &ndash; alle Beträge sind nominal</li>
       <li>Geld-Brief-Spanne, Slippage, Teilausführungen, Handelsaussetzungen</li>

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -211,7 +211,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Strategie</th><th>Startkapital &euro;</th><th>Schwelle pp (absolut)</th><th>Schwelle % (relativ)</th><th class="text-left">Überwachter Topf</th><th>Zielgewicht %</th><th>Zeitabhängige Gewichte</th><th>Simulationsbeginn</th></tr></thead>
+        <thead><tr><th>Strategie</th><th>Startkapital &euro;</th><th>Schwelle pp (absolut)</th><th>Schwelle % (relativ)</th><th class="text-left">Überwachter Topf</th><th>Zielgewicht %</th><th>Zeitabhängige Gewichte</th><th>Simulationsbeginn</th><th>Risikofreier Zins % p.a.</th></tr></thead>
         <tbody>
         {% for s in strategien %}
           <tr>
@@ -223,6 +223,7 @@
             <td>{{ s.ziel_gewicht }}</td>
             <td>{{ s.dynamisch }}</td>
             <td>{{ s.sim_beginn }}</td>
+            <td>{{ s.risikofreier_zins_label }}</td>
           </tr>
         {% endfor %}
         </tbody>
@@ -312,11 +313,24 @@
       Volatilität ist die annualisierte Standardabweichung der Wochenrenditen
       (&times; &radic;52), Max Drawdown der größte Rückgang vom bisherigen
       Höchststand. Sharpe teilt die annualisierte Rendite durch die gesamte
-      Streuung, Sortino nur durch die Streuung der Verlustwochen. Beide rechnen
-      mit einem risikofreien Zins von <strong>{{ risikofreier_zins }} %</strong>
-      &ndash; ebenfalls ein bewusster Platzhalter, kein realer Referenzzins. Hat
-      eine Reihe gar keine Verlustwochen, wird Sortino als 0 ausgewiesen statt
-      als undefiniert.
+      Streuung, Sortino nur durch die Streuung der Verlustwochen. Beide messen die
+      <em>Über</em>rendite gegenüber einem risikofreien Zins; der wird seit
+      <a href="https://github.com/S540d/Boersenspiel/issues/75">#75</a> nicht
+      mehr fest hinterlegt, sondern aus dem EUR-Geldmarkt-ETF
+      <strong>{{ geldmarkt_ticker }}</strong> über exakt denselben Zeitraum
+      abgeleitet, über den auch die jeweilige Strategie ausgewertet wird &ndash;
+      er steht deshalb je Strategie/Zeitraum in der Tabelle unten und in den
+      Zeitraum-Abschnitten der Detailseiten. Damit zieht die Kennzahl automatisch
+      mit dem Zinsumfeld mit (2006&ndash;2008 rund 3&ndash;4 %,
+      2012&ndash;2022 nahe 0 %, ab 2023 wieder 3&ndash;4 %). Vorher galten fest
+      {{ risikofreier_zins }} %; Sharpe war damit faktisch „Rendite ÷ Risiko"
+      statt „Überrendite ÷ Risiko" und konnte per Konstruktion nie zeigen, dass
+      eine Strategie den Geldmarkt <em>nicht</em> geschlagen hat &ndash; ein
+      Fehler, der ungleich wirkte: er hob Strategien mit geringer Volatilität
+      (kleiner Nenner) stärker an, also gerade die defensiven. Fehlt
+      {{ geldmarkt_ticker }} im Zeitraum oder ist er zu kurz, gilt weiterhin der
+      Platzhalter von {{ risikofreier_zins }} %. Hat eine Reihe gar keine
+      Verlustwochen, wird Sortino als 0 ausgewiesen statt als undefiniert.
     </p>
     <p class="hint">
       Die gleitenden Durchschnitte auf den Detailseiten nähern die klassischen

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -103,7 +103,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>Spekulationsfrist</th></tr></thead>
+        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>TER % p.a.</th><th>Spekulationsfrist</th></tr></thead>
         <tbody>
         {% for i in instrumente %}
           <tr>
@@ -115,6 +115,7 @@
             <td>{{ i.thesaurierend }}</td>
             <td>{{ i.ausschuettend }}</td>
             <td>{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
+            <td>{{ i.ter }}</td>
             <td>{{ i.spekulationsfrist }}</td>
           </tr>
         {% endfor %}
@@ -143,7 +144,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>Spekulationsfrist</th></tr></thead>
+        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>TER % p.a.</th><th>Spekulationsfrist</th></tr></thead>
         <tbody>
         {% for i in nicht_allokierte_instrumente %}
           <tr>
@@ -155,6 +156,7 @@
             <td>{{ i.thesaurierend }}</td>
             <td>{{ i.ausschuettend }}</td>
             <td>{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
+            <td>{{ i.ter }}</td>
             <td>{{ i.spekulationsfrist }}</td>
           </tr>
         {% endfor %}
@@ -169,7 +171,21 @@
       <div class="stat-tile"><div class="label">Kostenbasis</div><div class="value">Durchschnitt</div></div>
       <div class="stat-tile"><div class="label">Spread / Slippage</div><div class="value">nicht modelliert</div></div>
       <div class="stat-tile"><div class="label">Ausschüttungsrendite</div><div class="value">je Instrument</div></div>
+      <div class="stat-tile"><div class="label">Laufende Fondskosten (TER)</div><div class="value">je Instrument</div></div>
     </div>
+    <p class="hint">
+      Die <strong>laufenden Fondskosten (TER)</strong> jedes Fonds werden
+      wöchentlich anteilig (TER ÷ 52) vom Bestand abgezogen &ndash; als
+      Reduktion der Anteile, nicht als Barabfluss: der Anleger zahlt die TER
+      nicht aus der Tasche, sein Anteil am Fondsvermögen wird kleiner. Die
+      Kostenbasis bleibt deshalb unverändert. Einzelaktien, physisches Gold und
+      BTC tragen keine (Spalte „TER % p.a." oben). Ohne diese Modellierung wäre
+      der Verzicht nicht neutral gewesen, sondern gerichtet: die Sätze liegen um
+      eine Größenordnung auseinander, der Benchmark ist das günstigste
+      Instrument im Feld, und der Einzelaktien-Satellit trägt gar keine &ndash;
+      begünstigt worden wäre also ausgerechnet die konzentrierteste Variante
+      (<a href="https://github.com/S540d/Boersenspiel/issues/76">#76</a>).
+    </p>
     <p class="hint">
       Gekauft und verkauft wird zum Wochenschlusskurs, in beliebigen
       Bruchstücken, ohne Geld-Brief-Spanne und ohne Teilausführung. Gebühren des
@@ -351,7 +367,9 @@
       </li>
       <li>Inflation &ndash; alle Beträge sind nominal</li>
       <li>Geld-Brief-Spanne, Slippage, Teilausführungen, Handelsaussetzungen</li>
-      <li>Depot-, Ausgabeaufschlags- und Fondskosten (TER) &ndash; nur die Ordergebühr</li>
+      <li>Depot- und Ausgabeaufschlagskosten &ndash; die laufenden Fondskosten (TER) werden seit
+        <a href="https://github.com/S540d/Boersenspiel/issues/76">#76</a> modelliert (Tabelle oben),
+        Depotgebühren und Ausgabeaufschläge nicht</li>
       <li>Zinsen auf nicht investiertes Kapital</li>
       <li>Kapitalmaßnahmen wie Splits oder Fusionen über den Kursabruf hinaus</li>
       <li>Steuerliche Effekte über das Abgeltungsteuer- und § 23-Regime hinaus</li>

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -108,7 +108,8 @@
       <p class="hint">
         Leave-one-out je Mechanismus: CAGR (annualisierte Rendite) dieser Strategie
         minus CAGR derselben Strategie mit genau diesem einen Mechanismus
-        ausgeschaltet (Dezember-Harvest, Rebalancing, Ordergebühren, Besteuerung).
+        ausgeschaltet (Dezember-Harvest, Rebalancing, Ordergebühren, Besteuerung,
+        laufende Fondskosten).
         Positiv = der Mechanismus hat Rendite gebracht, negativ = er hat gekostet.
         Auf CAGR- statt Gesamtrendite-Basis, weil die Differenz zweier
         Gesamtrenditen keine sinnvolle Prozentpunkt-Angabe mehr ist, sobald sich

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -22,18 +22,22 @@ from boersenspiel.dashboard import (
     _cagr_pct,
     _gemeinsamer_beginn,
     _downside_deviation,
+    _GELDMARKT_TICKER,
     _jahre_zurueck,
     _VERGLEICH_MIN_WOCHEN,
     _vergleichs_cagr_pct,
     _max_drawdown_pct,
     _ohne_btc_fruehphase,
     _real_investierbarer_zeitraum,
+    _RISIKOFREIER_ZINS_PLATZHALTER,
+    _risikofreier_zins_pct,
     _sharpe_ratio,
     _slug,
     _sortino_ratio,
     _volatilitaet_pct,
     _walk_forward_segmente,
     _zeitraum_presets,
+    _ZINS_MIN_WOCHEN,
     build_dashboard,
 )
 from boersenspiel.engine import simulate
@@ -1051,3 +1055,65 @@ def test_ohne_benchmark_strategie_entfaellt_die_ueberrendite_spalte(tmp_path: Pa
 
     assert "im Vergleichszeitraum" in html
     assert "Überrendite pp p.a." not in html
+
+
+# --- Risikofreier Zins aus dem Geldmarkt-ETF (#75) ---------------------------
+
+
+def test_risikofreier_zins_wird_aus_dem_geldmarkt_etf_abgeleitet():
+    # Geldmarkt-ETF steigt ueber genau ein Jahr um 4% -> 4% p.a.
+    rows = []
+    kurs = Decimal("100")
+    start = date(2020, 1, 6)
+    wochen = 53
+    schritt = (Decimal("104") / Decimal("100")) ** (Decimal(1) / Decimal(wochen - 1))
+    for i in range(wochen):
+        rows.append(PriceRow(start + timedelta(weeks=i), {_GELDMARKT_TICKER: kurs}))
+        kurs = kurs * schritt
+
+    zins = _risikofreier_zins_pct(rows)
+    assert 3.5 < zins < 4.5
+
+
+def test_risikofreier_zins_faellt_ohne_geldmarkt_daten_auf_den_platzhalter_zurueck():
+    ohne = [PriceRow(date(2020, 1, 6) + timedelta(weeks=i), {"T1": Decimal("100")}) for i in range(60)]
+    assert _risikofreier_zins_pct(ohne) == _RISIKOFREIER_ZINS_PLATZHALTER
+
+    zu_kurz = [
+        PriceRow(date(2020, 1, 6) + timedelta(weeks=i), {_GELDMARKT_TICKER: Decimal("100")})
+        for i in range(_ZINS_MIN_WOCHEN - 1)
+    ]
+    assert _risikofreier_zins_pct(zu_kurz) == _RISIKOFREIER_ZINS_PLATZHALTER
+
+
+def test_sharpe_und_sortino_ziehen_den_risikofreien_zins_ab():
+    # Dieselbe Wertreihe, einmal gegen 0% und einmal gegen einen positiven Zins:
+    # der Abzug muss die Kennzahl senken. Vor #75 war das gar nicht moeglich -
+    # der Zins war fest 0 und Sharpe damit nie ein UEBERrendite-Mass.
+    # Bewusst mit Verlustwochen, sonst ist die Downside-Deviation 0 und Sortino
+    # laut Definition (siehe _sortino_ratio) fuer beide Zinsen 0.
+    werte = [100.0]
+    for i in range(60):
+        werte.append(werte[-1] * (1.02 if i % 3 else 0.99))
+
+    assert _sharpe_ratio(werte, 0.0) > _sharpe_ratio(werte, 5.0)
+    assert _sortino_ratio(werte, 0.0) > _sortino_ratio(werte, 5.0)
+    # Ohne Angabe gilt weiterhin der Platzhalter - unveraendertes Verhalten.
+    assert _sharpe_ratio(werte) == _sharpe_ratio(werte, _RISIKOFREIER_ZINS_PLATZHALTER)
+
+
+def test_praemissen_seite_weist_den_zins_je_strategie_aus(tmp_path: Path):
+    rows = []
+    kurs = Decimal("100")
+    geld = Decimal("100")
+    start = date(2020, 1, 6)
+    for i in range(60):
+        rows.append(PriceRow(start + timedelta(weeks=i), {"T1": kurs, _GELDMARKT_TICKER: geld}))
+        kurs = kurs * Decimal("1.005")
+        geld = geld * Decimal("1.0005")
+
+    build_dashboard(rows, ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+
+    assert "Risikofreier Zins" in html
+    assert _GELDMARKT_TICKER in html

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -20,8 +20,11 @@ from boersenspiel.dashboard import (
     _BTC_TICKER,
     _build_strategy_view,
     _cagr_pct,
+    _gemeinsamer_beginn,
     _downside_deviation,
     _jahre_zurueck,
+    _VERGLEICH_MIN_WOCHEN,
+    _vergleichs_cagr_pct,
     _max_drawdown_pct,
     _ohne_btc_fruehphase,
     _real_investierbarer_zeitraum,
@@ -948,3 +951,103 @@ def test_build_dashboard_rendert_benchmark_schalter_und_feste_skala(tmp_path: Pa
     assert 'id="benchmark-switch"' in detail_html
     assert f'data-benchmark="{_slug("Benchmark X")}"' in detail_html
     assert "suggestedMax:" not in detail_html
+
+
+# --- Gemeinsamer Vergleichszeitraum (#73) ------------------------------------
+
+
+def _lange_reihe(start: date, wochen: int, faktor_pro_woche: float, ticker: str) -> list[PriceRow]:
+    kurs = Decimal("100")
+    rows = []
+    for i in range(wochen):
+        rows.append(PriceRow(start + timedelta(weeks=i), {ticker: kurs}))
+        kurs = kurs * Decimal(str(faktor_pro_woche))
+    return rows
+
+
+def test_gemeinsamer_beginn_ist_das_spaeteste_startdatum():
+    a = [PriceRow(date(2020, 1, 6), {"T1": Decimal("100")})]
+    b = [PriceRow(date(2023, 5, 1), {"T2": Decimal("100")})]
+    assert _gemeinsamer_beginn({"A": a, "B": b}) == date(2023, 5, 1)
+    assert _gemeinsamer_beginn({}) is None
+    assert _gemeinsamer_beginn({"A": []}) is None
+
+
+def test_vergleichs_cagr_nutzt_nur_den_zeitraum_ab_dem_gemeinsamen_beginn():
+    # Erst 52 Wochen flach, danach 52 Wochen steigend. Die CAGR ueber die volle
+    # Historie muss deutlich unter der CAGR ab dem Anstieg liegen - sonst wuerde
+    # der Ausschnitt gar nicht wirken.
+    flach = [PriceRow(date(2020, 1, 6) + timedelta(weeks=i), {"T1": Decimal("100")}) for i in range(52)]
+    steigend = _lange_reihe(date(2021, 1, 4), 60, 1.01, "T1")
+    rows = flach + steigend
+    strategy = ZWEI_STRATEGIEN[0]
+
+    voll = _cagr_pct(
+        float(simulate(rows, strategy).value_history[-1].total_value / strategy.startkapital - 1) * 100,
+        (rows[-1].date - rows[0].date).days,
+    )
+    ausschnitt = _vergleichs_cagr_pct(strategy, rows, date(2021, 1, 4))
+
+    assert ausschnitt is not None
+    assert ausschnitt > voll + 10
+
+
+def test_vergleichs_cagr_entfaellt_bei_zu_kurzem_gemeinsamem_zeitraum():
+    rows = _lange_reihe(date(2020, 1, 6), _VERGLEICH_MIN_WOCHEN + 5, 1.01, "T1")
+    zu_kurz = rows[-(_VERGLEICH_MIN_WOCHEN - 1)].date
+    assert _vergleichs_cagr_pct(ZWEI_STRATEGIEN[0], rows, zu_kurz) is None
+    assert _vergleichs_cagr_pct(ZWEI_STRATEGIEN[0], rows, rows[0].date) is not None
+
+
+def test_uebersichtstabelle_zeigt_vergleichszeitraum_und_ueberrendite(tmp_path: Path):
+    # Zwei Strategien mit unterschiedlichem Simulationsbeginn: "Spaet" haelt ein
+    # Instrument, das erst spaeter einen Kurs hat, und beginnt deshalb spaeter.
+    # Genau diese Konstellation machte die CAGR-Spalten frueher unvergleichbar.
+    spaet = Strategy(
+        name="Spaet",
+        startkapital=Decimal("1000"),
+        toepfe=[
+            Topf(
+                name="Topf",
+                gewicht_gesamt=Decimal("1"),
+                sub_gewichte={"T1": Decimal("0.5"), "T2": Decimal("0.5")},
+            )
+        ],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+    frueh = ZWEI_STRATEGIEN[0]
+
+    rows = []
+    kurs = Decimal("100")
+    start = date(2020, 1, 6)
+    for i in range(120):
+        preise = {"T1": kurs}
+        if i >= 40:
+            preise["T2"] = kurs
+        rows.append(PriceRow(start + timedelta(weeks=i), preise))
+        kurs = kurs * Decimal("1.005")
+
+    build_dashboard(rows, [frueh, spaet], output_path=tmp_path / "index.html")
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+
+    # Der gemeinsame Beginn ist der spaetere der beiden Simulationsbeginne.
+    gemeinsam = rows[40].date.isoformat()
+    assert gemeinsam in html
+    assert "im Vergleichszeitraum" in html
+    # Beide eigenen Zeitraeume stehen als eigene Spalte in der Tabelle.
+    assert rows[0].date.isoformat() in html
+    assert rows[-1].date.isoformat() in html
+
+
+def test_ohne_benchmark_strategie_entfaellt_die_ueberrendite_spalte(tmp_path: Path):
+    # ZWEI_STRATEGIEN enthaelt keine Strategie aus BENCHMARK_STRATEGIEN - dann
+    # gibt es keine Referenzlinie und die Ueberrendite bleibt leer, statt gegen
+    # eine willkuerlich gewaehlte andere Strategie zu rechnen.
+    rows = _lange_reihe(date(2020, 1, 6), 60, 1.005, "T1")
+    build_dashboard(rows, ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+
+    assert "im Vergleichszeitraum" in html
+    assert "Überrendite pp p.a." not in html

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -17,6 +17,7 @@ from datetime import date
 from decimal import Decimal
 
 from boersenspiel.engine import simulate
+from boersenspiel.instruments import INSTRUMENTS, Instrument
 from boersenspiel.history_store import PriceRow
 from boersenspiel.strategies import BARBELL_20_80, Optimierungen, Strategy, Topf
 
@@ -417,13 +418,14 @@ def test_dividende_wird_als_cash_gutgeschrieben_und_versteuert():
     # (2,5% p.a.), obwohl der Kurs unveraendert bleibt und keine Position
     # verkauft wird.
     # Wert Jahresbeginn: 9,99 Einheiten * 100 = 999.
-    # Dividende = 999 * 0,025 = 24,975, komplett steuerpflichtig (0%
-    # Teilfreistellung fuer Einzelaktien) und in voller Hoehe gegen den
-    # Freibetrag verrechnet: 1000 - 24,975 = 975,025.
+    # Dividende = 999 * 0,030 = 29,97 (KO fuehrt seit #74 eine eigene
+    # Ausschuettungsrendite von 3,0% statt des Pauschal-Platzhalters von 2,5%),
+    # komplett steuerpflichtig (0% Teilfreistellung fuer Einzelaktien) und in
+    # voller Hoehe gegen den Freibetrag verrechnet: 1000 - 29,97 = 970,03.
     # Die Dividende wird als pending_cash gutgeschrieben, aber (mangels
     # weiterer Kurszeile) nicht mehr reinvestiert - die Stueckzahl bleibt
     # unveraendert, der ausgewiesene Portfoliowert steigt trotzdem um die
-    # Dividende (999 + 24,975 = 1023,975).
+    # Dividende (999 + 29,97 = 1028,97).
     strategy = Strategy(
         name="Test-Dividende",
         startkapital=Decimal("1000"),
@@ -440,9 +442,9 @@ def test_dividende_wird_als_cash_gutgeschrieben_und_versteuert():
     result = simulate(rows, strategy)
 
     assert result.holdings["KO"] == Decimal("9.99")  # keine Trades ausser Initialkauf
-    assert result.tax_status.freibetrag_verbleibend == Decimal("975.025")
+    assert result.tax_status.freibetrag_verbleibend == Decimal("970.03")
     assert result.tax_status.kumulierte_steuer == Decimal("0")
-    assert result.value_history[-1].total_value == Decimal("1023.975")
+    assert result.value_history[-1].total_value == Decimal("1028.97")
 
 
 def test_dividende_bleibt_aus_wenn_besteuerung_deaktiviert_ist():
@@ -468,7 +470,7 @@ def test_dividende_bleibt_aus_wenn_besteuerung_deaktiviert_ist():
 
     assert result.tax_status.freibetrag_verbleibend == Decimal("1000")
     assert result.tax_status.kumulierte_steuer == Decimal("0")
-    assert result.value_history[-1].total_value == Decimal("1023.975")
+    assert result.value_history[-1].total_value == Decimal("1028.97")
 
 
 def test_btc_gewinn_innerhalb_spekulationsfrist_landet_in_eigener_freigrenze():
@@ -716,3 +718,88 @@ def test_5_25_regel_relativ_default_aendert_altverhalten_nicht():
     strategy_ohne_relativ = Strategy(**KLEINER_TOPF_STRATEGY_BASIS)
     result = simulate(_kleiner_topf_rows(), strategy_ohne_relativ, Optimierungen(**_OHNE_REIBUNG))
     assert result.last_rebalance_date is None
+
+
+# --- Ausschuettungsrendite je Instrument (#74) ------------------------------
+
+
+def test_nicht_zahlende_einzelaktien_bekommen_keine_dividende():
+    """Sieben der zehn Satelliten-Aktien zahlen real keine Dividende. Vor #74
+    bekamen sie ueber ``ausschuettend=True`` trotzdem jaehrlich die
+    Pauschalrendite gutgeschrieben - geschenktes Geld, das die Rendite des
+    Satelliten-Topfs verzerrte."""
+    for ticker in ("TSLA", "RIVN", "PLTR", "MSTR", "SEDG", "LITE", "S92"):
+        assert INSTRUMENTS[ticker].ausschuettend is False, ticker
+
+    strategy = Strategy(
+        name="Test-Nichtzahler",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={"TSLA": Decimal("1")})],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("100"),
+        optimierungen=Optimierungen(steueroptimierung=False),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"TSLA": Decimal("100")}),
+        PriceRow(date(2024, 12, 30), {"TSLA": Decimal("100")}),
+    ]
+    result = simulate(rows, strategy)
+
+    # Kein Cash-Zufluss: der Wert bleibt exakt der Kaufwert (1000 - 1 Gebuehr).
+    assert result.value_history[-1].total_value == Decimal("999")
+    assert result.tax_status.freibetrag_verbleibend == Decimal("1000")
+
+
+def test_ausschuettende_instrumente_nutzen_ihre_eigene_rendite():
+    """Zwei ausschuettende Instrumente mit unterschiedlicher Rendite duerfen
+    nicht denselben Betrag ausschuetten (vor #74 taten sie genau das)."""
+    assert INSTRUMENTS["IQQ6"].dividendenrendite == Decimal("0.035")
+    assert INSTRUMENTS["IUSA"].dividendenrendite == Decimal("0.013")
+
+    def endwert(ticker: str) -> Decimal:
+        strategy = Strategy(
+            name=f"Test-{ticker}",
+            startkapital=Decimal("1000"),
+            toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={ticker: Decimal("1")})],
+            ziel_topf="TopfX",
+            ziel_gewicht=Decimal("1"),
+            rebalancing_schwelle_pp=Decimal("100"),
+            optimierungen=Optimierungen(steueroptimierung=False),
+        )
+        rows = [
+            PriceRow(date(2024, 1, 1), {ticker: Decimal("100")}),
+            PriceRow(date(2024, 12, 30), {ticker: Decimal("100")}),
+        ]
+        return simulate(rows, strategy).value_history[-1].total_value
+
+    # 999 * 0,035 = 34,965 bzw. 999 * 0,013 = 12,987
+    assert endwert("IQQ6") == Decimal("1033.965")
+    assert endwert("IUSA") == Decimal("1011.987")
+
+
+def test_ohne_hinterlegte_rendite_gilt_weiterhin_der_platzhalter():
+    """Der Pauschal-Platzhalter bleibt der Rueckfallwert fuer ausschuettende
+    Instrumente ohne eigenen Satz - #74 entfernt ihn nicht, es gilt nur nicht
+    mehr derselbe Wert fuer alle."""
+    inst = Instrument("XTEST", "Testinstrument", None, ausschuettend=True)
+    assert inst.dividendenrendite is None
+    INSTRUMENTS["XTEST"] = inst
+    try:
+        strategy = Strategy(
+            name="Test-Platzhalter",
+            startkapital=Decimal("1000"),
+            toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={"XTEST": Decimal("1")})],
+            ziel_topf="TopfX",
+            ziel_gewicht=Decimal("1"),
+            rebalancing_schwelle_pp=Decimal("100"),
+            optimierungen=Optimierungen(steueroptimierung=False),
+        )
+        rows = [
+            PriceRow(date(2024, 1, 1), {"XTEST": Decimal("100")}),
+            PriceRow(date(2024, 12, 30), {"XTEST": Decimal("100")}),
+        ]
+        # 999 * DIVIDENDENRENDITE_PLATZHALTER (2,5%) = 24,975
+        assert simulate(rows, strategy).value_history[-1].total_value == Decimal("1023.975")
+    finally:
+        del INSTRUMENTS["XTEST"]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,7 +13,7 @@ Barbell-spezifischen Annahmen fest einprogrammiert hat.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 
 from boersenspiel.engine import simulate
@@ -398,7 +398,7 @@ def test_vorabpauschale_verbraucht_freibetrag_ohne_verkauf():
         ziel_topf="TopfX",
         ziel_gewicht=Decimal("1"),
         rebalancing_schwelle_pp=Decimal("100"),
-        optimierungen=Optimierungen(steueroptimierung=False),
+        optimierungen=Optimierungen(steueroptimierung=False, fondskosten=False),
     )
     rows = [
         PriceRow(date(2024, 1, 1), {"EUNL": Decimal("100")}),
@@ -765,7 +765,10 @@ def test_ausschuettende_instrumente_nutzen_ihre_eigene_rendite():
             ziel_topf="TopfX",
             ziel_gewicht=Decimal("1"),
             rebalancing_schwelle_pp=Decimal("100"),
-            optimierungen=Optimierungen(steueroptimierung=False),
+            # fondskosten=False: dieser Test prueft ausschliesslich die
+            # Ausschuettung, die TER der beiden ETFs wuerde den Endwert sonst
+            # zusaetzlich mindern (siehe eigene TER-Tests unten).
+            optimierungen=Optimierungen(steueroptimierung=False, fondskosten=False),
         )
         rows = [
             PriceRow(date(2024, 1, 1), {ticker: Decimal("100")}),
@@ -803,3 +806,71 @@ def test_ohne_hinterlegte_rendite_gilt_weiterhin_der_platzhalter():
         assert simulate(rows, strategy).value_history[-1].total_value == Decimal("1023.975")
     finally:
         del INSTRUMENTS["XTEST"]
+
+
+# --- Laufende Fondskosten / TER (#76) ---------------------------------------
+
+
+def _ter_strategie(ticker: str, fondskosten: bool) -> Strategy:
+    return Strategy(
+        name=f"Test-TER-{ticker}-{fondskosten}",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={ticker: Decimal("1")})],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+        optimierungen=Optimierungen(
+            steueroptimierung=False, besteuerung=False, fondskosten=fondskosten
+        ),
+    )
+
+
+def _ter_rows(ticker: str, wochen: int) -> list[PriceRow]:
+    return [
+        PriceRow(date(2024, 1, 1) + timedelta(weeks=i), {ticker: Decimal("100")})
+        for i in range(wochen)
+    ]
+
+
+def test_ter_mindert_den_bestand_woechentlich_pro_rata():
+    # EXXY: TER 0,46% p.a., thesaurierend (schuettet also nichts aus, was den
+    # Endwert ueberlagern wuerde). Bei konstantem Kurs ueber 53 Zeilen
+    # (= 52 Wochen Haltedauer, die erste Zeile ist der Kauftag) muss der
+    # Bestand um (1 - 0,0046/52)^52 schrumpfen - von Hand nachgerechnet.
+    rows = _ter_rows("EXXY", 53)
+    result = simulate(rows, _ter_strategie("EXXY", fondskosten=True))
+
+    einsatz = Decimal("999")  # 1000 minus 1 EUR Ordergebuehr
+    erwartet = einsatz * (1 - Decimal("0.0046") / Decimal(52)) ** 52
+    ist = result.value_history[-1].total_value
+    assert abs(ist - erwartet) < Decimal("0.0001")
+    # Groessenordnung: rund 0,46% weniger als ohne Kosten.
+    assert Decimal("0.0044") < (einsatz - ist) / einsatz < Decimal("0.0047")
+
+
+def test_ter_schalter_aus_reproduziert_das_verhalten_ohne_fondskosten():
+    rows = _ter_rows("EXXY", 53)
+    ohne = simulate(rows, _ter_strategie("EXXY", fondskosten=False))
+    assert ohne.value_history[-1].total_value == Decimal("999")
+
+
+def test_instrumente_ohne_ter_bleiben_unberuehrt():
+    # Einzelaktien und physisches Gold tragen keine Fondsgebuehr - fuer sie
+    # darf der Schalter nichts aendern.
+    for ticker in ("TSLA", "4GLD", "BTC-EUR"):
+        assert INSTRUMENTS[ticker].ter == Decimal("0"), ticker
+        rows = _ter_rows(ticker, 53)
+        mit = simulate(rows, _ter_strategie(ticker, fondskosten=True))
+        ohne = simulate(rows, _ter_strategie(ticker, fondskosten=False))
+        assert mit.value_history[-1].total_value == ohne.value_history[-1].total_value
+
+
+def test_teure_und_guenstige_fonds_werden_unterschiedlich_belastet():
+    # Der Kern des Befunds aus #76: die Saetze liegen um eine Groessenordnung
+    # auseinander (IBCI 0,09% gegen EXXY 0,46%; beide thesaurierend, damit die
+    # Ausschuettung den Vergleich nicht ueberlagert). Ohne TER waeren beide
+    # gleich - und der guenstige Baustein damit relativ zu schlecht dargestellt.
+    guenstig = simulate(_ter_rows("IBCI", 53), _ter_strategie("IBCI", fondskosten=True))
+    teuer = simulate(_ter_rows("EXXY", 53), _ter_strategie("EXXY", fondskosten=True))
+
+    assert guenstig.value_history[-1].total_value > teuer.value_history[-1].total_value


### PR DESCRIPTION
Prüfung des Projekts aus der Perspektive, mit der es benutzt werden soll: *Welche Strategie maximiert langfristig die Rendite?* Vier Stellen führten dabei zu falschen Entscheidungen, alle vier sind hier behoben. Sie sind in der Reihenfolge ihrer Wirkung abgearbeitet.

## Wo das Projekt trägt

Vorweg, weil die Fixes das sonst überzeichnen: Die Grundarchitektur ist für diese Frage ungewöhnlich belastbar. `simulate()` ist eine reine Funktion ohne I/O — identische Kurshistorie plus Strategie ergibt immer dasselbe Ergebnis. Es wird nur die Rohdatenreihe persistiert, alles Abgeleitete bei jedem Build neu gerechnet, sodass keine Kennzahl gegenüber dem Code veralten kann. `Decimal` statt `float` für jede Geld-Arithmetik. Deutsche Steuerlogik in einer Tiefe, die man in Backtest-Spielzeug fast nie sieht (Teilfreistellung, Vorabpauschale, § 23-Freigrenze mit Kippeffekt). Die Prämissen-Seite benennt Rückschaufehler und fehlende Konfidenzintervalle von sich aus, und `_real_investierbarer_zeitraum()` (#63) nimmt den Look-ahead-Bias tatsächlich heraus, statt ihn nur zu erwähnen. Die Fixes unten setzen genau darauf auf.

## 1. Die Übersichtstabelle verglich unterschiedliche Zeiträume miteinander (#73)

Der schwerwiegendste Befund, weil er das Vorzeichen der Aussage dreht.

`_real_investierbarer_zeitraum()` schneidet die Historie je Strategie auf den Zeitraum zu, ab dem deren komplettes Instrumentenset handelbar war. Richtig — nur sind die Zeiträume danach sehr verschieden: der S&P-500-Benchmark braucht nur `IUSA` und lief über **20 Jahre ab 2006**, jede Barbell-Strategie erst **ab 2021**. Die nach CAGR sortierte Tabelle stellte beides nebeneinander, als wäre es dasselbe — ausgerechnet in der Zeile, an der jede Anlageentscheidung hängt.

Der Benchmark schaffte über sein 20-Jahres-Fenster 12,3 % p.a., über das Fenster der übrigen Strategien aber 14,2 %. Sechs Regeln, die die Seite als „schlägt den Index" auswies, lagen auf vergleichbarer Basis darunter.

Die Übersicht bekommt deshalb eine Leitspalte **„CAGR % p.a. im Vergleichszeitraum"**: jede Strategie zusätzlich frisch simuliert ab dem spätesten Startdatum aller angezeigten Strategien (mechanisch analog zu `_walk_forward_segmente()` / `_zeitraum_presets()`), Sortierung danach. Daneben eine Spalte **„Überrendite pp p.a."** gegen die Benchmark-Strategie im selben Zeitraum, plus den tatsächlichen eigenen Zeitraum je Zeile. Unter `_VERGLEICH_MIN_WOCHEN` entfällt die Spalte still, statt aus wenigen Wochen zu annualisieren; ohne Benchmark unter den angezeigten Strategien entfällt die Überrendite, statt gegen eine willkürlich gewählte andere Strategie zu rechnen.

## 2. Pauschale Dividende auf Titel, die keine zahlen (#74)

`apply_dividende()` schrieb jedem Instrument mit `ausschuettend=True` denselben Satz von 2,5 % p.a. gut. Sieben der zehn Satelliten-Aktien (Tesla, Rivian, Palantir, Strategy, SolarEdge, Lumentum, SMA Solar) zahlen real gar keine Dividende und bekamen jährlich Geld geschenkt. Umgekehrt waren Anleihen- und Immobilien-ETFs, deren laufender Ertrag zum großen Teil *gerade* aus der Ausschüttung besteht, deutlich zu niedrig angesetzt — ebenso `IUSA` mit 2,5 % statt real ~1,3 %, also die Vergleichslinie selbst.

Die Verzerrung war damit nicht zufällig, sondern gerichtet: sie begünstigte ausschüttungslose Wachstumswerte gegenüber genau den defensiven Bausteinen, die eine Barbell-Strategie überhaupt rechtfertigen. Allein die Phantom-Dividende der Nicht-Zahler machte am Einzelaktien-Satelliten 2,7 pp CAGR aus.

Neu ist `Instrument.dividendenrendite` je Instrument (aus öffentlichen Fact-Sheets); echte Nicht-Zahler stehen auf `ausschuettend=False`. Der bisherige Pauschalwert bleibt Rückfall für Instrumente ohne eigenen Satz. Verbleibende, jetzt aber ungerichtete Vereinfachung: der Satz ist je Instrument über die ganze Historie konstant.

## 3. Risikofreier Zins fest auf 0 % (#75)

Sharpe und Sortino rechneten gegen 0 %. Damit waren sie faktisch „Rendite ÷ Risiko" statt „*Über*rendite ÷ Risiko" — die eine Frage, die eine Sharpe-Ratio beantwortet (*werde ich für das Risiko besser bezahlt als fürs risikolose Parken?*), konnte per Konstruktion nie mit „nein" beantwortet werden. Der Fehler wirkte zudem ungleich: er hob Strategien mit geringer Volatilität am stärksten an, also gerade die defensiven, deren Rendite dem Geldmarkt am nächsten liegt.

Der Zins kommt jetzt aus `XEON` (EUR-Geldmarkt-ETF), der ohnehin mit durchgehender Historie seit 2007 in `price_history.csv` liegt und per Definition den Tagesgeldsatz abbildet. Seine eigene CAGR über exakt den ausgewerteten Zeitraum ist der passende Referenzzins und zieht bei jedem Build mit dem Zinsumfeld mit: gemessen 0,76 % über 2006–2026, 2,05 % über 2021–2026. Derselbe Grundsatz wie auf der Prämissen-Seite — nichts hinterlegen, was gegenüber den Daten veralten kann. Der Platzhalter bleibt Rückfall.

Nebenbefund: `_wochenrenditen()` liefert Brüche, während die übrigen Kennzahlen in Prozentpunkten rechnen. Der Zins wird vor dem Abzug umgerechnet, mit Kommentar an beiden Stellen.

## 4. Laufende Fondskosten nicht modelliert (#76)

Stand unter „nicht modelliert", war für die Rangfolge aber kein neutraler Verzicht: die Sätze liegen um eine Größenordnung auseinander (IUSA 0,07 % gegen IQQ6 0,59 %), der Benchmark ist damit das günstigste Instrument im ganzen Feld, und der Einzelaktien-Satellit trägt gar keine Fondsgebühr — begünstigt wurde also ausgerechnet die konzentrierteste Variante.

`Instrument.ter` wird wöchentlich pro rata abgezogen, als Reduktion der **Stückzahl** statt eines Barabflusses (der Anleger zahlt die TER nicht aus der Tasche, sein Anteil am Fondsvermögen wird kleiner); die Kostenbasis bleibt bewusst unverändert. Als fünfter `Optimierungen`-Schalter, damit der isolierte Effekt über die bestehende Leave-one-out-Auswertung auf jeder Detailseite sichtbar wird, statt behauptet zu werden. Depotgebühren und Ausgabeaufschläge bleiben unmodelliert.

## Ergebnis auf der realen Historie

Vergleichszeitraum 2021-11-21 → 2026-08-21, alle vier Fixes wirksam:

| Strategie | CAGR % p.a. | Überrendite pp |
|---|---:|---:|
| Barbell 20/60/20 + Einzelaktien-Satellit | +20,79 | +9,32 |
| Börsenweisheit: Buy the Dip | +17,53 | +6,06 |
| Barbell 20/80 | +16,27 | +4,80 |
| … | | |
| Börsenweisheit: Sell in May | +11,91 | +0,43 |
| **Benchmark: S&P 500 (Buy & Hold)** | **+11,47** | – |
| Börsenweisheiten (alle fünf kombiniert) | +11,23 | **−0,24** |
| Charttechnik: SMA-Crossover (4/20 Wochen) | +10,62 | **−0,85** |
| Barbell 20/80 (breiter diversifiziert) | +10,09 | **−1,38** |

Drei Regeln weisen jetzt eine negative Überrendite aus, die vorher als besser-als-der-Index dastanden. Die verbliebenen Überrenditen sind kleiner als zuvor und bleiben, wie die Prämissen-Seite sagt, aus einer einzigen, kurzen Kurshistorie geschätzt.

## Was bewusst offen bleibt

- Die Risikospalten (Volatilität, Max Drawdown, Sharpe, Sortino) beziehen sich weiterhin auf den jeweils **eigenen** Zeitraum der Strategie, nicht auf den Vergleichszeitraum. Die Tabelle weist den Zeitraum je Zeile aus, damit das sichtbar ist; eine Umstellung auch dieser Spalten wäre der nächste Schritt.
- Spread/Slippage und Depotgebühren sind weiterhin nicht modelliert.
- `VORABPAUSCHALE_BASISZINS_PLATZHALTER` bleibt ein Platzhalter statt echter BMF-Jahreswerte.

## Dokumentation

README, CLAUDE.md und die Dashboard-Texte sind auf alle vier Änderungen nachgezogen. Beim Durchgehen fiel dabei eine Stelle auf, die **schon vor diesem PR veraltet** war: der README-Abschnitt zu den strategieübergreifenden Mechanismen beschrieb diese weiterhin als „not toggleable" und #17 als offenen Vorschlag — tatsächlich ist #17 längst umgesetzt und jede Detailseite weist die Leave-one-out-Effekte aus. Die Tabelle nennt jetzt alle fünf Schalter samt Feldnamen und den tatsächlichen Stand.

Ebenso korrigiert: zwei Passagen in CLAUDE.md, die den neu ergänzten Abschnitten in derselben Datei widersprachen (`_RISIKOFREIER_ZINS_PLATZHALTER` als *die* Quelle des Zinses; Prämissen-Seite als „TER wird nicht modelliert"), der Text „Effekt der Optimierungs-Schalter" auf den Detailseiten, der die Mechanismen einzeln aufzählte, sowie der CLAUDE.md-Testkatalog. `docs/` ist nicht versioniert — die Seiten baut der Workflow beim Deploy; die gerenderten Seiten wurden lokal gegengeprüft, dass keine der alten Formulierungen mehr vorkommt.

## Tests

243 Tests grün (`pytest -q`), davon 16 neue. Die neuen Kennzahlen sind gegen handgerechnete Grenzfälle geprüft (TER-Abzug gegen `(1 − TER/52)^52`, Zins-Ableitung gegen eine konstruierte 4 %-Geldmarktreihe, Vergleichszeitraum gegen eine Reihe mit unterschiedlichen Startdaten), nicht nur als Smoke-Tests. Bestehende handgerechnete Engine-Tests, die ETFs verwenden, setzen `fondskosten=False`, damit sie weiterhin genau ihren eigenen Mechanismus prüfen; die zwei Dividendentests sind auf KOs neuen Satz nachgerechnet.