### PR TITLE
#78: Risikokennzahlen der Übersicht aus dem gemeinsamen Vergleichszeitraum

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,10 +661,31 @@ inkrementell fortgeschrieben).
   `build_dashboard()` legt daraus `vergleich_cagr_*` und `alpha_pp_*` (gegen
   die erste verfügbare Strategie aus `BENCHMARK_STRATEGIEN`) in jede View und
   sortiert die Übersicht danach. Unter `_VERGLEICH_MIN_WOCHEN` entfällt die
-  Spalte still, statt aus wenigen Wochen zu annualisieren. **Wichtig:** Die
-  Risikospalten (Volatilität/Max-Drawdown/Sharpe/Sortino) beziehen sich
-  weiterhin auf den jeweils eigenen Zeitraum — die Tabelle weist ihn deshalb
-  je Zeile mit aus.
+  Spalte still, statt aus wenigen Wochen zu annualisieren.
+  **Risikokennzahlen ebenfalls aus dem Vergleichszeitraum (#78):** Zunächst
+  galt das nur für die Rendite, Volatilität/Max-Drawdown/Sharpe/Sortino blieben
+  auf dem eigenen Zeitraum und wurden nur je Zeile gekennzeichnet — das
+  reichte nicht. Der Effekt trifft praktisch nur die Benchmark-Zeile (alle
+  übrigen Strategien liegen ohnehin fast ganz im gemeinsamen Fenster), war
+  dort aber groß genug, die Aussage der Tabelle zu drehen: Max Drawdown des
+  S&P-500-Benchmarks −51,95% über die eigene Historie (enthält 2008) gegen
+  −21,21% über den gemeinsamen Zeitraum, womit der Index vom scheinbar
+  riskantesten zu einem der risikoärmsten wird — aus vermeintlicher Dominanz
+  der Barbell-Strategien auf beiden Achsen wird ein echter
+  Rendite-Risiko-Tausch. Ein Sharpe-Paarvergleich kippte ebenfalls (0,76 gegen
+  0,64 wurde zu 0,66 gegen 0,66), weil für die beiden Zeiträume
+  unterschiedliche risikofreie Zinsen gelten (#75). `_vergleichs_cagr_pct()`
+  heißt deshalb jetzt `_vergleichs_kennzahlen()` und liefert das komplette
+  Bündel (CAGR/Vola/MaxDD/Sharpe/Sortino plus den Zins des Ausschnitts) statt
+  nur die CAGR — die Wertreihe des Vergleichslaufs lag ohnehin vor und wurde
+  bis dahin verworfen. **Beim Ändern beachten:** die Werte landen unter
+  eigenen `vergleich_*`-Feldnamen in der View. Die gleichnamigen Felder ohne
+  Präfix beschreiben weiter den eigenen Zeitraum und werden anderswo gebraucht
+  (Detailseite: Startwerte der Kacheln in „Kennzahlen nach
+  Betrachtungszeitraum"; Prämissen-Seite: risikofreier Zins der eigenen
+  Simulation) — sie zu überschreiben verfälscht beide. Die Übersichtstabelle
+  zeigt ausschließlich Vergleichszeitraum-Werte (Owner-Entscheidung), die
+  Eigen-Zeitraum-Kennzahlen bleiben vollständig auf der Detailseite.
   **Risikofreier Zins (#75):** `_risikofreier_zins_pct(rows)` leitet ihn aus
   dem EUR-Geldmarkt-ETF `_GELDMARKT_TICKER` (`XEON`, durchgehende Historie
   seit 2007) über exakt den ausgewerteten Zeitraum ab, statt ihn zu

--- a/README.md
+++ b/README.md
@@ -631,15 +631,23 @@ pytest -q
   so it could never show that a strategy failed to beat the money market —
   and it lifted low-volatility strategies most, i.e. exactly the defensive
   ones.
-- **Returns are only comparable within the common comparison period.** Each
-  strategy is simulated over the window in which its full instrument set was
-  actually tradeable, and those windows differ substantially (the S&P 500
+- **The overview table reports everything over a common comparison period.**
+  Each strategy is simulated over the window in which its full instrument set
+  was actually tradeable, and those windows differ substantially (the S&P 500
   benchmark needs only `IUSA` and runs from 2006; every barbell strategy
-  starts in 2021). The overview table's lead column therefore re-simulates
-  every strategy from the latest of those start dates and sorts by that
-  ([#73](https://github.com/S540d/Boersenspiel/issues/73)); the per-strategy
-  CAGR and the risk columns still refer to each strategy's own window, which
-  the table shows alongside them.
+  starts in 2021). The overview therefore re-simulates every strategy from the
+  latest of those start dates and reports **return and risk** from that single
+  run — CAGR, volatility, max drawdown, Sharpe, Sortino
+  ([#73](https://github.com/S540d/Boersenspiel/issues/73),
+  [#78](https://github.com/S540d/Boersenspiel/issues/78)) — sorted by it, with
+  the excess return over the benchmark alongside. Applying this to the risk
+  columns too was not cosmetic: over its own 20-year window the benchmark
+  carries a −51.95% max drawdown (the 2008 crisis, which no other strategy
+  lived through) against roughly −30% for the barbell strategies; over the
+  common window it is −21.21%, making the index one of the *least* risky
+  entries rather than by far the riskiest. Each strategy's own-window CAGR
+  stays as a secondary column, and its full own-window metrics remain on its
+  detail page under "Kennzahlen nach Betrachtungszeitraum".
 - **`BTC-EUR` history is far shorter than requested:** the 20-year backfill
   yields only ~50 weeks (from 2025-09-14), so Bitcoin is first bought near
   its high rather than across the full period — see

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -505,7 +505,7 @@ def _cagr_pct(rendite_pct: float, tage: int) -> float:
     return (faktor ** (1 / jahre) - 1) * 100
 
 
-# --- Gemeinsamer Vergleichszeitraum (#73) -----------------------------------------
+# --- Gemeinsamer Vergleichszeitraum (#73, Risikokennzahlen #78) --------------------
 #
 # _real_investierbarer_zeitraum() (F4, #63) schneidet die Historie JE STRATEGIE auf
 # den Zeitraum zu, ab dem deren komplettes Instrumentenset handelbar war. Das ist fuer
@@ -526,6 +526,31 @@ def _cagr_pct(rendite_pct: float, tage: int) -> float:
 # gemeinsamen Startdatum aller angezeigten Strategien - frisch, mit eigenem
 # Startkapital, exakt nach demselben Muster wie _walk_forward_segmente() und
 # _zeitraum_presets(). Die Uebersichtstabelle sortiert danach.
+#
+# #78: Das gilt seither fuer RENDITE UND RISIKO. Zunaechst waren nur die
+# Renditespalten umgestellt, Volatilitaet/Max-Drawdown/Sharpe/Sortino blieben auf
+# dem jeweils eigenen Zeitraum und wurden nur mit ausgewiesenem Zeitraum je Zeile
+# gekennzeichnet. Das reichte nicht: der Effekt konzentriert sich fast vollstaendig
+# auf die Benchmark-Zeile (alle uebrigen Strategien liegen ohnehin fast ganz im
+# gemeinsamen Fenster), und dort war er gross genug, um die Aussage der Tabelle zu
+# drehen - der Max Drawdown des S&P-500-Benchmarks stand bei -51,95% (enthaelt die
+# Finanzkrise 2008) gegenueber rund -30% der Barbell-Strategien, auf gleicher Basis
+# sind es -21,21%. Der Index sah damit als einziger sowohl renditeschwaecher als
+# auch mit Abstand riskanter aus, war auf vergleichbarer Basis aber der mit dem
+# GERINGSTEN Drawdown im Feld: aus scheinbarer Dominanz der Barbell-Strategien auf
+# beiden Achsen wird ein echter Rendite-Risiko-Tausch - genau die Abwaegung, um die
+# es bei einer Barbell-Strategie ueberhaupt geht. Auch ein Sharpe-Paarvergleich
+# kippte (0,76 gegen 0,64 wurde zu 0,66 gegen 0,66), weil fuer die beiden Zeitraeume
+# unterschiedliche risikofreie Zinsen gelten (0,76% ueber 20 Jahre, 2,05% ueber 5,
+# siehe #75). Ein je Zeile ausgewiesener Zeitraum macht das nachvollziehbar, aber
+# nicht aufloesbar - aus "2006-2026" laesst sich nicht ableiten, wie gross der
+# Drawdown ohne 2008 gewesen waere.
+#
+# Die Uebersichtstabelle zeigt deshalb AUSSCHLIESSLICH Vergleichszeitraum-Werte
+# (Owner-Entscheidung zu #78). Die Kennzahlen ueber den jeweils eigenen Zeitraum
+# einer Strategie gehen dadurch nicht verloren: sie stehen weiterhin auf deren
+# Detailseite im Abschnitt "Kennzahlen nach Betrachtungszeitraum" (#54), dessen
+# Preset "Gesamte Historie" genau die volle eigene Historie abbildet.
 
 # Unter dieser Laenge ist ein gemeinsamer Zeitraum keine belastbare Aussage mehr -
 # dann entfaellt die Spalte, statt eine aus wenigen Wochen annualisierte Zahl zu
@@ -540,16 +565,37 @@ def _gemeinsamer_beginn(strategie_rows: dict[str, list[PriceRow]]) -> date | Non
     return max(beginne) if beginne else None
 
 
-def _vergleichs_cagr_pct(
+def _vergleichs_kennzahlen(
     strategy: Strategy, rows: list[PriceRow], beginn: date
-) -> float | None:
-    """CAGR dieser Strategie, frisch simuliert ab ``beginn``. ``None``, wenn der
-    verbleibende Zeitraum zu kurz fuer eine belastbare Annualisierung ist."""
+) -> dict | None:
+    """ALLE Kennzahlen dieser Strategie, frisch simuliert ab ``beginn`` - Rendite
+    UND Risiko. ``None``, wenn der verbleibende Zeitraum zu kurz fuer eine
+    belastbare Annualisierung ist.
+
+    Lieferte bis #78 nur die CAGR und verwarf die Wertreihe des Vergleichslaufs,
+    obwohl die Risikokennzahlen daraus ohne weitere Simulation ableitbar sind. Das
+    war nicht bloss ungenutztes Potenzial, sondern liess die Uebersichtstabelle
+    Rendite und Risiko aus zwei VERSCHIEDENEN Zeitraeumen nebeneinanderstellen -
+    siehe den Kommentar an ``_VERGLEICH_MIN_WOCHEN`` oben und #78.
+
+    Der risikofreie Zins fuer Sharpe/Sortino kommt aus genau diesem Ausschnitt
+    (#75), nicht aus dem eigenen Zeitraum der Strategie - sonst waere die
+    Ueberrendite gegen einen Zins gemessen, der in diesem Fenster gar nicht galt.
+    """
     ausschnitt = [r for r in rows if r.date >= beginn]
     if len(ausschnitt) < _VERGLEICH_MIN_WOCHEN:
         return None
     result = simulate(ausschnitt, strategy)
-    return _cagr_pct(_f(_rendite_pct(result, strategy)), _tage_zwischen(result))
+    total_values = [_f(vp.total_value) for vp in result.value_history]
+    zins_pct = _risikofreier_zins_pct(ausschnitt)
+    return {
+        "cagr_pct": _cagr_pct(_f(_rendite_pct(result, strategy)), _tage_zwischen(result)),
+        "volatilitaet_pct": _volatilitaet_pct(total_values),
+        "max_drawdown_pct": _max_drawdown_pct(total_values),
+        "sharpe_ratio": _sharpe_ratio(total_values, zins_pct),
+        "sortino_ratio": _sortino_ratio(total_values, zins_pct),
+        "risikofreier_zins_pct": zins_pct,
+    }
 
 
 def _optimierungs_effekte(
@@ -956,10 +1002,10 @@ def build_dashboard(
     # Uebersichtstabelle Gleiches mit Gleichem vergleicht. Siehe _gemeinsamer_beginn().
     beginn = _gemeinsamer_beginn(strategie_rows)
     benchmark_namen = {b.name for b in BENCHMARK_STRATEGIEN}
-    vergleich_cagr: dict[str, float | None] = {}
+    vergleich: dict[str, dict | None] = {}
     if beginn is not None:
         for s in strategies:
-            vergleich_cagr[s.name] = _vergleichs_cagr_pct(s, strategie_rows[s.name], beginn)
+            vergleich[s.name] = _vergleichs_kennzahlen(s, strategie_rows[s.name], beginn)
     # Referenzlinie fuer die Ueberrendite: die erste Benchmark-Strategie, die im
     # gemeinsamen Zeitraum ueberhaupt eine Zahl liefert. Steht keine zur Verfuegung
     # (kein Benchmark unter den angezeigten Strategien), entfaellt die Spalte still,
@@ -967,15 +1013,37 @@ def build_dashboard(
     benchmark_cagr: float | None = None
     benchmark_label: str | None = None
     for s in strategies:
-        if s.name in benchmark_namen and vergleich_cagr.get(s.name) is not None:
-            benchmark_cagr = vergleich_cagr[s.name]
+        kennzahlen = vergleich.get(s.name)
+        if s.name in benchmark_namen and kennzahlen is not None:
+            benchmark_cagr = kennzahlen["cagr_pct"]
             benchmark_label = s.name
             break
 
     for view in views:
-        wert = vergleich_cagr.get(view["name"])
+        k = vergleich.get(view["name"])
+        wert = k["cagr_pct"] if k is not None else None
         view["vergleich_cagr_pct"] = wert
         view["vergleich_cagr_label"] = f"{wert:+.2f}" if wert is not None else "–"
+        # #78: Auch die Risikokennzahlen der UEBERSICHT stammen aus dem gemeinsamen
+        # Zeitraum - aber bewusst unter EIGENEN Feldnamen. Die gleichnamigen Felder
+        # ohne Praefix beschreiben weiterhin den eigenen Zeitraum der Strategie und
+        # werden anderswo gebraucht: die Detailseite nutzt sie als Startwerte der
+        # Kacheln im Abschnitt "Kennzahlen nach Betrachtungszeitraum" (#54, Preset
+        # "Gesamte Historie"), die Praemissen-Seite den risikofreien Zins der
+        # eigenen Simulation. Sie hier zu ueberschreiben wuerde beide verfaelschen.
+        view["vergleich_volatilitaet_label"] = (
+            f"{k['volatilitaet_pct']:.2f}" if k is not None else None
+        )
+        view["vergleich_max_drawdown_pct"] = k["max_drawdown_pct"] if k is not None else None
+        view["vergleich_max_drawdown_label"] = (
+            (f"{-k['max_drawdown_pct']:.2f}" if k["max_drawdown_pct"] else "0.00")
+            if k is not None
+            else None
+        )
+        view["vergleich_sharpe_ratio"] = k["sharpe_ratio"] if k is not None else None
+        view["vergleich_sharpe_label"] = f"{k['sharpe_ratio']:.2f}" if k is not None else None
+        view["vergleich_sortino_ratio"] = k["sortino_ratio"] if k is not None else None
+        view["vergleich_sortino_label"] = f"{k['sortino_ratio']:.2f}" if k is not None else None
         if wert is None or benchmark_cagr is None or view["name"] in benchmark_namen:
             view["alpha_pp"] = None
             view["alpha_pp_label"] = "–"
@@ -983,7 +1051,15 @@ def build_dashboard(
             view["alpha_pp"] = wert - benchmark_cagr
             view["alpha_pp_label"] = f"{wert - benchmark_cagr:+.2f}"
 
+    # Der risikofreie Zins des Vergleichszeitraums gilt fuer ALLE Zeilen gleich (es
+    # ist derselbe Zeitraum) - deshalb einmal im Seitenkontext statt je View.
+    vergleich_zins = next(
+        (k["risikofreier_zins_pct"] for k in vergleich.values() if k is not None), None
+    )
     vergleich_kontext = {
+        "vergleich_zins_label": (
+            f"{vergleich_zins:.2f}".replace(".", ",") if vergleich_zins is not None else None
+        ),
         "vergleich_beginn": beginn.isoformat() if beginn is not None else None,
         "vergleich_ende": rows[-1].date.isoformat(),
         "vergleich_benchmark": benchmark_label,

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -49,20 +49,32 @@
       simuliert, in dem ihr komplettes Instrumentenset tatsächlich handelbar war
       (letzte Spalte) &ndash; sonst würde ein 2026 zusammengestelltes Portfolio
       rückwirkend ab 2006 gekauft. Diese Zeiträume sind aber unterschiedlich lang und
-      decken unterschiedliche Marktphasen ab; ihre CAGR-Werte lassen sich deshalb
-      <em>nicht</em> direkt gegeneinander stellen. Die Leitspalte
-      <strong>„CAGR % p.a. im Vergleichszeitraum"</strong> simuliert deshalb jede
-      Strategie zusätzlich ab <strong>{{ vergleich_beginn }}</strong> &ndash; dem
-      spätesten Startdatum aller hier gezeigten Strategien, ab dem also jede von
-      ihnen Kurse hat &ndash; jeweils frisch mit eigenem Startkapital. Nur diese
-      Spalte vergleicht Gleiches mit Gleichem, und nur nach ihr ist die Tabelle
-      sortiert.
+      decken unterschiedliche Marktphasen ab; ihre Kennzahlen lassen sich deshalb
+      <em>nicht</em> direkt gegeneinander stellen. <strong>Rendite und Risiko</strong>
+      werden hier deshalb durchgehend über einen gemeinsamen Zeitraum ausgewiesen:
+      jede Strategie wird zusätzlich ab <strong>{{ vergleich_beginn }}</strong>
+      &ndash; dem spätesten Startdatum aller hier gezeigten Strategien, ab dem also
+      jede von ihnen Kurse hat &ndash; frisch mit eigenem Startkapital simuliert.
+      CAGR, Volatilität, Max Drawdown, Sharpe und Sortino stammen alle aus diesem
+      Lauf und gehören damit zusammen; sortiert ist die Tabelle danach.
       {% if vergleich_benchmark %}
       Die Spalte <strong>„Überrendite pp p.a."</strong> ist die Differenz dazu
       gegenüber „{{ vergleich_benchmark }}" ({{ vergleich_benchmark_label }} % p.a.
       im selben Zeitraum) &ndash; ein negativer Wert heißt, die Strategie hätte den
       Index über diesen Zeitraum <em>nicht</em> geschlagen.
       {% endif %}
+      Warum das auch fürs Risiko nötig ist: eine Strategie mit langer eigener
+      Historie schleppt Krisen mit, die die übrigen nie durchlaufen haben. Über die
+      volle Historie steht der S&amp;P-500-Benchmark bei einem Max Drawdown von rund
+      &minus;52 % (Finanzkrise 2008) gegenüber rund &minus;30 % der
+      Barbell-Strategien &ndash; über den gemeinsamen Zeitraum sind es rund
+      &minus;21 %, womit er den <em>geringsten</em> Drawdown im Feld hat statt den
+      höchsten. Aus scheinbarer Unterlegenheit auf beiden Achsen wird so ein echter
+      Rendite-Risiko-Tausch.
+      Die <strong>„CAGR % p.a. (eigener Zeitraum)"</strong> steht als Nebenspalte
+      daneben; die vollständigen Kennzahlen über den eigenen Zeitraum einer Strategie
+      stehen auf deren Detailseite im Abschnitt „Kennzahlen nach
+      Betrachtungszeitraum".
       Ein kurzer Vergleichszeitraum bleibt eine schmale Datenbasis: er zeigt, wie
       sich die Strategien im selben Marktumfeld verhalten haben, nicht wie sie sich
       künftig verhalten werden.
@@ -81,30 +93,42 @@
       Sharpe teilt die annualisierte Rendite durch die gesamte Streuung, Sortino nur
       durch die Streuung der Verlustwochen (Streuung nach oben zählt dort nicht als
       Risiko). Höher ist besser; negativ heißt, das eingegangene Risiko hat sich
-      gegenüber risikolosem Parken nicht gelohnt. Der risikofreie Zins dafür wird
-      aus dem EUR-Geldmarkt-ETF über den jeweils ausgewerteten Zeitraum abgeleitet
-      (siehe Prämissen), nicht fest angenommen. Alle Renditewerte hier sind
+      gegenüber risikolosem Parken nicht gelohnt. Der risikofreie Zins dafür wird aus
+      dem EUR-Geldmarkt-ETF über den ausgewerteten Zeitraum abgeleitet (siehe
+      Prämissen), nicht fest angenommen &ndash; hier also
+      {% if vergleich_zins_label %}{{ vergleich_zins_label }} % p.a. über den
+      Vergleichszeitraum, einheitlich für alle Zeilen{% else %}je Zeile über deren
+      eigenen Zeitraum{% endif %}. Alle Renditewerte hier sind
       Bruttowerte (vor Steuer) - die geschätzte Nettorendite je Strategie
       steht auf der jeweiligen Detailseite.
     </p>
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
     <div class="overflow-x">
       <table class="summary-table">
-        <thead><tr><th>Strategie / Szenario</th>{% if vergleich_verfuegbar %}<th>CAGR % p.a. im Vergleichszeitraum</th><th>&Uuml;berrendite pp p.a.</th>{% endif %}<th>CAGR % p.a. (eigener Zeitraum)</th><th>Gesamtrendite % (brutto)</th><th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th><th>Eigener Zeitraum</th></tr></thead>
+        <thead><tr><th>Strategie / Szenario</th>{% if vergleich_verfuegbar %}<th>CAGR % p.a. (Vergleichszeitraum)</th><th>&Uuml;berrendite pp p.a.</th>{% endif %}<th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>CAGR % p.a. (eigener Zeitraum)</th><th>Gesamtrendite % (brutto)</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th><th>Eigener Zeitraum</th></tr></thead>
         <tbody>
         {% for s in summary %}
           <tr>
             <td><a href="{{ s.id }}.html">{{ s.name }}</a></td>
             {% if vergleich_verfuegbar %}
-            <td class="{{ ('positive' if s.vergleich_cagr_pct >= 0 else 'negative') if s.vergleich_cagr_pct is not none else '' }}"><strong>{{ s.vergleich_cagr_label }}</strong></td>
+            {# Rendite UND Risiko aus dem gemeinsamen Vergleichszeitraum (#73/#78) -
+               nur so gehoeren die Zahlen einer Zeile ueberhaupt zusammen. #}
+            <td class="{{ ('positive' if s.vergleich_cagr_pct >= 0 else 'negative') if s.vergleich_cagr_pct is not none else '' }}"><strong>{{ s.vergleich_cagr_label or '–' }}</strong></td>
             <td class="{{ ('positive' if s.alpha_pp >= 0 else 'negative') if s.alpha_pp is not none else '' }}">{{ s.alpha_pp_label }}</td>
-            {% endif %}
-            <td class="{{ 'positive' if s.cagr_pct >= 0 else 'negative' }}">{{ s.cagr_label }}</td>
-            <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
+            <td>{{ s.vergleich_volatilitaet_label or '–' }}</td>
+            <td class="{{ 'negative' if s.vergleich_max_drawdown_pct else '' }}">{{ s.vergleich_max_drawdown_label or '–' }}</td>
+            <td class="{{ ('positive' if s.vergleich_sharpe_ratio >= 0 else 'negative') if s.vergleich_sharpe_ratio is not none else '' }}">{{ s.vergleich_sharpe_label or '–' }}</td>
+            <td class="{{ ('positive' if s.vergleich_sortino_ratio >= 0 else 'negative') if s.vergleich_sortino_ratio is not none else '' }}">{{ s.vergleich_sortino_label or '–' }}</td>
+            {% else %}
+            {# Kein gemeinsamer Zeitraum ermittelbar - dann gelten durchgehend die
+               Werte des jeweils eigenen Zeitraums, klar so beschriftet. #}
             <td>{{ s.volatilitaet_label }}</td>
             <td class="{{ 'negative' if s.max_drawdown_pct else '' }}">{{ s.max_drawdown_label }}</td>
             <td class="{{ 'positive' if s.sharpe_ratio >= 0 else 'negative' }}">{{ s.sharpe_label }}</td>
             <td class="{{ 'positive' if s.sortino_ratio >= 0 else 'negative' }}">{{ s.sortino_label }}</td>
+            {% endif %}
+            <td class="{{ 'positive' if s.cagr_pct >= 0 else 'negative' }}">{{ s.cagr_label }}</td>
+            <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.gewinn_label }}</td>
             <td>{{ s.total_value }}</td>
             <td class="hint-cell">{{ s.sim_beginn }} &ndash; {{ s.sim_ende }}<br>({{ s.sim_jahre_label }} Jahre)</td>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -8,6 +8,7 @@ kommt aus ``engine.simulate()``).
 
 from __future__ import annotations
 
+import re
 from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -22,10 +23,11 @@ from boersenspiel.dashboard import (
     _cagr_pct,
     _gemeinsamer_beginn,
     _downside_deviation,
+    _f,
     _GELDMARKT_TICKER,
     _jahre_zurueck,
     _VERGLEICH_MIN_WOCHEN,
-    _vergleichs_cagr_pct,
+    _vergleichs_kennzahlen,
     _max_drawdown_pct,
     _ohne_btc_fruehphase,
     _real_investierbarer_zeitraum,
@@ -977,7 +979,7 @@ def test_gemeinsamer_beginn_ist_das_spaeteste_startdatum():
     assert _gemeinsamer_beginn({"A": []}) is None
 
 
-def test_vergleichs_cagr_nutzt_nur_den_zeitraum_ab_dem_gemeinsamen_beginn():
+def test_vergleichs_kennzahlen_nutzen_nur_den_zeitraum_ab_dem_gemeinsamen_beginn():
     # Erst 52 Wochen flach, danach 52 Wochen steigend. Die CAGR ueber die volle
     # Historie muss deutlich unter der CAGR ab dem Anstieg liegen - sonst wuerde
     # der Ausschnitt gar nicht wirken.
@@ -990,17 +992,17 @@ def test_vergleichs_cagr_nutzt_nur_den_zeitraum_ab_dem_gemeinsamen_beginn():
         float(simulate(rows, strategy).value_history[-1].total_value / strategy.startkapital - 1) * 100,
         (rows[-1].date - rows[0].date).days,
     )
-    ausschnitt = _vergleichs_cagr_pct(strategy, rows, date(2021, 1, 4))
+    ausschnitt = _vergleichs_kennzahlen(strategy, rows, date(2021, 1, 4))
 
     assert ausschnitt is not None
-    assert ausschnitt > voll + 10
+    assert ausschnitt["cagr_pct"] > voll + 10
 
 
-def test_vergleichs_cagr_entfaellt_bei_zu_kurzem_gemeinsamem_zeitraum():
+def test_vergleichs_kennzahlen_entfallen_bei_zu_kurzem_gemeinsamem_zeitraum():
     rows = _lange_reihe(date(2020, 1, 6), _VERGLEICH_MIN_WOCHEN + 5, 1.01, "T1")
     zu_kurz = rows[-(_VERGLEICH_MIN_WOCHEN - 1)].date
-    assert _vergleichs_cagr_pct(ZWEI_STRATEGIEN[0], rows, zu_kurz) is None
-    assert _vergleichs_cagr_pct(ZWEI_STRATEGIEN[0], rows, rows[0].date) is not None
+    assert _vergleichs_kennzahlen(ZWEI_STRATEGIEN[0], rows, zu_kurz) is None
+    assert _vergleichs_kennzahlen(ZWEI_STRATEGIEN[0], rows, rows[0].date) is not None
 
 
 def test_uebersichtstabelle_zeigt_vergleichszeitraum_und_ueberrendite(tmp_path: Path):
@@ -1039,7 +1041,7 @@ def test_uebersichtstabelle_zeigt_vergleichszeitraum_und_ueberrendite(tmp_path: 
     # Der gemeinsame Beginn ist der spaetere der beiden Simulationsbeginne.
     gemeinsam = rows[40].date.isoformat()
     assert gemeinsam in html
-    assert "im Vergleichszeitraum" in html
+    assert "Vergleichszeitraum" in html
     # Beide eigenen Zeitraeume stehen als eigene Spalte in der Tabelle.
     assert rows[0].date.isoformat() in html
     assert rows[-1].date.isoformat() in html
@@ -1053,7 +1055,7 @@ def test_ohne_benchmark_strategie_entfaellt_die_ueberrendite_spalte(tmp_path: Pa
     build_dashboard(rows, ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
     html = (tmp_path / "index.html").read_text(encoding="utf-8")
 
-    assert "im Vergleichszeitraum" in html
+    assert "Vergleichszeitraum" in html
     assert "Überrendite pp p.a." not in html
 
 
@@ -1117,3 +1119,104 @@ def test_praemissen_seite_weist_den_zins_je_strategie_aus(tmp_path: Path):
 
     assert "Risikofreier Zins" in html
     assert _GELDMARKT_TICKER in html
+
+
+def test_uebersicht_zeigt_risikokennzahlen_aus_dem_gemeinsamen_zeitraum(tmp_path: Path):
+    """#78: Der Kern des Befunds - eine Strategie mit langer eigener Historie
+    schleppt Krisen mit, die die uebrigen nie durchlaufen haben. Hier stuerzt
+    "Lang" frueh um 60% ab, lange bevor "Spaet" ueberhaupt existiert. Ihr Max
+    Drawdown ueber den eigenen Zeitraum ist deshalb dramatisch, ueber den
+    gemeinsamen dagegen klein - die Uebersicht muss den kleinen zeigen."""
+    lang = ZWEI_STRATEGIEN[0]
+    spaet = Strategy(
+        name="Spaet",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T2": Decimal("1")})],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+
+    rows = []
+    start = date(2020, 1, 6)
+    for i in range(120):
+        # T1 bricht in Woche 10 um 60% ein und erholt sich danach stetig; in
+        # Woche 80 (also NACH dem gemeinsamen Beginn) gibt es einen kleinen
+        # Ruecksetzer, damit der Vergleichs-Drawdown nicht exakt 0 ist.
+        if i == 10:
+            t1 = Decimal("40")
+        elif i == 80:
+            t1 = (Decimal("100") + Decimal(i)) * Decimal("0.95")
+        else:
+            t1 = Decimal("100") + Decimal(i)
+        preise = {"T1": t1}
+        if i >= 60:
+            preise["T2"] = Decimal("100") + Decimal(i)
+        rows.append(PriceRow(start + timedelta(weeks=i), preise))
+
+    beginn = rows[60].date
+    eigen = _max_drawdown_pct(
+        [_f(vp.total_value) for vp in simulate(rows, lang).value_history]
+    )
+    gemeinsam = _vergleichs_kennzahlen(lang, rows, beginn)
+
+    assert gemeinsam is not None
+    # Der Crash liegt vor dem gemeinsamen Beginn - er darf dort nicht mehr auftauchen.
+    assert eigen > 50.0
+    assert 0.0 < gemeinsam["max_drawdown_pct"] < 10.0
+
+    build_dashboard(rows, [lang, spaet], output_path=tmp_path / "index.html")
+    tabelle = (
+        (tmp_path / "index.html")
+        .read_text(encoding="utf-8")
+        .split('<table class="summary-table">')[1]
+        .split("</table>")[0]
+    )
+
+    # In der Uebersicht steht der kleine (vergleichbare) Drawdown, nicht der grosse.
+    assert f"{-gemeinsam['max_drawdown_pct']:.2f}" in tabelle
+    assert f"{-eigen:.2f}" not in tabelle
+
+    # Die Kennzahlen des eigenen Zeitraums bleiben auf der Detailseite erhalten.
+    detail = _detail_html(tmp_path, _slug(lang.name))
+    assert "Kennzahlen nach Betrachtungszeitraum" in detail
+    assert f"{-eigen:.2f}" in detail
+
+
+def test_ohne_gemeinsamen_zeitraum_bleibt_die_uebersicht_bei_den_eigenen_werten(tmp_path: Path):
+    """Faellt der Vergleichszeitraum weg (zu kurz), darf die Tabelle keine leeren
+    Risikospalten zeigen - dann gelten durchgehend die Werte des eigenen
+    Zeitraums, und die Spaltenzahl muss weiterhin zum Kopf passen."""
+    rows = _lange_reihe(date(2020, 1, 6), _VERGLEICH_MIN_WOCHEN - 2, 1.005, "T1")
+    build_dashboard(rows, ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    tabelle = (
+        (tmp_path / "index.html")
+        .read_text(encoding="utf-8")
+        .split('<table class="summary-table">')[1]
+        .split("</table>")[0]
+    )
+
+    assert "Vergleichszeitraum" not in tabelle
+    kopf = len(re.findall(r"<th>", tabelle))
+    zeilen = re.findall(r"<tr>\s*<td>.*?</tr>", tabelle, re.S)
+    assert zeilen
+    for zeile in zeilen:
+        assert len(re.findall(r"<td", zeile)) == kopf
+
+
+def test_spaltenzahl_passt_zum_tabellenkopf_mit_vergleichszeitraum(tmp_path: Path):
+    rows = _lange_reihe(date(2020, 1, 6), 80, 1.005, "T1")
+    build_dashboard(rows, ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    tabelle = (
+        (tmp_path / "index.html")
+        .read_text(encoding="utf-8")
+        .split('<table class="summary-table">')[1]
+        .split("</table>")[0]
+    )
+
+    assert "Vergleichszeitraum" in tabelle
+    kopf = len(re.findall(r"<th>", tabelle))
+    zeilen = re.findall(r"<tr>\s*<td>.*?</tr>", tabelle, re.S)
+    assert zeilen
+    for zeile in zeilen:
+        assert len(re.findall(r"<td", zeile)) == kopf


### PR DESCRIPTION
Schließt #78, Folgearbeit zu #73.

In #73 wurde nur die **Rendite** auf einen gemeinsamen Zeitraum umgestellt; Volatilität, Max Drawdown, Sharpe und Sortino blieben auf dem jeweils eigenen Zeitraum und wurden nur je Zeile gekennzeichnet. Das reichte nicht — die Tabelle stellte damit Rendite und Risiko aus zwei *verschiedenen* Fenstern nebeneinander.

## Warum das die Aussage der Tabelle drehte

Der Effekt trifft praktisch nur **eine Zeile**: alle Strategien außer dem Benchmark liegen ohnehin fast vollständig im gemeinsamen Fenster, ihre Werte bewegen sich um Zehntel. Der Benchmark läuft über 20 Jahre und schleppt die Finanzkrise 2008 mit, die keine andere Strategie durchlaufen hat.

| | eigener Zeitraum | Vergleichszeitraum |
|---|---:|---:|
| **Max Drawdown Benchmark** | −51,95 % | **−21,21 %** |
| Max Drawdown Barbell 20/80 | −30,18 % | −29,29 % |
| Sharpe Benchmark | 0,64 | 0,66 |
| Sharpe Barbell 20/80 (breiter div.) | 0,76 | **0,66** |

**1. Der Drawdown-Vergleich kippt.** Bisher las sich die Tabelle als: *der Index bringt weniger Rendite **und** hat das mit Abstand höchste Verlustrisiko* — die Barbell-Strategien dominieren ihn also auf beiden Achsen, die Entscheidung ist trivial. Auf gleicher Basis hat der Index mit −21,21 % einen der **niedrigsten** Drawdowns im Feld. Damit wird daraus ein echter Rendite-Risiko-Tausch — genau die Abwägung, um die es bei einer Barbell-Strategie überhaupt geht, und die vorher unsichtbar war.

**2. Ein Sharpe-Paarvergleich kippt.** „Barbell 20/80 (breiter diversifiziert)" stand mit 0,76 gegen 0,64 des Benchmarks, sah risikoadjustiert also klar besser aus. Über den gemeinsamen Zeitraum sind beide bei **0,66** — gleichauf. Der Unterschied kam nicht aus der Strategie, sondern daraus, dass für die beiden Zeiträume unterschiedliche risikofreie Zinsen gelten (0,76 % über 20 Jahre gegen 2,05 % über 5, siehe #75).

Ein je Zeile ausgewiesener Zeitraum macht das nachvollziehbar, aber nicht auflösbar: aus „2006–2026" lässt sich nicht ableiten, wie groß der Drawdown ohne 2008 gewesen wäre.

## Umsetzung

- `_vergleichs_cagr_pct()` → **`_vergleichs_kennzahlen()`**: liefert das komplette Bündel (CAGR, Volatilität, Max Drawdown, Sharpe, Sortino plus den risikofreien Zins des Ausschnitts) statt nur die CAGR. Die Wertreihe des Vergleichslaufs lag ohnehin vor und wurde bis dahin verworfen — **keine zusätzliche Simulation**.
- Die Übersichtstabelle zeigt ausschließlich Vergleichszeitraum-Werte (die im Issue offengelassene Darstellungsfrage, so entschieden). Die CAGR über den eigenen Zeitraum bleibt als Nebenspalte; die vollständigen Eigen-Zeitraum-Kennzahlen stehen weiterhin auf der Detailseite unter „Kennzahlen nach Betrachtungszeitraum" (#54), die genau dafür da ist.
- Die Werte landen unter eigenen `vergleich_*`-Feldnamen. **Wichtig beim Weiterarbeiten:** die gleichnamigen Felder ohne Präfix beschreiben weiter den eigenen Zeitraum und werden anderswo gebraucht — die Detailseite nutzt sie als Startwerte ihrer Kacheln, die Prämissen-Seite den risikofreien Zins der eigenen Simulation. Sie zu überschreiben hätte beide verfälscht (beim Umsetzen zunächst genau so passiert und korrigiert).
- Fällt der Vergleichszeitraum weg (zu kurz für eine belastbare Annualisierung), zeigt die Tabelle durchgehend die Werte des eigenen Zeitraums statt leerer Spalten.

Rein in der Darstellungsschicht, kein Eingriff in `engine.py`.

## Ergebnis

Die Übersicht auf der realen Historie (Vergleichszeitraum ab 2021-11-21):

| Strategie | CAGR | Überrendite | Vola | Max DD | Sharpe |
|---|---:|---:|---:|---:|---:|
| Barbell 20/60/20 + Satellit | +20,79 | +9,32 | 18,77 | −28,94 | 0,98 |
| Buy the Dip | +17,53 | +6,06 | 18,69 | −29,96 | 0,84 |
| Barbell 20/80 | +16,27 | +4,80 | 18,19 | −29,29 | 0,80 |
| Sell in May | +11,91 | +0,43 | 14,20 | −23,13 | 0,71 |
| **Benchmark: S&P 500** | **+11,47** | – | **14,63** | **−21,21** | **0,66** |
| Börsenweisheiten (kombiniert) | +11,23 | −0,24 | 14,36 | −27,65 | 0,66 |
| SMA-Crossover (4/20) | +10,62 | −0,85 | 15,57 | −25,67 | 0,58 |
| Barbell 20/80 (breiter div.) | +10,06 | −1,41 | 12,27 | −18,82 | 0,66 |

Der Benchmark steht jetzt dort, wo er hingehört: renditeschwächer als die meisten Strategien, aber mit dem zweitniedrigsten Drawdown und einem Sharpe im Mittelfeld.

## Tests

246 grün (`pytest -q`), davon 3 neue:
- Eine Strategie mit einem Crash **vor** dem gemeinsamen Beginn: ihr eigener Max Drawdown liegt über 50 %, der des Vergleichszeitraums unter 10 % — die Übersicht muss den kleinen zeigen und den großen nicht enthalten, die Detailseite umgekehrt den großen behalten.
- Spaltenzahl stimmt mit dem Tabellenkopf überein, in **beiden** Zweigen (mit und ohne verfügbaren Vergleichszeitraum) — beim Umsetzen war der Fallback-Zweig zunächst um eine Spalte verschoben.

README und CLAUDE.md sind nachgezogen, inklusive des Hinweises auf die doppelt belegten Feldnamen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzYka1LY3LTy6Vw9ahLYaL)_