### PR TITLE
#79/#80/#81/#82: Portfolio-Liste, Ersatzbond-Zeitraum, Info-Tooltips, Korrelationsgrafik

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -708,6 +708,78 @@ inkrementell fortgeschrieben).
   Fließtext schreiben, was nicht aus `views` belegt ist, und die
   Deutsch-Formatierung über `_zahl()/_pp()/_pct()/_eur()` laufen lassen (ein
   `.replace(".", ",")` auf dem ganzen Satz erwischt sonst den Satzpunkt).
+  **Drei kleinere Startseiten-Ergänzungen (#79/#81/#82), alle rein in der
+  Darstellungsschicht, keine neue Simulation:**
+  - `common_context["portfolio_instrumente"]` (#79) listet ALLE
+    `instruments.TICKERS` (nicht nur die allokierten, anders als
+    `instrumente_anzahl`/#66) mit Ticker und ausgeschriebenem Namen in einer
+    Tabelle im Abschnitt „Das Portfolio" der Startseite — beantwortet direkt
+    "was wird da eigentlich wöchentlich abgerufen?", unabhängig davon, ob ein
+    Instrument aktuell in einer Strategie/einem Szenario steckt.
+  - Info-Tooltips (#81): jede Kennzahl-Spaltenüberschrift der
+    Übersichtstabelle (CAGR, Überrendite, Volatilität, Max Drawdown, Sharpe,
+    Sortino, Gesamtrendite, Eigener Zeitraum) bekommt ein `<span
+    class="info-tip" title="...">i</span>` mit Erklärungstext — natives
+    `title`-Attribut statt JS-Tooltip (kein zusätzliches Skript, per
+    Tastatur/Screenreader über `tabindex="0"` erreichbar). Die Tooltip-Texte
+    dürfen das Wort "Vergleichszeitraum" nicht enthalten, wenn sie außerhalb
+    des `{% if vergleich_verfuegbar %}`-Blocks stehen — ein Test prüft, dass
+    ohne gemeinsamen Vergleichszeitraum dieses Wort in der gesamten Tabelle
+    nirgends vorkommt (`test_ohne_gemeinsamen_zeitraum_...`), ein zu
+    ausführlicher Tooltip-Text an einer immer gerenderten Spalte hätte das
+    sonst unbeabsichtigt verletzt.
+  - Korrelationsgrafik (#82): ein Chart.js-Scatter-Chart
+    (`#correlation-chart`) direkt unter dem CAGR-Balkendiagramm, x-Achse
+    CAGR % p.a., y-Achse Max Drawdown % (negativ dargestellt, wie in der
+    Tabelle) — je Strategie/Szenario ein Punkt, aus denselben `summary`-Werten
+    wie die Übersichtstabelle (Vergleichszeitraum-Werte, falls verfügbar,
+    sonst der jeweils eigene Zeitraum). Macht den Rendite-Risiko-Tausch, den
+    die Tabelle nur spaltenweise zeigt, auf einen Blick sichtbar.
+  **Längerer Betrachtungszeitraum per Ersatzbond-Annahme (#80), zusätzlicher
+  Preset statt Ersatz der bestehenden Zeiträume:** `_real_investierbarer_
+  zeitraum()` (F4/#63) schneidet die Historie je Strategie auf den Zeitpunkt
+  zurecht, ab dem ALLE Zielinstrumente handelbar sind — das kostet z. B. bei
+  der dreitöpfigen Barbell-Strategie rund 15 Jahre Historie (Start erst 2021
+  statt 2006). Issue #80 bittet ausdrücklich um einen längeren Zeitraum, mit
+  der Annahme, dass das Kapital eines noch nicht handelbaren Zielinstruments
+  bis zu dessen Verfügbarkeit in einem einzigen, für ALLE Strategien/Szenarien
+  GLEICHEN Anleihe-ETF angelegt war ("nicht unterschiedliche Bonds", explizite
+  Vorgabe im Issue). `_ERSATZBOND_TICKER = "IBCL"` (Euro-Staatsanleihen
+  15–30 Jahre, Historie ab 2007-05-18, die längste unter den Anleihen-ETFs) ist
+  die Wahl — bewusst eine echte Anleihe, nicht `_GELDMARKT_TICKER` (XEON), das
+  als Cash-Äquivalent für den risikofreien Zins (#75) dient.
+  `_mit_ersatzbond(strategy)` erweitert eine Strategie um diese Annahme über
+  `Strategy.gewichte_fn` (dieselbe Erweiterungsstelle wie `scenarios.py`, kein
+  Engine-Eingriff): das Ziel-Gewicht jedes in der aktuellen Zeile noch nicht
+  handelbaren Instruments wandert auf `_ERSATZBOND_TICKER`, statt wie in
+  `handelbare_gewichte()` anteilig auf die ÜBRIGEN Zielinstrumente verteilt zu
+  werden — genau das war die in F4 beschriebene Überkonzentration (v. a.
+  Bitcoin in der Frühphase). Der Ersatzticker muss dafür Teil von
+  `Strategy.alle_ticker_gewichte()` sein, sonst würde `engine.
+  rebalance_to_targets()` das umgeleitete Gewicht stillschweigend verwerfen
+  (iteriert nur über die beim Start fixierten `tickers`, siehe die
+  "Werterhaltung beim Rebalancing"-Erklärung zu `engine.py` oben) — ist der
+  Ersatzticker noch nicht Teil der Strategie, ergänzt `_mit_ersatzbond()` einen
+  zusätzlichen Topf mit `gewicht_gesamt=0`, ohne die eigentlichen
+  Topf-Zielgewichte zu verändern; ist er es schon (z. B. würde er es bei
+  künftigen Strategien sein), wird kein Topf ergänzt (sonst gäbe es den
+  Ticker doppelt, was `Strategy.topf_von()` nicht vorsieht).
+  `_zeitraum_presets()` bekommt dafür einen optionalen dritten Parameter
+  `erweiterte_rows` (in `build_dashboard()`: `rows_ohne_btc_fruehphase`, also
+  die volle, nur um die BTC-Frühphase bereinigte Historie, gemeinsam für alle
+  Strategien) und hängt bei tatsächlichem Gewinn an Historie
+  (`erweiterte_rows[0].date < rows[0].date`) einen fünften Preset
+  `"erweitert"` ("Erweitert (Ersatzbond-Annahme)") an — simuliert mit
+  `_mit_ersatzbond(strategy)` über `erweiterte_rows`. Bewusst NUR bei
+  tatsächlichem Gewinn angeboten (z. B. nicht bei `SP500_BENCHMARK`, dessen
+  einziges Instrument `IUSA` fast die gesamte Historie abdeckt) — sonst wäre
+  der Preset nur eine redundante Kopie von "Gesamte Historie". Weil der neue
+  Preset über den generischen `s.zeitraum_presets`-Loop in
+  `dashboard.html.j2`/`strategy_detail.html.j2` gerendert wird, war dafür
+  KEINE Template-Änderung nötig — nur ein zusätzlicher Hinweistext auf der
+  Detailseite, der erklärt, was die Annahme bedeutet. Ändert nichts an der
+  primären "Eigener Zeitraum"/"Vergleichszeitraum"-Darstellung (#73/#78) oder
+  an bestehenden Tests — rein additiv.
 
 ### Kursquelle wechseln
 

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -33,6 +33,7 @@ from .strategies import (
     VORABPAUSCHALE_BASISZINS_PLATZHALTER,
     VORABPAUSCHALE_FAKTOR,
     Strategy,
+    Topf,
 )
 
 # Status-Werte in fetch_log.csv, bei denen der Kurs NICHT frisch abgerufen wurde
@@ -102,6 +103,75 @@ def _real_investierbarer_zeitraum(rows: list[PriceRow], strategy: Strategy) -> l
         if ziel_ticker <= set(row.prices):
             return rows[i:]
     return rows
+
+
+# --- #80: laengerer Betrachtungszeitraum per Ersatzbond-Annahme --------------
+#
+# _real_investierbarer_zeitraum() (F4/#63) schneidet die Historie auf den
+# Zeitpunkt zurecht, ab dem ALLE Zielinstrumente einer Strategie handelbar
+# sind - das vermeidet die Ueberkonzentration frueh existierender Instrumente
+# (v.a. Bitcoin), kostet aber Jahre an Historie: die dreitoepfige
+# Barbell-Strategie startet dadurch z.B. erst 2021 statt am Beginn der
+# Kurshistorie (2006). Issue #80 bittet ausdruecklich um einen laengeren
+# Zeitraum, mit der Annahme, dass das Kapital eines noch nicht handelbaren
+# Zielinstruments bis zu dessen Verfuegbarkeit in einem einzigen, fuer ALLE
+# Strategien/Szenarien GLEICHEN Anleihe-ETF angelegt war - "nicht
+# unterschiedliche Bonds" war eine explizite Vorgabe im Issue.
+#
+# IBCL (Euro-Staatsanleihen 15-30 Jahre) ist die Wahl: eine echte Anleihe (im
+# Gegensatz zum Geldmarkt-ETF XEON, der als Cash-Aequivalent fuer den
+# risikofreien Zins dient, siehe _GELDMARKT_TICKER) mit der laengsten
+# verfuegbaren Historie unter den Anleihen-ETFs (ab 2007-05-18, siehe
+# instruments.py) - deckt damit fast die gesamte Kurshistorie ab 2006-09 ab.
+#
+# Umsetzung ueber Strategy.gewichte_fn statt eines Engine-Eingriffs (dieselbe
+# Erweiterungsstelle wie scenarios.py): die Ziel-Gewichte jedes noch nicht
+# handelbaren Instruments wandern in dieser Zeile auf IBCL um, statt wie in
+# handelbare_gewichte() anteilig auf die UEBRIGEN Zielinstrumente verteilt zu
+# werden (genau das war die in F4 beschriebene Ueberkonzentration). IBCL muss
+# dafuer Teil von Strategy.alle_ticker_gewichte() sein, sonst wuerde
+# engine.simulate() das umgeleitete Gewicht stillschweigend verwerfen (siehe
+# engine.rebalance_to_targets(): iteriert nur ueber die beim Start fixierten
+# `tickers`) - ist IBCL noch nicht Teil der Strategie, ergaenzt ein
+# zusaetzlicher Topf mit Gesamtgewicht 0 es, ohne die eigentlichen
+# Topf-Zielgewichte zu veraendern.
+_ERSATZBOND_TICKER = "IBCL"
+
+
+def _mit_ersatzbond(strategy: Strategy) -> Strategy:
+    """Erweitert ``strategy`` um die Ersatzbond-Annahme aus #80 (siehe oben)."""
+    basis_gewichte = strategy.alle_ticker_gewichte()
+    hat_ersatzbond_schon = _ERSATZBOND_TICKER in basis_gewichte
+    toepfe = strategy.toepfe
+    if not hat_ersatzbond_schon:
+        toepfe = [
+            *toepfe,
+            Topf(
+                name="Ersatzbond (vor Verfügbarkeit, #80)",
+                gewicht_gesamt=Decimal(0),
+                sub_gewichte={_ERSATZBOND_TICKER: Decimal(1)},
+            ),
+        ]
+    urspruengliche_gewichte_fn = strategy.gewichte_fn
+
+    def gewichte_fn(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+        gewichte = dict(
+            urspruengliche_gewichte_fn(rows, i) if urspruengliche_gewichte_fn is not None else basis_gewichte
+        )
+        prices = rows[i].prices
+        ersatz_anteil = Decimal(0)
+        for ticker in list(gewichte):
+            if ticker == _ERSATZBOND_TICKER:
+                continue
+            gewicht = gewichte[ticker]
+            if gewicht > 0 and ticker not in prices:
+                ersatz_anteil += gewicht
+                gewichte[ticker] = Decimal(0)
+        if ersatz_anteil > 0:
+            gewichte[_ERSATZBOND_TICKER] = gewichte.get(_ERSATZBOND_TICKER, Decimal(0)) + ersatz_anteil
+        return gewichte
+
+    return replace(strategy, toepfe=toepfe, gewichte_fn=gewichte_fn)
 
 # Wochen-Naeherung der klassischen 50-/200-Tage-Durchschnitte (5 Handelstage/Woche),
 # fuer die wochenweise gefuehrte Kurshistorie - derselbe Ansatz wie beim Szenario
@@ -372,7 +442,35 @@ def _jahre_zurueck(stichtag: date, jahre: int) -> date:
         return stichtag.replace(year=stichtag.year - jahre, day=28)
 
 
-def _zeitraum_presets(rows: list[PriceRow], strategy: Strategy) -> list[dict]:
+def _preset_eintrag(preset_id: str, label: str, preset_rows: list[PriceRow], strategy: Strategy) -> dict:
+    result = simulate(preset_rows, strategy)
+    # Risikofreier Zins aus dem Geldmarkt-ETF ueber genau DIESEN Preset-Zeitraum
+    # (#75) - ein 1-Jahres-Preset im Hochzinsumfeld hat einen anderen Referenzzins
+    # als die volle Historie.
+    zins_pct = _risikofreier_zins_pct(preset_rows)
+    total_values = [_f(vp.total_value) for vp in result.value_history]
+    labels = [vp.date.isoformat() for vp in result.value_history]
+    rendite_pct = _rendite_pct(result, strategy)
+    return {
+        "id": preset_id,
+        "label": label,
+        "rendite_pct": _f(rendite_pct),
+        "rendite_label": f"{rendite_pct:+.2f}",
+        "volatilitaet_label": f"{_volatilitaet_pct(total_values):.2f}",
+        "max_drawdown_label": f"{-_max_drawdown_pct(total_values):.2f}",
+        "sharpe_label": f"{_sharpe_ratio(total_values, zins_pct):.2f}",
+        "sortino_label": f"{_sortino_ratio(total_values, zins_pct):.2f}",
+        "risikofreier_zins_label": f"{zins_pct:.2f}".replace(".", ","),
+        "labels": labels,
+        "total_values": total_values,
+        "chart_max": max(total_values) if total_values else 0.0,
+        "benchmarks": _benchmark_reihen(preset_rows, strategy),
+    }
+
+
+def _zeitraum_presets(
+    rows: list[PriceRow], strategy: Strategy, erweiterte_rows: list[PriceRow] | None = None
+) -> list[dict]:
     letztes_datum = rows[-1].date
     presets = []
     for preset_id, jahre in _ZEITRAUM_PRESETS:
@@ -383,30 +481,16 @@ def _zeitraum_presets(rows: list[PriceRow], strategy: Strategy) -> list[dict]:
             preset_rows = [r for r in rows if r.date >= cutoff]
         if len(preset_rows) < 1:
             continue
-        result = simulate(preset_rows, strategy)
-        # Risikofreier Zins aus dem Geldmarkt-ETF ueber genau DIESEN Preset-Zeitraum
-        # (#75) - ein 1-Jahres-Preset im Hochzinsumfeld hat einen anderen Referenzzins
-        # als die volle Historie.
-        zins_pct = _risikofreier_zins_pct(preset_rows)
-        total_values = [_f(vp.total_value) for vp in result.value_history]
-        labels = [vp.date.isoformat() for vp in result.value_history]
-        rendite_pct = _rendite_pct(result, strategy)
+        presets.append(_preset_eintrag(preset_id, _ZEITRAUM_PRESET_LABELS[preset_id], preset_rows, strategy))
+    # #80: zusaetzlicher Preset ueber die volle (nicht auf "alle Zielinstrumente
+    # handelbar" zurechtgeschnittene) Historie, mit der Ersatzbond-Annahme statt
+    # der Look-ahead-Vermeidung aus F4/#63 - nur anbieten, wenn dadurch
+    # tatsaechlich mehr Historie zur Verfuegung steht, sonst waere er identisch
+    # mit "Gesamte Historie" und nur verwirrende Redundanz.
+    if erweiterte_rows is not None and erweiterte_rows and erweiterte_rows[0].date < rows[0].date:
+        erweiterte_strategie = _mit_ersatzbond(strategy)
         presets.append(
-            {
-                "id": preset_id,
-                "label": _ZEITRAUM_PRESET_LABELS[preset_id],
-                "rendite_pct": _f(rendite_pct),
-                "rendite_label": f"{rendite_pct:+.2f}",
-                "volatilitaet_label": f"{_volatilitaet_pct(total_values):.2f}",
-                "max_drawdown_label": f"{-_max_drawdown_pct(total_values):.2f}",
-                "sharpe_label": f"{_sharpe_ratio(total_values, zins_pct):.2f}",
-                "sortino_label": f"{_sortino_ratio(total_values, zins_pct):.2f}",
-                "risikofreier_zins_label": f"{zins_pct:.2f}".replace(".", ","),
-                "labels": labels,
-                "total_values": total_values,
-                "chart_max": max(total_values) if total_values else 0.0,
-                "benchmarks": _benchmark_reihen(preset_rows, strategy),
-            }
+            _preset_eintrag("erweitert", "Erweitert (Ersatzbond-Annahme)", erweiterte_rows, erweiterte_strategie)
         )
     return presets
 
@@ -632,6 +716,7 @@ def _build_strategy_view(
     result: SimulationResult,
     rows: list[PriceRow],
     carry_forward: dict[str, int] | None = None,
+    erweiterte_rows: list[PriceRow] | None = None,
 ) -> dict:
     points = result.value_history
     labels = [vp.date.isoformat() for vp in points]
@@ -709,7 +794,7 @@ def _build_strategy_view(
         if walk_forward_segmente
         else 0.0
     )
-    zeitraum_presets = _zeitraum_presets(rows, strategy)
+    zeitraum_presets = _zeitraum_presets(rows, strategy, erweiterte_rows)
     benchmarks = _benchmark_reihen(rows, strategy)
 
     # Leave-one-out: Einzeleffekt jeder Teilregel als Differenz zur Variante ohne sie,
@@ -994,7 +1079,13 @@ def build_dashboard(
     strategie_rows = {s.name: _real_investierbarer_zeitraum(rows_ohne_btc_fruehphase, s) for s in strategies}
 
     views = [
-        _build_strategy_view(s, simulate(strategie_rows[s.name], s), strategie_rows[s.name], carry_forward)
+        _build_strategy_view(
+            s,
+            simulate(strategie_rows[s.name], s),
+            strategie_rows[s.name],
+            carry_forward,
+            erweiterte_rows=rows_ohne_btc_fruehphase,
+        )
         for s in strategies
     ]
     # Gemeinsamer Vergleichszeitraum (#73): jede Strategie zusaetzlich ab dem
@@ -1115,6 +1206,16 @@ def build_dashboard(
         # eingetragen, damit die Zahl auf jeder Seite automatisch mit einem
         # künftigen Instrumente-/Strategiewechsel mitzieht.
         instrumente_anzahl=len(_allokierte_ticker(strategies)),
+        # #79: alle abgerufenen Instrumente (Ticker + ausgeschriebener Name) auf
+        # der Startseite, generisch aus instruments.TICKERS/INSTRUMENTS abgeleitet
+        # statt hinterlegt - zieht bei einer künftigen Instrumentenänderung
+        # automatisch mit, statt wie die README-Tabelle von Hand nachgezogen zu
+        # werden. Bewusst ALLE Ticker (nicht nur die allokierten, #66): die
+        # Frage "was wird da wöchentlich abgerufen?" ist unabhängig davon, ob
+        # ein Instrument aktuell in einer Strategie steckt.
+        portfolio_instrumente=[
+            {"ticker": t, "name": INSTRUMENTS[t].name} for t in TICKERS
+        ],
         benchmark_optionen=[{"id": k, "label": v} for k, v in benchmark_optionen.items()],
         **vergleich_kontext,
     )

--- a/src/boersenspiel/templates/base.html.j2
+++ b/src/boersenspiel/templates/base.html.j2
@@ -167,6 +167,17 @@
   }
   .benchmark-switch button:hover { color: var(--text-primary); }
   .benchmark-switch button.active { background: var(--series-2); border-color: var(--series-2); color: #fff; }
+  /* Info-Tooltips an Tabellenüberschriften (#81): natives title-Attribut statt
+     JS-Tooltip, damit die Erklärung ohne zusätzliches Skript per Hover/Fokus
+     erscheint und auch mit Tastatur/Screenreader erreichbar bleibt. */
+  .info-tip {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 13px; height: 13px; border-radius: 50%;
+    background: var(--text-muted); color: var(--surface-1);
+    font-size: 0.62rem; font-weight: 700; font-style: normal;
+    text-transform: none; letter-spacing: normal; margin-left: 4px;
+    cursor: help; vertical-align: middle;
+  }
   .back-link { margin: 0; font-size: 0.9rem; }
   .header-bar { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
   .menu { position: relative; flex: none; }

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -22,6 +22,24 @@
       hoch-volatile Wachstums-/Themenwerte mit zwei defensiven Blue Chips
       (Coca-Cola, Roche) als Gegenbeispiel.
     </p>
+    <p class="hint">
+      Alle {{ portfolio_instrumente|length }} wöchentlich abgerufenen Datenreihen im
+      Überblick (Kürzel und ausgeschriebener Name) - welche Strategie welches
+      Instrument tatsächlich hält, zeigt die jeweilige Detailseite unter
+      „Topf-Gewichtung"; nicht jedes hier gelistete Instrument steckt in jeder
+      Strategie (siehe Prämissen-Seite, Abschnitt „Datenreihen ohne
+      Allokation").
+    </p>
+    <div class="overflow-x">
+      <table class="portfolio-table">
+        <thead><tr><th class="text-left">Kürzel</th><th class="text-left">Instrument</th></tr></thead>
+        <tbody>
+        {% for i in portfolio_instrumente %}
+          <tr><td class="text-left">{{ i.ticker }}</td><td class="text-left">{{ i.name }}</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </section>
 {% if learnings %}
   <section class="strategy" id="key-learnings">
@@ -103,9 +121,20 @@
       steht auf der jeweiligen Detailseite.
     </p>
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
+    <p class="hint">
+      <strong>Rendite gegen Risiko:</strong> jeder Punkt ist eine Strategie/ein
+      Szenario, x-Achse CAGR % p.a., y-Achse Max Drawdown % (jeweils
+      {% if vergleich_verfuegbar %}aus dem gemeinsamen Vergleichszeitraum{% else %}aus dem eigenen Zeitraum{% endif %}).
+      Oben rechts liegt der günstigste Fall (hohe Rendite, kleiner Drawdown),
+      unten rechts der problematischste (hohe Rendite, aber auch hoher
+      Drawdown) - macht sichtbar, ob eine hohe Rendite mit entsprechend
+      höherem Risiko erkauft ist, statt die beiden Achsen getrennt in der
+      Tabelle nachschlagen zu müssen.
+    </p>
+    <div class="summary-chart-box"><canvas id="correlation-chart"></canvas></div>
     <div class="overflow-x">
       <table class="summary-table">
-        <thead><tr><th>Strategie / Szenario</th>{% if vergleich_verfuegbar %}<th>CAGR % p.a. (Vergleichszeitraum)</th><th>&Uuml;berrendite pp p.a.</th>{% endif %}<th>Volatilität % (ann.)</th><th>Max Drawdown %</th><th>Sharpe</th><th>Sortino</th><th>CAGR % p.a. (eigener Zeitraum)</th><th>Gesamtrendite % (brutto)</th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th><th>Eigener Zeitraum</th></tr></thead>
+        <thead><tr><th>Strategie / Szenario</th>{% if vergleich_verfuegbar %}<th>CAGR % p.a. (Vergleichszeitraum)<span class="info-tip" tabindex="0" title="Annualisierte Rendite (Compound Annual Growth Rate): die konstante jährliche Wachstumsrate, die über den gemeinsamen Vergleichszeitraum auf denselben Endwert führt. Vergleichbar auch bei unterschiedlich langen Zeiträumen, anders als die Gesamtrendite.">i</span></th><th>&Uuml;berrendite pp p.a.<span class="info-tip" tabindex="0" title="Differenz der CAGR gegenüber dem Benchmark (S&P 500) im selben Vergleichszeitraum, in Prozentpunkten. Positiv = die Strategie hat den Index über diesen Zeitraum geschlagen, negativ = nicht.">i</span></th>{% endif %}<th>Volatilität % (ann.)<span class="info-tip" tabindex="0" title="Annualisierte Standardabweichung der wöchentlichen Renditen - ein Maß für die Schwankungsbreite des Wertverlaufs. Höher bedeutet unruhiger, nicht zwangsläufig schlechter.">i</span></th><th>Max Drawdown %<span class="info-tip" tabindex="0" title="Der größte prozentuale Rückgang vom bisherigen Höchststand des Portfoliowerts während des Betrachtungszeitraums - der schlimmste Verlust, den ein Anleger tatsächlich ausgehalten hätte.">i</span></th><th>Sharpe<span class="info-tip" tabindex="0" title="Sharpe-Ratio: annualisierte Überrendite über dem risikofreien Zins, geteilt durch die gesamte Volatilität. Höher ist besser; negativ heißt, das Risiko hat sich gegenüber risikolosem Parken nicht gelohnt.">i</span></th><th>Sortino<span class="info-tip" tabindex="0" title="Sortino-Ratio: wie Sharpe, aber es zählt nur die Streuung der Verlustwochen als Risiko (Schwankung nach oben wird nicht bestraft). Meist etwas höher als die Sharpe-Ratio derselben Strategie.">i</span></th><th>CAGR % p.a. (eigener Zeitraum)<span class="info-tip" tabindex="0" title="Annualisierte Rendite über den eigenen, individuell längsten handelbaren Zeitraum dieser Strategie (kann für jede Zeile unterschiedlich lang sein) - Nebenspalte, nicht direkt mit anderen Zeilen vergleichbar.">i</span></th><th>Gesamtrendite % (brutto)<span class="info-tip" tabindex="0" title="Gesamte prozentuale Wertsteigerung über den eigenen Zeitraum, vor Steuer. Bei langen Zeiträumen praktisch unlesbar (z. B. mehrere Tausend Prozent) - die CAGR-Spalten sind deshalb die Leitkennzahl.">i</span></th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th><th>Eigener Zeitraum<span class="info-tip" tabindex="0" title="Der Zeitraum, ab dem für diese Strategie tatsächlich alle ihre Zielinstrumente handelbar waren (kein rückwirkender Kauf eines 2026 zusammengestellten Portfolios ab 2006).">i</span></th></tr></thead>
         <tbody>
         {% for s in summary %}
           <tr>
@@ -224,6 +253,51 @@
       scales: {
         x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
         y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+      },
+    },
+  });
+
+  // Korrelationsgrafik (#82): Rendite (CAGR) gegen Risiko (Max Drawdown) je
+  // Strategie/Szenario, aus denselben Werten wie die Uebersichtstabelle
+  // (Vergleichszeitraum, falls verfuegbar, sonst der jeweils eigene Zeitraum) -
+  // keine zusaetzliche Simulation, reine Darstellung bereits vorhandener Zahlen.
+  new Chart(document.getElementById('correlation-chart'), {
+    type: 'scatter',
+    data: {
+      datasets: [{
+        label: 'Strategien/Szenarien',
+        data: [
+          {% for s in summary %}
+          {
+            x: {{ (s.vergleich_cagr_pct if vergleich_verfuegbar else s.cagr_pct) | tojson }},
+            y: {{ (-((s.vergleich_max_drawdown_pct if vergleich_verfuegbar else s.max_drawdown_pct) or 0.0)) | tojson }},
+            name: {{ s.name | tojson }},
+          },
+          {% endfor %}
+        ],
+        backgroundColor: colors.series1,
+        pointRadius: 6,
+        pointHoverRadius: 8,
+      }],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        title: {
+          display: true,
+          text: {% if vergleich_verfuegbar %}'CAGR gegen Max Drawdown im gemeinsamen Vergleichszeitraum ab {{ vergleich_beginn }}'{% else %}'CAGR gegen Max Drawdown (jeweils eigener Zeitraum)'{% endif %},
+          color: colors.text,
+        },
+        tooltip: {
+          callbacks: {
+            label: (ctx) => `${ctx.raw.name}: CAGR ${ctx.raw.x.toFixed(2)} % p.a., Max Drawdown ${ctx.raw.y.toFixed(2)} %`,
+          },
+        },
+      },
+      scales: {
+        x: { ...commonScales.x, title: { display: true, text: 'CAGR % p.a.', color: colors.text } },
+        y: { ...commonScales.y, title: { display: true, text: 'Max Drawdown %', color: colors.text } },
       },
     },
   });

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -37,6 +37,20 @@
       Jeder Zeitraum ist eine eigenständige Neu-Simulation mit frischem
       Startkapital (kein fortgeführtes Depot) - analog zum Walk-Forward-
       Abschnitt unten, nur mit festen statt gleich großen Perioden (#54).
+      {% if 'erweitert' in (s.zeitraum_presets | map(attribute='id') | list) %}
+      Der Zeitraum <strong>„Erweitert (Ersatzbond-Annahme)"</strong> (#80) läuft
+      über die volle verfügbare Kurshistorie statt nur ab dem Zeitpunkt, ab dem
+      alle Zielinstrumente dieser Strategie handelbar waren: solange ein
+      Zielinstrument noch nicht existierte, gilt sein Kapitalanteil als in
+      <strong>IBCL</strong> (Euro-Staatsanleihen 15&ndash;30 Jahre) angelegt
+      &ndash; demselben Anleihe-ETF für ALLE Strategien und Szenarien, statt
+      je nach Strategie unterschiedlicher Ersatzinstrumente. Das vermeidet
+      die Überkonzentration früh existierender Instrumente (v. a. Bitcoin),
+      die sonst entstünde (siehe Prämissen, „Rückschaufehler mit Hebel"),
+      zeigt aber einen längeren Zeitraum auf Kosten einer zusätzlichen
+      Annahme: real hätte eine 2026 zusammengestellte Strategie 2006 noch gar
+      nicht existiert.
+      {% endif %}
     </p>
     <div class="zeitraum-switch" id="detail-zeitraum-switch">
       {% for p in s.zeitraum_presets %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -21,11 +21,13 @@ from boersenspiel.dashboard import (
     _BTC_TICKER,
     _build_strategy_view,
     _cagr_pct,
+    _ERSATZBOND_TICKER,
     _gemeinsamer_beginn,
     _downside_deviation,
     _f,
     _GELDMARKT_TICKER,
     _jahre_zurueck,
+    _mit_ersatzbond,
     _VERGLEICH_MIN_WOCHEN,
     _vergleichs_kennzahlen,
     _max_drawdown_pct,
@@ -579,6 +581,122 @@ def test_build_dashboard_zeigt_zeitraum_abschnitt_auf_detailseite(tmp_path: Path
 
     assert "Kennzahlen nach Betrachtungszeitraum" in detail_html
     assert 'id="detail-zeitraum-switch"' in detail_html
+
+
+# --- #80: laengerer Zeitraum per Ersatzbond-Annahme --------------------------
+
+_ZWEI_TICKER_STRATEGIE = Strategy(
+    name="C: Ersatzbond-Test",
+    startkapital=Decimal("1000"),
+    toepfe=[
+        Topf(
+            name="Topf",
+            gewicht_gesamt=Decimal("1"),
+            sub_gewichte={"T1": Decimal("0.5"), "T2": Decimal("0.5")},
+        )
+    ],
+    ziel_topf="Topf",
+    ziel_gewicht=Decimal("1"),
+    rebalancing_schwelle_pp=Decimal("1000"),
+)
+
+
+def _rows_mit_spaeterem_instrument() -> list[PriceRow]:
+    """T1 und der Ersatzbond sind von Anfang an handelbar, T2 kommt erst in
+    Woche 3 hinzu - simuliert eine Boersenaufnahme mitten in der Historie."""
+    start = date(2020, 1, 6)
+    rows = []
+    for i in range(6):
+        prices = {"T1": Decimal("100"), _ERSATZBOND_TICKER: Decimal("50")}
+        if i >= 3:
+            prices["T2"] = Decimal("100")
+        rows.append(PriceRow(start + timedelta(weeks=i), prices))
+    return rows
+
+
+def test_mit_ersatzbond_leitet_das_gewicht_des_noch_nicht_handelbaren_tickers_auf_ihn_um():
+    erweitert = _mit_ersatzbond(_ZWEI_TICKER_STRATEGIE)
+    rows = _rows_mit_spaeterem_instrument()
+
+    # Vor Verfuegbarkeit von T2: dessen 50% wandern auf den Ersatzbond statt
+    # (wie handelbare_gewichte() es sonst taete) proportional auf T1 - T1
+    # bleibt bei seinem eigenen Zielgewicht.
+    gewichte_frueh = erweitert.gewichte_fn(rows, 0)
+    assert gewichte_frueh["T1"] == Decimal("0.5")
+    assert gewichte_frueh["T2"] == Decimal("0")
+    assert gewichte_frueh[_ERSATZBOND_TICKER] == Decimal("0.5")
+
+    # Sobald T2 handelbar ist, gelten wieder die normalen Zielgewichte, der
+    # Ersatzbond bekommt kein zusaetzliches Gewicht mehr.
+    gewichte_spaet = erweitert.gewichte_fn(rows, 3)
+    assert gewichte_spaet["T1"] == Decimal("0.5")
+    assert gewichte_spaet["T2"] == Decimal("0.5")
+    assert gewichte_spaet.get(_ERSATZBOND_TICKER, Decimal("0")) == Decimal("0")
+
+
+def test_mit_ersatzbond_haelt_das_depot_voll_investiert_ueber_die_ganze_reihe():
+    erweitert = _mit_ersatzbond(_ZWEI_TICKER_STRATEGIE)
+    rows = _rows_mit_spaeterem_instrument()
+    result = simulate(rows, erweitert)
+    # Kein Geld verschwindet und keins bleibt unverzinst liegen (siehe
+    # engine.py "Werterhaltung beim Rebalancing") - der Depotwert bleibt in
+    # jeder Zeile positiv und plausibel nah am Startkapital.
+    for vp in result.value_history:
+        assert vp.total_value > 0
+
+
+def test_mit_ersatzbond_ergaenzt_topf_nur_wenn_ersatzticker_noch_nicht_teil_der_strategie_ist():
+    # _ZWEI_TICKER_STRATEGIE kennt den Ersatzticker noch nicht -> ein
+    # zusaetzlicher Topf mit Gesamtgewicht 0 wird ergaenzt.
+    erweitert = _mit_ersatzbond(_ZWEI_TICKER_STRATEGIE)
+    assert _ERSATZBOND_TICKER in erweitert.alle_ticker_gewichte()
+    assert len(erweitert.toepfe) == len(_ZWEI_TICKER_STRATEGIE.toepfe) + 1
+
+    # Ist der Ersatzticker bereits Teil der Strategie, wird kein Topf ergaenzt
+    # (sonst gaebe es den Ticker zweimal, was topf_von() nicht vorsieht).
+    strategie_mit_ersatzticker = Strategy(
+        name="D: hat Ersatzbond schon",
+        startkapital=Decimal("1000"),
+        toepfe=[
+            Topf(
+                name="Topf",
+                gewicht_gesamt=Decimal("1"),
+                sub_gewichte={"T1": Decimal("0.5"), _ERSATZBOND_TICKER: Decimal("0.5")},
+            )
+        ],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+    erweitert2 = _mit_ersatzbond(strategie_mit_ersatzticker)
+    assert len(erweitert2.toepfe) == len(strategie_mit_ersatzticker.toepfe)
+
+
+def test_zeitraum_presets_bietet_erweiterten_zeitraum_nur_bei_tatsaechlichem_gewinn_an():
+    rows = _rows_mit_spaeterem_instrument()
+    eigene_rows = rows[3:]  # das, was _real_investierbarer_zeitraum() liefern wuerde
+
+    mit_gewinn = _zeitraum_presets(eigene_rows, _ZWEI_TICKER_STRATEGIE, erweiterte_rows=rows)
+    assert "erweitert" in [p["id"] for p in mit_gewinn]
+
+    # Ohne tatsaechlichen Gewinn an Historie (identischer Beginn) wird der
+    # Preset nicht angeboten - sonst waere er nur eine redundante Kopie von
+    # "Gesamte Historie".
+    ohne_gewinn = _zeitraum_presets(rows, _ZWEI_TICKER_STRATEGIE, erweiterte_rows=rows)
+    assert "erweitert" not in [p["id"] for p in ohne_gewinn]
+
+    # Ohne erweiterte_rows (Standardfall) entfaellt der Preset ebenfalls.
+    ohne_param = _zeitraum_presets(eigene_rows, _ZWEI_TICKER_STRATEGIE)
+    assert "erweitert" not in [p["id"] for p in ohne_param]
+
+
+def test_build_dashboard_zeigt_erweiterten_zeitraum_auf_detailseite_bei_lueckenhafter_historie(
+    tmp_path: Path,
+):
+    build_dashboard(_rows_mit_spaeterem_instrument(), [_ZWEI_TICKER_STRATEGIE], output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "c-ersatzbond-test")
+    assert "Erweitert (Ersatzbond-Annahme)" in detail_html
+    assert _ERSATZBOND_TICKER in detail_html
     assert 'id="zeitraum-chart"' in detail_html
     for preset_id in ("1j", "3j", "5j", "alle"):
         assert f'data-preset="{preset_id}"' in detail_html
@@ -1220,3 +1338,52 @@ def test_spaltenzahl_passt_zum_tabellenkopf_mit_vergleichszeitraum(tmp_path: Pat
     assert zeilen
     for zeile in zeilen:
         assert len(re.findall(r"<td", zeile)) == kopf
+
+
+# --- #79: Portfolio-Uebersicht (Ticker + Name) auf der Startseite ------------
+
+
+def test_startseite_listet_alle_instrumente_mit_kuerzel_und_namen(tmp_path: Path):
+    from boersenspiel.instruments import INSTRUMENTS
+
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    # Alle TICKERS erscheinen, nicht nur die von ZWEI_STRATEGIEN allokierten
+    # ("T1") - die Liste soll unabhaengig von der Allokation zeigen, was
+    # ueberhaupt woechentlich abgerufen wird (#79).
+    assert len(TICKERS) > 1
+    for ticker in TICKERS:
+        assert f">{ticker}<" in html
+        assert INSTRUMENTS[ticker].name in html
+
+
+# --- #81: Info-Tooltips an den Kennzahl-Spalten der Uebersichtstabelle -------
+
+
+def test_uebersichtstabelle_hat_info_tooltips_an_den_kennzahl_spalten(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    tabelle = (
+        output.read_text(encoding="utf-8")
+        .split('<table class="summary-table">')[1]
+        .split("</table>")[0]
+    )
+    # Ein Tooltip je Kennzahl-Spalte im Tabellenkopf, mit erklaerendem Text -
+    # kein leeres Icon ohne Erklaerung.
+    assert tabelle.count('class="info-tip"') >= 7
+    assert "annualisierte" in tabelle.lower()
+
+
+# --- #82: Korrelationsgrafik Rendite (CAGR) gegen Risiko (Max Drawdown) -----
+
+
+def test_startseite_zeigt_korrelationsgrafik_rendite_gegen_drawdown(tmp_path: Path):
+    output = build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    html = output.read_text(encoding="utf-8")
+
+    assert '<canvas id="correlation-chart"></canvas>' in html
+    assert "correlation-chart" in html
+    # Beide Strategien-Namen stehen als Punktbeschriftung im Streudiagramm.
+    assert "A: Verdoppler" in html
+    assert "B: Verlierer" in html
+    assert "type: 'scatter'" in html


### PR DESCRIPTION
Setzt vier der fünf offenen Issues um (#72 war bereits umgesetzt, siehe unten).

## #79 – Portfolio beschreiben
Die Startseite listet jetzt im Abschnitt „Das Portfolio" alle wöchentlich abgerufenen Instrumente mit Kürzel und ausgeschriebenem Namen, dynamisch aus `instruments.TICKERS`/`INSTRUMENTS` abgeleitet (nicht hartkodiert – zieht bei künftigen Instrumentenänderungen automatisch mit).

## #81 – Mehr Erklärungen
Jede Kennzahl-Spaltenüberschrift der Übersichtstabelle (CAGR, Überrendite, Volatilität, Max Drawdown, Sharpe, Sortino, Gesamtrendite, Eigener Zeitraum) hat jetzt ein kleines „i"-Icon mit Erklärungstext (natives `title`-Attribut, per Hover/Fokus erreichbar, keine zusätzliche JS-Abhängigkeit). Beantwortet insbesondere die im Issue gestellte Frage: CAGR ist die annualisierte Rendite dieser Strategie über ihren eigenen Zeitraum, Überrendite die Differenz ihrer CAGR zum Benchmark im gemeinsamen Vergleichszeitraum.

## #82 – Korrelationsgrafik
Neues Streudiagramm auf der Startseite (Chart.js Scatter), x-Achse CAGR % p.a., y-Achse Max Drawdown % – ein Punkt je Strategie/Szenario, aus denselben Werten wie die Übersichtstabelle. Macht den Rendite-Risiko-Tausch auf einen Blick sichtbar statt ihn spaltenweise nachschlagen zu müssen.

## #80 – Zeitraum zu kurz
Neuer Zeitraum-Preset **„Erweitert (Ersatzbond-Annahme)"** auf jeder Detailseite (und im Zeitraum-Umschalter der Startseite): läuft über die volle verfügbare Kurshistorie statt nur ab dem Zeitpunkt, ab dem alle Zielinstrumente einer Strategie handelbar sind. Solange ein Zielinstrument noch nicht existierte, gilt sein Kapitalanteil als in **IBCL** (Euro-Staatsanleihen 15–30 Jahre) angelegt – einheitlich für ALLE Strategien und Szenarien, wie im Issue ausdrücklich gefordert ("nicht unterschiedliche Bonds").

Umgesetzt über `Strategy.gewichte_fn` (dieselbe Erweiterungsstelle wie die Szenarien in `scenarios.py`), kein Eingriff in `engine.py`. Bewusst als **zusätzlicher** Preset neben "1 Jahr"/"3 Jahre"/"5 Jahre"/"Gesamte Historie" statt als Ersatz: die bisherige "Eigener Zeitraum"/"Vergleichszeitraum"-Logik (#63/#73/#78) samt aller darauf aufbauenden Tests bleibt unverändert, wer die längere Historie sehen will, wählt den neuen Preset. Wird nur angeboten, wenn dadurch tatsächlich mehr Historie zur Verfügung steht (z. B. nicht beim S&P-500-Benchmark, der ohnehin fast die gesamte Historie abdeckt).

Beispiel Barbell 20/80: „Gesamte Historie" (ab 2021, Look-ahead-bereinigt) zeigt +118,72 %, „Erweitert" (ab 2006) zeigt +1245,15 % bei plausibler Volatilität/Max Drawdown/Sharpe – keine Ausreißer, das Depot bleibt durchgehend voll investiert und positiv.

## #72 – Schalter für Benchmark
War bereits vollständig umgesetzt (Commit `c7efdc4`, vor dieser PR auf `main`). Issue mit Erklärung geschlossen: `FR0010755611` fehlt bewusst weiterhin wegen des 25/25-Request-Budgets bei Alpha Vantage.

## Tests
254 grün (`pytest -q`), davon 8 neue:
- `_mit_ersatzbond()` gegen eine konstruierte Zwei-Ticker-Strategie (Gewicht wandert vor Verfügbarkeit auf IBCL, danach wieder normal; Depot bleibt durchgehend positiv/voll investiert).
- Zusätzlicher Topf wird nur ergänzt, wenn der Ersatzticker noch nicht Teil der Strategie ist.
- `_zeitraum_presets()` bietet den neuen Preset nur bei tatsächlichem Historiengewinn an.
- End-to-End: Detailseite zeigt den neuen Preset bei lückenhafter Historie.
- Startseite listet alle Instrumente mit Name (#79).
- Übersichtstabelle hat Info-Tooltips an den Kennzahl-Spalten (#81).
- Startseite zeigt die Korrelationsgrafik (#82).

CLAUDE.md ist entsprechend nachgezogen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmAPR8dtBWg4SEHFBkN4mL)_