### PR TITLE
Wert nach Steuern beim sofortigen Verkauf (Liquidationswert)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,32 @@ inkrementell fortgeschrieben).
   Steuerbar über den fünften `Optimierungen`-Schalter `fondskosten`. Bestehende
   handgerechnete Engine-Tests, die ETFs verwenden, setzen `fondskosten=False`,
   damit sie weiterhin genau ihren eigenen Mechanismus prüfen.
+  **Liquidationswert nach Steuer (Sofortverkauf zum Stichtag):** `kumulierte_
+  steuer` (siehe oben) erfasst nur bereits TATSÄCHLICH realisierte Trades
+  (Rebalancing, Dezember-Harvest) — der Anteil des Endwerts, der noch in
+  unrealisierten Gewinnen laufender Positionen steckt, bleibt dort unversteuert.
+  `SimulationResult` führt deshalb drei zusätzliche Felder
+  (`liquidationswert_nach_steuer`/`liquidationssteuer`/`liquidationsgebuehren`):
+  ein hypothetischer Verkauf des GESAMTEN Depots zum Stichtag der letzten
+  Kurszeile, berechnet direkt im Anschluss an die Hauptschleife in
+  `simulate()` (braucht Zugriff auf `positions[t].cost_total`/
+  `avg_kauf_tag_ordinal()`, die nicht Teil von `SimulationResult` sind — daher
+  kein Darstellungsschicht-Mechanismus wie sonst üblich). Spiegelt denselben
+  Verkaufsmechanismus wie `rebalance_to_targets()`: Ordergebühr mindert den
+  realisierten Gewinn (`gain_roh = wert - cost_total - gebuehr`), Teilfreistellung
+  gilt symmetrisch für Gewinn/Verlust, und Instrumente mit Spekulationsfrist
+  (#37, BTC-EUR) laufen über die getrennte Freigrenze statt den
+  Sparerpauschbetrag/Verlustvortrag zu berühren. Rechnet dabei bewusst auf
+  KOPIEN von `freibetrag_verbleibend`/`verlustvortrag`/`spek_verlustvortrag`/
+  `spek_gewinn_jahr` statt die nonlocal-Variablen zu mutieren — `tax_status`
+  bleibt dadurch unverändert eine Aussage über tatsächlich realisierte Gewinne,
+  die neuen Felder sind eine rein additive Momentaufnahme obendrauf.
+  `dashboard._build_strategy_view()` zeigt das Ergebnis auf der Detailseite in
+  der Box „Wert nach Steuern beim sofortigen Verkauf" — bewusst zusätzlich zur
+  „Geschätzten Nettorendite" (F6a) statt als deren Ersatz: F6a zieht nur die
+  bereits realisierte Steuer ab, diese Box zusätzlich die auf die noch
+  unrealisierten Gewinne UND die Verkaufsgebühren, ist also die realistischere
+  Antwort auf „was bleibt vom eingesetzten Kapital tatsächlich übrig".
 - `dashboard.py` + `templates/` — reine Darstellungsschicht, rendert
   `engine.simulate()`-Ergebnisse für alle (oder eine ausgewählte)
   Strategie(n) aus `STRATEGIES`. Seit #31 mehrere Seitentypen statt einer

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -781,6 +781,18 @@ def _build_strategy_view(
     else:
         netto_rendite_pct = Decimal(0)
     netto_cagr_pct = _cagr_pct(_f(netto_rendite_pct), tage)
+    # Sofortverkauf zum Stichtag der letzten Kurszeile: anders als die "geschätzte
+    # Nettorendite" oben (die nur die bereits TATSÄCHLICH realisierte Steuer vom
+    # Bruttoendwert abzieht) zieht result.liquidationswert_nach_steuer zusätzlich
+    # Ordergebühren und Steuer auf die bislang UNREALISIERTEN Gewinne jeder noch
+    # gehaltenen Position ab (engine.simulate(), berechnet auf Kopien des
+    # Steuerledgers - siehe Kommentar dort) - die realistischere Antwort auf "was
+    # bleibt vom eingesetzten Kapital, wenn ich heute alles verkaufe".
+    liquidationswert = result.liquidationswert_nach_steuer
+    if strategy.startkapital > 0:
+        liquidations_rendite_pct = (liquidationswert - strategy.startkapital) / strategy.startkapital * 100
+    else:
+        liquidations_rendite_pct = Decimal(0)
     volatilitaet_pct = _volatilitaet_pct(total_values)
     max_drawdown_pct = _max_drawdown_pct(total_values)
     risikofreier_zins_pct = _risikofreier_zins_pct(rows)
@@ -825,6 +837,10 @@ def _build_strategy_view(
         "cagr_label": f"{cagr_pct:+.2f}",
         "netto_rendite_pct_label": f"{netto_rendite_pct:+.2f}",
         "netto_cagr_label": f"{netto_cagr_pct:+.2f}",
+        "liquidationswert_label": f"{liquidationswert:.2f}",
+        "liquidationssteuer_label": f"{result.liquidationssteuer:.2f}",
+        "liquidationsgebuehren_label": f"{result.liquidationsgebuehren:.2f}",
+        "liquidations_rendite_pct_label": f"{liquidations_rendite_pct:+.2f}",
         "gewinn_label": f"{gewinn:+.2f}",
         "volatilitaet_pct": volatilitaet_pct,
         "volatilitaet_label": f"{volatilitaet_pct:.2f}",

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -141,6 +141,16 @@ class SimulationResult:
     tax_status: TaxStatus
     last_rebalance_date: date | None
     last_harvest_date: date | None
+    # Hypothetischer Sofortverkauf des GESAMTEN Depots zum Stichtag der letzten
+    # Kurszeile: was vom Depotwert bliebe nach Ordergebühren und Steuer auf die
+    # bislang UNREALISIERTEN Gewinne übrig. Siehe Kommentar an
+    # ``_liquidation_nach_steuer()`` weiter unten für die Berechnung. Rein
+    # zusätzliche Momentaufnahme - ändert nichts an ``tax_status`` (die bleibt
+    # eine Aussage über tatsächlich realisierte Trades) oder am simulierten
+    # Wertverlauf.
+    liquidationswert_nach_steuer: Decimal = Decimal(0)
+    liquidationssteuer: Decimal = Decimal(0)
+    liquidationsgebuehren: Decimal = Decimal(0)
 
 
 @dataclass
@@ -830,6 +840,67 @@ def simulate(
     )
     holdings = {t: positions[t].units for t in tickers}
 
+    # --- Sofortverkauf zum Stichtag der letzten Kurszeile -----------------------
+    #
+    # Was bliebe vom Depotwert, würde JETZT (der letzten Kurszeile) das gesamte
+    # Depot verkauft? ``total_value``/``values`` (aus der letzten Schleifeniteration
+    # oben) sind Bruttowerte - unrealisierte Gewinne stecken noch unversteuert in
+    # jeder Position, ``kumulierte_steuer`` erfasst nur bereits TATSÄCHLICH
+    # realisierte Trades (Rebalancing, Dezember-Harvest). Diese Rechnung spiegelt
+    # denselben Verkaufs-Mechanismus wie ``rebalance_to_targets()``: Gebühr
+    # mindert den realisierten Gewinn (``realized_gain = proceeds - cost_removed -
+    # gebuehr``), Teilfreistellung gilt symmetrisch für Gewinn/Verlust
+    # (``process_realized_gain``), und Instrumente mit Spekulationsfrist (#37,
+    # nur BTC-EUR) laufen über die getrennte Freigrenze statt den
+    # Sparerpauschbetrag/Verlustvortrag zu berühren - beides auf KOPIEN des
+    # Steuerledgers, damit ``tax_status`` unverändert eine Aussage über
+    # tatsächlich realisierte Gewinne bleibt.
+    gehaltene_ticker = [t for t in tickers if positions[t].units > 0]
+    liquidationsgebuehren = gebuehr * len(gehaltene_ticker)
+    liquidationssteuer = Decimal(0)
+    if opt.besteuerung:
+        freibetrag_liq = freibetrag_verbleibend
+        verlust_liq = verlustvortrag
+        spek_verlust_liq = spek_verlustvortrag
+        spek_gewinn_liq = spek_gewinn_jahr
+        for t in gehaltene_ticker:
+            gain_roh = values.get(t, Decimal(0)) - positions[t].cost_total - gebuehr
+            frist = _spekulationsfrist_tage(t)
+            if frist is not None:
+                haltedauer = Decimal(rows[-1].date.toordinal()) - positions[t].avg_kauf_tag_ordinal()
+                if haltedauer > frist:
+                    continue  # Frist abgelaufen -> steuerfrei, § 23 EStG
+                if gain_roh <= 0:
+                    spek_verlust_liq += -gain_roh
+                    continue
+                offset = min(gain_roh, spek_verlust_liq)
+                spek_verlust_liq -= offset
+                rest = gain_roh - offset
+                vorher = spek_gewinn_liq
+                spek_gewinn_liq += rest
+                steuer_vorher = (
+                    vorher * STEUERSATZ if vorher > SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR else Decimal(0)
+                )
+                steuer_nachher = (
+                    spek_gewinn_liq * STEUERSATZ
+                    if spek_gewinn_liq > SPEKULATIONSFRIST_FREIGRENZE_PRO_JAHR
+                    else Decimal(0)
+                )
+                liquidationssteuer += steuer_nachher - steuer_vorher
+                continue
+            gain = gain_roh * (1 - _teilfreistellung(t))
+            if gain <= 0:
+                verlust_liq += -gain
+                continue
+            offset_verlust = min(gain, verlust_liq)
+            verlust_liq -= offset_verlust
+            rest = gain - offset_verlust
+            offset_freibetrag = min(rest, freibetrag_liq)
+            freibetrag_liq -= offset_freibetrag
+            steuerpflichtig = rest - offset_freibetrag
+            liquidationssteuer += steuerpflichtig * STEUERSATZ
+    liquidationswert_nach_steuer = total_value - liquidationsgebuehren - liquidationssteuer
+
     return SimulationResult(
         strategy_name=strategy.name,
         value_history=value_history,
@@ -838,4 +909,7 @@ def simulate(
         tax_status=tax_status,
         last_rebalance_date=last_rebalance_date,
         last_harvest_date=last_harvest_date,
+        liquidationswert_nach_steuer=liquidationswert_nach_steuer,
+        liquidationssteuer=liquidationssteuer,
+        liquidationsgebuehren=liquidationsgebuehren,
     )

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -31,6 +31,23 @@
       real fallen Steuern unterjährig zu unterschiedlichen Zeitpunkten an,
       nicht als einmaliger Abzug am Ende (#63, F6a).
     </p>
+    <div class="stat-row">
+      <div class="stat-tile"><div class="label">Wert nach Steuern beim sofortigen Verkauf<span class="info-tip" tabindex="0" title="Hypothetischer Verkauf des GESAMTEN Depots zum Stichtag der letzten Kurszeile: Bruttoendwert minus Ordergebühren minus Steuer auf die bislang unrealisierten Gewinne jeder noch gehaltenen Position (Sparerpauschbetrag/Verlustvortrag bzw. bei BTC die eigene Spekulationsfrist-Freigrenze werden dabei berücksichtigt).">i</span></div><div class="value">{{ s.liquidationswert_label }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">davon Steuer auf unrealisierte Gewinne</div><div class="value">{{ s.liquidationssteuer_label }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">davon Ordergebühren</div><div class="value">{{ s.liquidationsgebuehren_label }} &euro;</div></div>
+      <div class="stat-tile"><div class="label">Rendite % nach vollständiger Versteuerung</div><div class="value">{{ s.liquidations_rendite_pct_label }}</div></div>
+    </div>
+    <p class="hint">
+      Der Unterschied zur "Geschätzten Nettorendite" oben: die zieht nur die
+      bereits <em>tatsächlich realisierte</em> Steuer (aus Rebalancing- und
+      Dezember-Harvest-Verkäufen) vom Endwert ab. Der "Wert nach Steuern beim
+      sofortigen Verkauf" geht einen Schritt weiter und rechnet zusätzlich die
+      Steuer, die auf die noch <em>unrealisierten</em> Gewinne der aktuell
+      gehaltenen Positionen fällig würde, wenn das komplette Depot heute
+      verkauft würde &ndash; plus die dafür anfallenden Ordergebühren. Das ist
+      die realistischere Antwort auf "was bleibt vom eingesetzten Kapital
+      tatsächlich übrig".
+    </p>
     {% if s.zeitraum_presets %}
     <h3>Kennzahlen nach Betrachtungszeitraum</h3>
     <p class="hint">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -13,6 +13,8 @@ from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
 
+import pytest
+
 import boersenspiel.dashboard as dashboard_module
 from boersenspiel.dashboard import (
     _allokierte_ticker,
@@ -919,6 +921,42 @@ def test_netto_rendite_liegt_unter_der_bruttorendite_wenn_steuer_anfaellt():
     brutto = float(view["cagr_label"].replace(",", "."))
     netto = float(view["netto_cagr_label"].replace(",", "."))
     assert netto < brutto
+
+
+# --- Wert nach Steuern beim sofortigen Verkauf (Liquidationswert) -----------
+
+
+def test_build_strategy_view_uebernimmt_den_liquidationswert_aus_dem_ergebnis():
+    rows = [
+        PriceRow(date(2024, 1, 1), {"T1": Decimal("100"), "T2": Decimal("100")}),
+        PriceRow(date(2024, 1, 8), {"T1": Decimal("1000"), "T2": Decimal("100")}),
+    ]
+    result = simulate(rows, GROSSER_GEWINN_STRATEGY)
+    view = _build_strategy_view(GROSSER_GEWINN_STRATEGY, result, rows)
+
+    assert float(view["liquidationswert_label"]) == pytest.approx(float(result.liquidationswert_nach_steuer), abs=0.01)
+    assert float(view["liquidationssteuer_label"]) == pytest.approx(float(result.liquidationssteuer), abs=0.01)
+    assert float(view["liquidationsgebuehren_label"]) == pytest.approx(float(result.liquidationsgebuehren), abs=0.01)
+    # Gesamtwert - Steuer - Gebuehren muss exakt den ausgewiesenen Liquidationswert ergeben.
+    gesamtwert = float(result.value_history[-1].total_value)
+    assert gesamtwert - float(view["liquidationssteuer_label"]) - float(view["liquidationsgebuehren_label"]) == float(
+        view["liquidationswert_label"]
+    )
+    # Bei diesem grossen unrealisierten Rebalance-Gewinn ist die Steuer > 0,
+    # der Liquidationswert liegt also unter dem Bruttoendwert.
+    assert float(view["liquidationssteuer_label"]) > 0
+    assert float(view["liquidationswert_label"]) < gesamtwert
+
+
+def test_build_dashboard_zeigt_liquidationsbox_auf_detailseite(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    detail_html = _detail_html(tmp_path, "a-verdoppler")
+
+    assert "Wert nach Steuern beim sofortigen Verkauf" in detail_html
+    assert "Rendite % nach vollständiger Versteuerung" in detail_html
+    # Nur auf der Detailseite, nicht auf der Startseite (#31-Trennung).
+    index_html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "Wert nach Steuern beim sofortigen Verkauf" not in index_html
 
 
 # --- #66: veraltete Instrumentenzahl, unallokierte Instrumente unerklaert ----------

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -529,6 +529,116 @@ def test_btc_gewinn_nach_ablauf_der_spekulationsfrist_ist_steuerfrei():
     assert result.tax_status.freibetrag_verbleibend == Decimal("1000")
 
 
+# --- Sofortverkauf zum Stichtag (Liquidationswert nach Steuer) --------------
+
+
+def test_liquidationswert_zieht_steuer_auf_unrealisierten_gewinn_ab():
+    # Einzige Position 4GLD (0% Teilfreistellung), keine Rebalance-Verkaeufe,
+    # keine Ordergebuehr (isoliert die Steuerrechnung) - der komplette Gewinn
+    # bleibt bis zum Schluss unrealisiert und steckt nur in
+    # liquidationswert_nach_steuer, nicht in tax_status.kumulierte_steuer.
+    # Kauf: 100.000 / 100 = 1000 Einheiten, cost_total = 100.000.
+    # Verkaufswert: 1000 * 300 = 300.000 -> Gewinn 200.000.
+    # Nach Sparerpauschbetrag (1000): 199.000 * 26,375% = 52.486,25 Steuer.
+    strategy = Strategy(
+        name="Test-Liquidation-Kapitalertrag",
+        startkapital=Decimal("100000"),
+        toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={"4GLD": Decimal("1")})],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("100"),
+        optimierungen=Optimierungen(ordergebuehren=False, steueroptimierung=False, fondskosten=False),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"4GLD": Decimal("100")}),
+        PriceRow(date(2024, 6, 1), {"4GLD": Decimal("300")}),
+    ]
+    result = simulate(rows, strategy)
+
+    assert result.value_history[-1].total_value == Decimal("300000")
+    assert result.tax_status.kumulierte_steuer == Decimal("0")  # nichts realisiert
+    assert result.liquidationsgebuehren == Decimal("0")
+    assert result.liquidationssteuer == Decimal("52486.25")
+    assert result.liquidationswert_nach_steuer == Decimal("247513.75")
+
+
+def test_liquidationswert_zieht_verkaufsgebuehr_je_gehaltenem_instrument_ab():
+    # Zwei gehaltene Instrumente -> zwei Verkaufsgebuehren (ORDERGEBUEHR = 1
+    # EUR je Trade). besteuerung=False isoliert den Gebuehren-Effekt: keine
+    # Steuer, nur die Gebuehr mindert den Nettowert.
+    strategy = Strategy(
+        name="Test-Liquidation-Gebuehr",
+        startkapital=Decimal("1000"),
+        toepfe=[
+            Topf(name="TopfX", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"4GLD": Decimal("1")}),
+            Topf(name="TopfY", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"EUNA": Decimal("1")}),
+        ],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("0.5"),
+        rebalancing_schwelle_pp=Decimal("100"),
+        optimierungen=Optimierungen(besteuerung=False, steueroptimierung=False, fondskosten=False),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"4GLD": Decimal("100"), "EUNA": Decimal("100")}),
+        PriceRow(date(2024, 6, 1), {"4GLD": Decimal("150"), "EUNA": Decimal("120")}),
+    ]
+    result = simulate(rows, strategy)
+
+    assert result.liquidationssteuer == Decimal("0")
+    assert result.liquidationsgebuehren == Decimal("2")  # ORDERGEBUEHR * 2 Instrumente
+    assert result.liquidationswert_nach_steuer == result.value_history[-1].total_value - Decimal("2")
+
+
+def test_liquidationswert_beruecksichtigt_spekulationsfrist_von_btc():
+    # BTC-EUR innerhalb der Spekulationsfrist (#37) mit einem Gewinn deutlich
+    # ueber der Freigrenze (1000 EUR) - der GESAMTE Gewinn wird steuerpflichtig
+    # (Kippgrenze, keine Teilfreistellung fuer BTC), landet aber im getrennten
+    # Freigrenzen-Topf statt den Sparerpauschbetrag zu verbrauchen.
+    # Kauf: 1000/100 = 10 Einheiten, cost_total = 1000. Verkauf: 10*300 = 3000
+    # -> Gewinn 2000, ueber der 1000er-Freigrenze -> 2000 * 26,375% = 527,50.
+    strategy = Strategy(
+        name="Test-Liquidation-BTC-Frist",
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={"BTC-EUR": Decimal("1")})],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("100"),
+        optimierungen=Optimierungen(ordergebuehren=False, steueroptimierung=False, fondskosten=False),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"BTC-EUR": Decimal("100")}),
+        PriceRow(date(2024, 6, 1), {"BTC-EUR": Decimal("300")}),
+    ]
+    result = simulate(rows, strategy)
+
+    assert result.liquidationssteuer == Decimal("527.50")
+    assert result.tax_status.freibetrag_verbleibend == Decimal("1000")  # unberuehrt
+    assert result.liquidationswert_nach_steuer == Decimal("3000") - Decimal("527.50")
+
+
+def test_liquidationswert_ohne_besteuerung_zieht_nur_gebuehren_ab():
+    strategy = Strategy(
+        name="Test-Liquidation-ohne-Besteuerung",
+        startkapital=Decimal("100000"),
+        toepfe=[Topf(name="TopfX", gewicht_gesamt=Decimal("1"), sub_gewichte={"4GLD": Decimal("1")})],
+        ziel_topf="TopfX",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("100"),
+        optimierungen=Optimierungen(besteuerung=False, steueroptimierung=False, fondskosten=False),
+    )
+    rows = [
+        PriceRow(date(2024, 1, 1), {"4GLD": Decimal("100")}),
+        PriceRow(date(2024, 6, 1), {"4GLD": Decimal("300")}),
+    ]
+    result = simulate(rows, strategy)
+
+    assert result.liquidationssteuer == Decimal("0")
+    # ORDERGEBUEHR faellt unabhaengig von opt.besteuerung an (reine
+    # Steuerabschaltung, keine Gebuehrenbefreiung).
+    assert result.liquidationsgebuehren == Decimal("1")
+    assert result.liquidationswert_nach_steuer == result.value_history[-1].total_value - Decimal("1")
+
+
 def test_missing_price_in_later_row_values_with_last_known_price():
     # T2 fehlt in der mittleren Zeile - die Position darf nicht aus der Summe
     # herausfallen, sondern wird mit dem letzten bekannten Kurs bewertet.


### PR DESCRIPTION
Beantwortet die Frage: würde man zum Stichtag der letzten Kurszeile das gesamte Depot verkaufen, was bliebe vom eingesetzten Kapital nach Steuern übrig?

## Hintergrund
`engine.py` führt `kumulierte_steuer` bewusst nur als Tracking-Größe für **tatsächlich realisierte** Trades (Rebalancing, Dezember-Harvest) – der simulierte Depotwert selbst ist überall ein Bruttowert. Die bestehende „Geschätzte Nettorendite" (#63, F6a) zieht deshalb nur diese bereits realisierte Steuer vom Endwert ab; die Steuer auf noch **unrealisierte** Gewinne der aktuell gehaltenen Positionen fehlt darin komplett.

## Umsetzung
`engine.simulate()` berechnet direkt im Anschluss an die Hauptschleife einen hypothetischen Sofortverkauf des gesamten Depots zum Stichtag der letzten Kurszeile (neue Felder auf `SimulationResult`: `liquidationswert_nach_steuer`, `liquidationssteuer`, `liquidationsgebuehren`). Das braucht Zugriff auf `positions[t].cost_total`/`avg_kauf_tag_ordinal()`, die nicht Teil des öffentlichen Ergebnisses sind – deshalb in der Engine statt wie sonst üblich in der Darstellungsschicht.

Spiegelt denselben Verkaufsmechanismus wie `rebalance_to_targets()`:
- Ordergebühr mindert den realisierten Gewinn (`gain = wert − cost_total − gebuehr`)
- Teilfreistellung (30 % für Aktienfonds-ETFs) gilt symmetrisch für Gewinn/Verlust
- Instrumente mit Spekulationsfrist (§ 23 EStG, nur BTC-EUR) laufen über die getrennte Freigrenze statt den Sparerpauschbetrag/Verlustvortrag zu berühren

Rechnet dabei auf **Kopien** des Steuerledgers (`freibetrag_verbleibend`, `verlustvortrag`, `spek_verlustvortrag`, `spek_gewinn_jahr`) – `tax_status` bleibt dadurch unverändert eine Aussage über tatsächlich realisierte Gewinne, die neuen Felder sind eine rein additive Momentaufnahme obendrauf.

## Dashboard
Neue Box **„Wert nach Steuern beim sofortigen Verkauf"** auf jeder Detailseite, zusätzlich zur bestehenden „Geschätzten Nettorendite" (nicht als Ersatz): Aufschlüsselung nach Steuer auf unrealisierte Gewinne, Ordergebühren, und der resultierenden Rendite nach vollständiger Versteuerung, mit Info-Tooltip und erklärendem Hinweistext zum Unterschied zu F6a.

## Tests
260 grün (`pytest -q`), davon 6 neue:
- Handgerechneter Kapitalertrag-Fall (großer unrealisierter Gewinn, Steuer nach Sparerpauschbetrag).
- Ordergebühr wird je gehaltenem Instrument abgezogen.
- BTC innerhalb der Spekulationsfrist über der Freigrenze (voller Gewinn steuerpflichtig, Sparerpauschbetrag bleibt unberührt).
- `opt.besteuerung=False` zieht nur noch Gebühren ab, keine Steuer.
- `_build_strategy_view()` übernimmt die Werte korrekt (Gesamtwert − Steuer − Gebühren = Liquidationswert).
- End-to-End: Box erscheint nur auf der Detailseite, nicht auf der Startseite.

CLAUDE.md ist entsprechend nachgezogen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmAPR8dtBWg4SEHFBkN4mL)_