### PR TITLE
Sprachumschalter Deutsch/Englisch im Dreipunktmenü

### DIFF
--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -51,6 +51,14 @@ _OPTIMIERUNGS_LABELS: dict[str, str] = {
     "besteuerung": "Besteuerung",
     "fondskosten": "Laufende Fondskosten (TER)",
 }
+# Englische Fassung fuers clientseitige Sprachumschalten (Dreipunktmenue).
+_OPTIMIERUNGS_LABELS_EN: dict[str, str] = {
+    "steueroptimierung": "Tax optimization (December harvest)",
+    "rebalancing": "Rebalancing",
+    "ordergebuehren": "Order fees",
+    "besteuerung": "Taxation",
+    "fondskosten": "Ongoing fund costs (TER)",
+}
 
 
 # --- F4 (#63): Rueckschaufehler mit Hebel ------------------------------------------
@@ -398,6 +406,24 @@ _ZEITRAUM_PRESET_LABELS: dict[str, str] = {
     "5j": "5 Jahre",
     "alle": "Gesamte Historie",
 }
+# Englische Fassung fuers clientseitige Sprachumschalten (Dreipunktmenue).
+_ZEITRAUM_PRESET_LABELS_EN: dict[str, str] = {
+    "1j": "1 year",
+    "3j": "3 years",
+    "5j": "5 years",
+    "alle": "Entire history",
+}
+_ERWEITERT_PRESET_LABEL_EN = "Extended (replacement bond assumption)"
+
+# Englische Anzeigenamen der ueber alle Strategien/Szenarien hinweg verwendeten
+# Topf-Namen (Chart-Legenden auf den Detailseiten) - rein darstellerisch, die
+# Topf-Namen selbst (als dict-Schluessel in Strategy/engine.py) bleiben deutsch.
+_TOPF_NAMEN_EN: dict[str, str] = {
+    "Topf A - Sicherheit": "Bucket A - Safety",
+    "Topf B - Wachstum": "Bucket B - Growth",
+    "Topf C - Einzelaktien-Satellit": "Bucket C - Individual Stock Satellite",
+    "Topf A - Benchmark": "Bucket A - Benchmark",
+}
 
 
 def _benchmark_reihen(rows: list[PriceRow], strategy: Strategy) -> list[dict]:
@@ -442,7 +468,9 @@ def _jahre_zurueck(stichtag: date, jahre: int) -> date:
         return stichtag.replace(year=stichtag.year - jahre, day=28)
 
 
-def _preset_eintrag(preset_id: str, label: str, preset_rows: list[PriceRow], strategy: Strategy) -> dict:
+def _preset_eintrag(
+    preset_id: str, label: str, preset_rows: list[PriceRow], strategy: Strategy, label_en: str | None = None
+) -> dict:
     result = simulate(preset_rows, strategy)
     # Risikofreier Zins aus dem Geldmarkt-ETF ueber genau DIESEN Preset-Zeitraum
     # (#75) - ein 1-Jahres-Preset im Hochzinsumfeld hat einen anderen Referenzzins
@@ -454,6 +482,7 @@ def _preset_eintrag(preset_id: str, label: str, preset_rows: list[PriceRow], str
     return {
         "id": preset_id,
         "label": label,
+        "label_en": label_en or label,
         "rendite_pct": _f(rendite_pct),
         "rendite_label": f"{rendite_pct:+.2f}",
         "volatilitaet_label": f"{_volatilitaet_pct(total_values):.2f}",
@@ -481,7 +510,15 @@ def _zeitraum_presets(
             preset_rows = [r for r in rows if r.date >= cutoff]
         if len(preset_rows) < 1:
             continue
-        presets.append(_preset_eintrag(preset_id, _ZEITRAUM_PRESET_LABELS[preset_id], preset_rows, strategy))
+        presets.append(
+            _preset_eintrag(
+                preset_id,
+                _ZEITRAUM_PRESET_LABELS[preset_id],
+                preset_rows,
+                strategy,
+                _ZEITRAUM_PRESET_LABELS_EN[preset_id],
+            )
+        )
     # #80: zusaetzlicher Preset ueber die volle (nicht auf "alle Zielinstrumente
     # handelbar" zurechtgeschnittene) Historie, mit der Ersatzbond-Annahme statt
     # der Look-ahead-Vermeidung aus F4/#63 - nur anbieten, wenn dadurch
@@ -490,7 +527,13 @@ def _zeitraum_presets(
     if erweiterte_rows is not None and erweiterte_rows and erweiterte_rows[0].date < rows[0].date:
         erweiterte_strategie = _mit_ersatzbond(strategy)
         presets.append(
-            _preset_eintrag("erweitert", "Erweitert (Ersatzbond-Annahme)", erweiterte_rows, erweiterte_strategie)
+            _preset_eintrag(
+                "erweitert",
+                "Erweitert (Ersatzbond-Annahme)",
+                erweiterte_rows,
+                erweiterte_strategie,
+                _ERWEITERT_PRESET_LABEL_EN,
+            )
         )
     return presets
 
@@ -702,6 +745,7 @@ def _optimierungs_effekte(
         effekte.append(
             {
                 "name": label,
+                "name_en": _OPTIMIERUNGS_LABELS_EN[feld],
                 "delta_pp": delta_pp,
                 "delta_label": f"{delta_pp:+.2f}",
                 "ohne_rendite_label": f"{ohne_rendite_pct:+.2f}",
@@ -831,6 +875,7 @@ def _build_strategy_view(
         "name": result.strategy_name,
         "id": _slug(result.strategy_name),
         "beschreibung": strategy.beschreibung,
+        "beschreibung_en": strategy.beschreibung_en or strategy.beschreibung,
         "rendite_pct": _f(rendite_pct),
         "rendite_pct_label": f"{rendite_pct:+.2f}",
         "cagr_pct": cagr_pct,
@@ -990,7 +1035,9 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
             "isin": inst.isin or "–",
             "teilfreistellung": f"{inst.teilfreistellung * 100:.0f}",
             "thesaurierend": "ja" if inst.thesaurierend else "nein",
+            "thesaurierend_en": "yes" if inst.thesaurierend else "no",
             "ausschuettend": "ja" if inst.ausschuettend else "nein",
+            "ausschuettend_en": "yes" if inst.ausschuettend else "no",
             # #74: je Instrument statt eines Pauschalwerts fuer alle. "-" fuer
             # Instrumente, die nicht ausschuetten; der Platzhalter erscheint nur
             # dort, wo tatsaechlich kein instrumenteneigener Wert hinterlegt ist.
@@ -1005,6 +1052,9 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
             "ter": f"{float(inst.ter) * 100:.2f}".replace(".", ",") if inst.ter else "–",
             "spekulationsfrist": (
                 f"{inst.spekulationsfrist_tage} Tage" if inst.spekulationsfrist_tage else "–"
+            ),
+            "spekulationsfrist_en": (
+                f"{inst.spekulationsfrist_tage} days" if inst.spekulationsfrist_tage else "–"
             ),
             "erster_kurs": erste.get(ticker, "– (nie)"),
             "fehlt_anfangs": erste.get(ticker) != rows[0].date.isoformat(),
@@ -1026,8 +1076,10 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
                 "schwelle": f"{s.rebalancing_schwelle_pp}",
                 "schwelle_relativ": f"{s.rebalancing_schwelle_relativ * 100:.0f}",
                 "ziel_topf": s.ziel_topf,
+                "ziel_topf_en": _TOPF_NAMEN_EN.get(s.ziel_topf, s.ziel_topf),
                 "ziel_gewicht": f"{s.ziel_gewicht * 100:.0f}",
                 "dynamisch": "ja" if s.gewichte_fn is not None else "nein",
+                "dynamisch_en": "yes" if s.gewichte_fn is not None else "no",
                 "toepfe": [
                     {"name": t.name, "gewicht": f"{t.gewicht_gesamt * 100:.0f}"} for t in s.toepfe
                 ],
@@ -1233,6 +1285,7 @@ def build_dashboard(
             {"ticker": t, "name": INSTRUMENTS[t].name} for t in TICKERS
         ],
         benchmark_optionen=[{"id": k, "label": v} for k, v in benchmark_optionen.items()],
+        topf_namen_en_json=json.dumps(_TOPF_NAMEN_EN),
         **vergleich_kontext,
     )
 

--- a/src/boersenspiel/learnings.py
+++ b/src/boersenspiel/learnings.py
@@ -11,6 +11,10 @@ bereits gerenderten Strategie-Views aus ``dashboard.py``. Liefert sie ``None``,
 lässt sich die Frage aus den vorhandenen Daten nicht beantworten (z. B. weil zu
 wenige Strategien vorliegen) - dann fällt das Learning still weg, statt eine
 Aussage zu erfinden.
+
+Jede Regel liefert ihre drei Textfelder zweisprachig (``*_de``/``*_en``) - das
+Dashboard rendert Deutsch als Standard und blendet Englisch per
+data-i18n-en-Attribut clientseitig ein (Dreipunktmenü-Sprachumschalter).
 """
 
 from __future__ import annotations
@@ -22,9 +26,12 @@ from .strategies import ORDERGEBUEHR
 
 @dataclass(frozen=True)
 class Learning:
-    titel: str
-    kernaussage: str  # eine Zeile, die Zahl im Vordergrund
-    detail: str  # Einordnung/Begründung
+    titel_de: str
+    titel_en: str
+    kernaussage_de: str  # eine Zeile, die Zahl im Vordergrund
+    kernaussage_en: str
+    detail_de: str  # Einordnung/Begründung
+    detail_en: str
 
 
 def _nach_rendite(views: list[dict]) -> list[dict]:
@@ -48,6 +55,22 @@ def _eur(wert: float) -> str:
     return f"{wert:,.0f} €".replace(",", ".")
 
 
+def _zahl_en(wert: float, nachkommastellen: int) -> str:
+    return f"{wert:.{nachkommastellen}f}"
+
+
+def _pp_en(wert: float) -> str:
+    return f"{_zahl_en(wert, 2)} pp" if wert < 0 else f"+{_zahl_en(wert, 2)} pp"
+
+
+def _pct_en(wert: float) -> str:
+    return f"{_zahl_en(wert, 2)}%" if wert < 0 else f"+{_zahl_en(wert, 2)}%"
+
+
+def _eur_en(wert: float) -> str:
+    return f"€{wert:,.0f}"
+
+
 def _spannweite(views: list[dict]) -> Learning | None:
     """Wie viel hängt überhaupt an der Regel - bei identischer Kurshistorie?"""
     if len(views) < 2:
@@ -56,17 +79,29 @@ def _spannweite(views: list[dict]) -> Learning | None:
     bester, schlechtester = rangliste[0], rangliste[-1]
     spread = bester["rendite_pct"] - schlechtester["rendite_pct"]
     return Learning(
-        titel="Die Regel entscheidet, nicht der Markt",
-        kernaussage=(
+        titel_de="Die Regel entscheidet, nicht der Markt",
+        titel_en="The rule decides, not the market",
+        kernaussage_de=(
             f"{_pp(spread)} Unterschied zwischen bester und schlechtester Regel - "
             f"bei exakt derselben Kurshistorie."
         ),
-        detail=(
+        kernaussage_en=(
+            f"{_pp_en(spread)} difference between the best and worst rule - "
+            f"on exactly the same price history."
+        ),
+        detail_de=(
             f"„{bester['name']}\" kommt auf {_pct(bester['rendite_pct'])}, "
             f"„{schlechtester['name']}\" auf {_pct(schlechtester['rendite_pct'])}. "
             f"Alle {len(views)} Läufe sehen dieselben Kurse, dasselbe Startkapital und "
             f"dieselbe Steuer-/Gebührenlogik. Der gesamte Unterschied entsteht allein "
             f"daraus, wann umgeschichtet wird."
+        ),
+        detail_en=(
+            f"\"{bester['name']}\" reaches {_pct_en(bester['rendite_pct'])}, "
+            f"\"{schlechtester['name']}\" reaches {_pct_en(schlechtester['rendite_pct'])}. "
+            f"All {len(views)} runs see the same prices, the same starting capital and "
+            f"the same tax/fee logic. The entire difference comes purely from when the "
+            f"portfolio gets reshuffled."
         ),
     )
 
@@ -82,18 +117,31 @@ def _aktivitaet(views: list[dict]) -> Learning | None:
     if aktivste["name"] == ruhigste["name"]:
         return None
     return Learning(
-        titel="Mehr Handeln ist nicht mehr Rendite",
-        kernaussage=(
+        titel_de="Mehr Handeln ist nicht mehr Rendite",
+        titel_en="More trading isn't more return",
+        kernaussage_de=(
             f"Die handelsintensivste Regel ({aktivste['trade_count']} Trades) landet auf "
             f"Platz {platz[aktivste['name']]} von {len(views)}, die ruhigste "
             f"({ruhigste['trade_count']} Trades) auf Platz {platz[ruhigste['name']]}."
         ),
-        detail=(
+        kernaussage_en=(
+            f"The most trade-intensive rule ({aktivste['trade_count']} trades) ends up in "
+            f"rank {platz[aktivste['name']]} of {len(views)}, the quietest one "
+            f"({ruhigste['trade_count']} trades) in rank {platz[ruhigste['name']]}."
+        ),
+        detail_de=(
             f"„{aktivste['name']}\" handelt am meisten und erreicht "
             f"{_pct(aktivste['rendite_pct'])}; „{ruhigste['name']}\" handelt am wenigsten "
             f"und erreicht {_pct(ruhigste['rendite_pct'])}. Jeder Trade kostet "
             f"{ORDERGEBUEHR} € Gebühr und kann zusätzlich Gewinne steuerpflichtig "
             f"realisieren - Aktivität muss diesen Aufschlag erst wieder verdienen."
+        ),
+        detail_en=(
+            f"\"{aktivste['name']}\" trades the most and reaches "
+            f"{_pct_en(aktivste['rendite_pct'])}; \"{ruhigste['name']}\" trades the least "
+            f"and reaches {_pct_en(ruhigste['rendite_pct'])}. Every trade costs "
+            f"€{ORDERGEBUEHR} in fees and can additionally trigger taxable realized "
+            f"gains - activity first has to earn back that surcharge."
         ),
     )
 
@@ -111,17 +159,29 @@ def _reibungskosten(views: list[dict]) -> Learning | None:
         return None
     anteil = gesamt / aktivste["startkapital_num"] * 100
     return Learning(
-        titel="Reibung ist sichtbar, aber selten entscheidend",
-        kernaussage=(
+        titel_de="Reibung ist sichtbar, aber selten entscheidend",
+        titel_en="Friction is visible, but rarely decisive",
+        kernaussage_de=(
             f"{_eur(gesamt)} Gebühren und Steuer bei „{aktivste['name']}\" - "
             f"{_zahl(anteil, 1)} % des Startkapitals."
         ),
-        detail=(
+        kernaussage_en=(
+            f"{_eur_en(gesamt)} in fees and tax for \"{aktivste['name']}\" - "
+            f"{_zahl_en(anteil, 1)}% of the starting capital."
+        ),
+        detail_de=(
             f"Davon {_eur(gebuehren)} Ordergebühren ({aktivste['trade_count']} Trades × "
             f"{ORDERGEBUEHR} €) und {_eur(steuer)} kumulierte Steuer. Das erklärt einen "
             f"Teil des Rückstands aktiver Regeln, aber nicht die großen Abstände in der "
             f"Übersicht - die entstehen dadurch, zu welchen Kursen umgeschichtet wird, "
             f"nicht durch die Transaktionskosten."
+        ),
+        detail_en=(
+            f"Of that, {_eur_en(gebuehren)} order fees ({aktivste['trade_count']} trades × "
+            f"€{ORDERGEBUEHR}) and {_eur_en(steuer)} cumulative tax. That explains part "
+            f"of the gap for active rules, but not the large gaps in the overview - "
+            f"those come from the prices at which the portfolio gets reshuffled, not "
+            f"from transaction costs."
         ),
     )
 
@@ -136,21 +196,38 @@ def _kombinationseffekt(views: list[dict]) -> Learning | None:
     negativ = [b for b in beitraege if b["delta_pp"] < 0]
     bester = max(beitraege, key=lambda b: b["delta_pp"])
     schlechtester = min(beitraege, key=lambda b: b["delta_pp"])
+    rueckhalt_de = "einziger Rückhalt" if len(negativ) == len(beitraege) - 1 else "stärkster Rückhalt"
+    rueckhalt_en = "sole positive contributor" if len(negativ) == len(beitraege) - 1 else "strongest positive contributor"
     return Learning(
-        titel="Regeln zusammenwerfen macht sie nicht besser",
-        kernaussage=(
+        titel_de="Regeln zusammenwerfen macht sie nicht besser",
+        titel_en="Throwing rules together doesn't make them better",
+        kernaussage_de=(
             f"„{kombi['name']}\" kommt auf {_pct(kombi['rendite_pct'])}; "
             f"{len(negativ)} von {len(beitraege)} Teilregeln liefern einen negativen "
             f"Beitrag."
         ),
-        detail=(
+        kernaussage_en=(
+            f"\"{kombi['name']}\" reaches {_pct_en(kombi['rendite_pct'])}; "
+            f"{len(negativ)} of {len(beitraege)} sub-rules contribute a negative "
+            f"effect."
+        ),
+        detail_de=(
             f"Größter Bremsklotz ist „{schlechtester['name']}\" mit "
             f"{_pp(schlechtester['delta_pp'])}, "
-            f"{'einziger Rückhalt' if len(negativ) == len(beitraege) - 1 else 'stärkster Rückhalt'} "
+            f"{rueckhalt_de} "
             f"„{bester['name']}\" mit {_pp(bester['delta_pp'])}. Sich widersprechende "
             f"Signale erzeugen Hin- und Her-Umschichtungen (Whipsaw): erst nach einem "
             f"Rückgang verkaufen, dann nach der Erholung zurückkaufen. Die Einzeleffekte "
             f"stehen im Detailabschnitt der Strategie."
+        ),
+        detail_en=(
+            f"The biggest drag is \"{schlechtester['name']}\" at "
+            f"{_pp_en(schlechtester['delta_pp'])}, the "
+            f"{rueckhalt_en} is "
+            f"\"{bester['name']}\" at {_pp_en(bester['delta_pp'])}. Contradicting "
+            f"signals produce back-and-forth reshuffling (whipsaw): selling after a "
+            f"decline, then buying back after the recovery. The individual effects are "
+            f"listed in the strategy's detail section."
         ),
     )
 
@@ -162,16 +239,27 @@ def _extremwerte_streuung(views: list[dict]) -> Learning | None:
     positiv = [v for v in views if v["rendite_pct"] > 0]
     anteil = len(positiv) / len(views) * 100
     return Learning(
-        titel="Ein Zeitfenster ist kein Beweis",
-        kernaussage=(
+        titel_de="Ein Zeitfenster ist kein Beweis",
+        titel_en="One time window is not proof",
+        kernaussage_de=(
             f"{len(positiv)} von {len(views)} Regeln stehen im Plus "
             f"({_zahl(anteil, 0)} %) - über genau einen historischen Zeitraum."
         ),
-        detail=(
+        kernaussage_en=(
+            f"{len(positiv)} of {len(views)} rules are in the black "
+            f"({_zahl_en(anteil, 0)}%) - over exactly one historical period."
+        ),
+        detail_de=(
             "Die Auswertung läuft über einen einzigen historischen Zeitraum und über "
             "Regeln, deren Parameter bewusst nicht optimiert wurden. Sie zeigt, wie sich "
             "diese Regeln in genau diesem Fenster verhalten hätten - kein Beleg dafür, "
             "wie sie sich künftig verhalten, und keine Anlageempfehlung."
+        ),
+        detail_en=(
+            "This evaluation runs over a single historical period, and over rules whose "
+            "parameters were deliberately not optimized. It shows how these rules would "
+            "have behaved in exactly this window - not evidence of how they will behave "
+            "in the future, and not investment advice."
         ),
     )
 

--- a/src/boersenspiel/scenarios.py
+++ b/src/boersenspiel/scenarios.py
@@ -134,6 +134,11 @@ SELL_IN_MAY = Strategy(
         "Von Mai bis September (inklusive) 100% defensiv (Topf A), sonst normale "
         "Barbell-Verteilung. Testet die Börsenweisheit 'Sell in May and go away'."
     ),
+    beschreibung_en=(
+        "100% defensive (bucket A) from May through September inclusive, otherwise "
+        "the normal barbell distribution. Tests the market saying 'Sell in May and "
+        "go away'."
+    ),
     teil_von=BOERSENWEISHEITEN_NAME,
 )
 
@@ -182,6 +187,15 @@ BUY_AND_HOLD = Strategy(
         "Dauervotum/dämpfender Anker, weil sich 'gar nicht umschichten' nicht als "
         "Quoten-Votum neben den anderen Regeln kombinieren lässt (siehe #27)."
     ),
+    beschreibung_en=(
+        "The initial allocation is never actively rebalanced ('time in the market "
+        "beats timing the market'). The December tax mechanism stays active like "
+        "for the other strategies. In the combined 'All five market sayings "
+        "combined' scenario, the same saying works differently: there it is the "
+        "only rule that always votes for the normal barbell quote and acts as a "
+        "permanent, dampening anchor, because 'never reshuffle' cannot itself be "
+        "combined as a quote vote alongside the other rules (see #27)."
+    ),
     teil_von=BOERSENWEISHEITEN_NAME,
 )
 
@@ -219,6 +233,10 @@ SANTA_CLAUS_RALLY = Strategy(
     beschreibung=(
         "In Dezember und Januar Wachstumsquote auf 95% hochgefahren ('Santa Claus "
         "Rally'), sonst normale Barbell-Verteilung."
+    ),
+    beschreibung_en=(
+        "Growth quota raised to 95% in December and January ('Santa Claus Rally'), "
+        "otherwise the normal barbell distribution."
     ),
     teil_von=BOERSENWEISHEITEN_NAME,
 )
@@ -267,6 +285,11 @@ BUY_THE_DIP = Strategy(
     beschreibung=(
         "Liegt der MSCI-World-ETF mehr als 10% unter seinem 20-Wochen-Hoch, "
         "Wachstumsquote auf 95% hochfahren ('buy the dip'), sonst normale Verteilung."
+    ),
+    beschreibung_en=(
+        "If the MSCI World ETF is more than 10% below its 20-week high, the growth "
+        "quota is raised to 95% ('buy the dip'), otherwise the normal distribution "
+        "applies."
     ),
     teil_von=BOERSENWEISHEITEN_NAME,
 )
@@ -329,6 +352,11 @@ CUT_LOSSES = Strategy(
         "Trailing-Stop je Wachstums-Instrument: fällt eines mehr als 15% unter sein "
         "eigenes 20-Wochen-Hoch, wird nur dieses auf 0% gesetzt ('cut your losses "
         "short'), andere Wachstums-Instrumente bleiben unangetastet."
+    ),
+    beschreibung_en=(
+        "A trailing stop per growth instrument: if one falls more than 15% below "
+        "its own 20-week high, only that instrument is set to 0% ('cut your losses "
+        "short'), other growth instruments are left untouched."
     ),
     teil_von=BOERSENWEISHEITEN_NAME,
 )
@@ -427,6 +455,12 @@ BOERSENWEISHEITEN = _weisheiten_strategy(
         "arithmetische Mittel der abgegebenen Voten. 'Cut your losses short, let your "
         "winners run' wirkt danach zusätzlich als Instrument-Overlay."
     ),
+    beschreibung_en=(
+        "Combines the five market sayings above into one strategy: each votes for a "
+        "growth quota (or abstains), the target quota is the arithmetic mean of the "
+        "votes cast. 'Cut your losses short, let your winners run' then additionally "
+        "acts as a per-instrument overlay."
+    ),
     beitraege=tuple(
         Beitrag(
             name=weisheit.spruch,
@@ -479,6 +513,11 @@ CHART_SMA_CROSSOVER = Strategy(
         "unter dem 40-Wochen-Durchschnitt ('Death Cross'), 100% defensiv, sonst "
         "('Golden Cross'/normal) reguläre Barbell-Gewichte."
     ),
+    beschreibung_en=(
+        "A chart-based trend indicator on the MSCI World ETF: if the 10-week "
+        "average is below the 40-week average ('death cross'), 100% defensive, "
+        "otherwise ('golden cross'/normal) regular barbell weights."
+    ),
 )
 
 
@@ -518,6 +557,12 @@ CHART_SMA_CROSSOVER_KURZ = Strategy(
         "10/40 Wochen, entspricht 21/100 statt 50/200 Handelstagen) für ein "
         "reaktionsschnelleres Signal - Erweiterung des Golden-/Death-Cross-Ansatzes "
         "aus #28."
+    ),
+    beschreibung_en=(
+        "Like 'SMA crossover (10/40 weeks)', but with shorter windows (4/20 instead "
+        "of 10/40 weeks, equivalent to 21/100 instead of 50/200 trading days) for a "
+        "more responsive signal - an extension of the golden/death cross approach "
+        "from #28."
     ),
 )
 
@@ -582,6 +627,11 @@ MOMENTUM_ROTATION = Strategy(
         "Innerhalb des Wachstums-Topfs (80%) werden nur die 2 Instrumente mit der "
         "höchsten 12-Wochen-Trailing-Rendite gleichgewichtet gehalten, die übrigen auf "
         "0% gesetzt. Der Sicherheits-Topf bleibt unverändert."
+    ),
+    beschreibung_en=(
+        "Within the growth bucket (80%), only the 2 instruments with the highest "
+        "12-week trailing return are held at equal weight, the rest are set to 0%. "
+        "The safety bucket stays unchanged."
     ),
 )
 
@@ -651,6 +701,11 @@ VOLATILITY_TARGET = Strategy(
         "des MSCI-World-ETF linear zwischen 50% (hohe Volatilität) und 90% (niedrige "
         "Volatilität) skaliert - Risk-Parity-/Vol-Targeting-Prinzip."
     ),
+    beschreibung_en=(
+        "The growth quota is scaled linearly between 50% (high volatility) and 90% "
+        "(low volatility) depending on the realized 12-week volatility of the MSCI "
+        "World ETF - a risk-parity/vol-targeting principle."
+    ),
 )
 
 
@@ -689,6 +744,12 @@ COST_AVERAGE_ENTRY = Strategy(
         "Statt das Startkapital sofort komplett zu investieren, wird die "
         "Wachstumsquote über die ersten 10 Wochen linear von 0% auf die normale "
         "Barbell-Verteilung hochgefahren - Annäherung an ratierliches Investieren."
+    ),
+    beschreibung_en=(
+        "Instead of investing the starting capital all at once, the growth quota "
+        "is ramped up linearly from 0% to the normal barbell distribution over the "
+        "first 10 weeks - an approximation of dollar-cost averaging instead of a "
+        "lump-sum investment."
     ),
 )
 

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -101,6 +101,10 @@ class Strategy:
     # Optional: Kurzbeschreibung der Strategie/des Szenarios fürs Dashboard (#26).
     # Leer bedeutet: keine Beschreibung wird angezeigt.
     beschreibung: str = ""
+    # Englische Fassung von ``beschreibung`` fürs clientseitige Sprachumschalten
+    # im Dreipunktmenü. Leer bedeutet: keine Übersetzung hinterlegt (das Dashboard
+    # zeigt dann weiterhin die deutsche Fassung, auch mit Englisch ausgewählt).
+    beschreibung_en: str = ""
     # Welche der fünf Mechanismen aus ``Optimierungen`` für diese Strategie standardmäßig
     # greifen. ``engine.simulate()`` übernimmt diese, sofern ihr nicht explizit eine
     # andere ``Optimierungen``-Instanz übergeben wird (siehe #17).
@@ -173,6 +177,12 @@ BARBELL_20_80 = Strategy(
         "5 Prozentpunkte absolut oder 25% relativ vom eigenen Zielgewicht abweicht "
         "(5/25-Regel, marktüblich)."
     ),
+    beschreibung_en=(
+        "20% safety (broad bond/gold ETFs), 80% growth (broad equity ETFs plus "
+        "Bitcoin). Rebalances to the target weights as soon as ONE bucket deviates "
+        "by more than 5 percentage points absolute or 25% relative to its own target "
+        "weight (5/25 rule, market-standard)."
+    ),
 )
 
 # --- Strategie 2: Barbell 30/70 (Beispiel für eine alternative Gewichtung) -
@@ -208,6 +218,11 @@ BARBELL_30_70 = Strategy(
     beschreibung=(
         "Defensivere Variante des Barbell-Ansatzes: 30% Sicherheit statt 20%, dafür "
         "70% Wachstum. Rebalancing-Trigger wie bei Barbell 20/80 (5/25-Regel je Topf)."
+    ),
+    beschreibung_en=(
+        "A more defensive variant of the barbell approach: 30% safety instead of "
+        "20%, and 70% growth. Rebalancing trigger the same as Barbell 20/80 "
+        "(5/25 rule per bucket)."
     ),
 )
 
@@ -274,6 +289,11 @@ BARBELL_20_60_20_SATELLIT = Strategy(
         "eines dritten, gleichgewichteten Topfs aus 10 Einzelaktien (20%) - das "
         "80/20-Risikoprofil bleibt erhalten, nur granularer gestreut."
     ),
+    beschreibung_en=(
+        "Like Barbell 20/80, but the growth bucket shrinks from 80% to 60% in "
+        "favor of a third, equally weighted bucket of 10 individual stocks (20%) - "
+        "the 80/20 risk profile stays the same, just spread more granularly."
+    ),
 )
 
 # --- Strategie 4: Barbell 20/80, breiter diversifiziert (#64) --------------
@@ -339,6 +359,15 @@ BARBELL_20_80_DIVERSIFIZIERT = Strategy(
         "Immobilien (IQQ6) und breite Rohstoffe (EXXY). Erster Ansatz, nicht "
         "optimiert/gebacktestet."
     ),
+    beschreibung_en=(
+        "Like Barbell 20/80 (20% safety / 80% growth), but with broader "
+        "diversification across the six instruments added in #64: bucket A gets a "
+        "real cash building block via XEON (EUR money market) instead of an equity "
+        "ETF share, plus IBCL/IBCI (bonds with a different duration/real-rate "
+        "profile). Bucket B reduces the US/tech concentration via EXSA (Europe) and "
+        "adds real estate (IQQ6) and broad commodities (EXXY). A first approach, "
+        "not optimized or backtested."
+    ),
 )
 
 # --- Strategie 5: Benchmark S&P 500 (#64) -----------------------------------
@@ -370,6 +399,12 @@ SP500_BENCHMARK = Strategy(
         "an der Xetra), nie aktiv umgeschichtet. Dient als Referenz 'einfach den "
         "Index kaufen' gegenüber den Barbell-Strategien und Szenarien, kein "
         "eigenständiger Anlagevorschlag."
+    ),
+    beschreibung_en=(
+        "A pure comparison line: a single purchase of IUSA (S&P 500, USD, "
+        "EUR-quoted on Xetra), never actively reshuffled. Serves as the 'simply "
+        "buy the index' reference against the barbell strategies and scenarios, "
+        "not a standalone investment recommendation."
     ),
     # Waechst ueber 20 Jahre auf ein Vielfaches der uebrigen Strategien - mit
     # gemeinsamer Y-Achse wuerden alle anderen Wertverlauf-Charts auf der

--- a/src/boersenspiel/templates/base.html.j2
+++ b/src/boersenspiel/templates/base.html.j2
@@ -201,21 +201,35 @@
   }
   .menu nav a:hover { background: var(--page); }
   .menu nav .menu-hint { display: block; padding: 4px 10px 8px; color: var(--text-muted); font-size: 0.75rem; }
+  .menu nav .menu-divider { height: 1px; background: var(--border); margin: 4px 2px; }
+  .menu nav .lang-switch { display: flex; gap: 4px; padding: 4px 6px 6px; }
+  .menu nav .lang-switch button {
+    flex: 1; font: inherit; font-size: 0.82rem; cursor: pointer; padding: 5px 8px; border-radius: 5px;
+    border: 1px solid var(--border); background: var(--page); color: var(--text-secondary);
+  }
+  .menu nav .lang-switch button:hover { color: var(--text-primary); }
+  .menu nav .lang-switch button.active { background: var(--series-1); border-color: var(--series-1); color: #fff; }
 </style>
 </head>
 <body>
+<script>window.__i18nRefresh = [];</script>
 <header>
   <div class="header-bar">
     <div>
-      <h1>{% block header_title %}Barbell-Portfolio Dashboard{% endblock %}</h1>
-      <div class="meta">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
+      <h1>{% block header_title %}<span data-i18n-en="Barbell Portfolio Dashboard">Barbell-Portfolio Dashboard</span>{% endblock %}</h1>
+      <div class="meta" data-i18n-en="Generated {{ generated_at }} from {{ row_count }} price rows (last price: {{ last_date }})">Erzeugt {{ generated_at }} aus {{ row_count }} Kurszeilen (letzter Kurs: {{ last_date }})</div>
     </div>
     <details class="menu">
-      <summary aria-label="Menü" title="Menü">&#8942;</summary>
+      <summary aria-label="Menü" title="Menü" data-i18n-en-title="Menu">&#8942;</summary>
       <nav>
-        <a href="index.html">Übersicht</a>
-        <a href="praemissen.html">Prämissen &amp; Annahmen</a>
-        <span class="menu-hint">Worauf die Zahlen beruhen</span>
+        <a href="index.html" data-i18n-en="Overview">Übersicht</a>
+        <a href="praemissen.html" data-i18n-en="Premises &amp; Assumptions">Prämissen &amp; Annahmen</a>
+        <span class="menu-hint" data-i18n-en="What the numbers are based on">Worauf die Zahlen beruhen</span>
+        <div class="menu-divider"></div>
+        <div class="lang-switch" role="group" aria-label="Sprache / Language">
+          <button type="button" data-lang-btn="de">Deutsch</button>
+          <button type="button" data-lang-btn="en">English</button>
+        </div>
       </nav>
     </details>
   </div>
@@ -224,10 +238,38 @@
 <main>
 {% block content %}{% endblock %}
 </main>
-<footer>
+<footer data-i18n-en="Barbell Portfolio Dashboard · statically generated, no live data · price history and simulation deterministic from data/price_history.csv.">
   Barbell-Portfolio-Dashboard &middot; statisch erzeugt, keine Live-Daten &middot;
   Kurshistorie und Simulation deterministisch aus <code>data/price_history.csv</code>.
 </footer>
 {% block scripts %}{% endblock %}
+<script>
+  (function () {
+    function applyLanguage(lang) {
+      document.documentElement.setAttribute('lang', lang === 'en' ? 'en' : 'de');
+      document.querySelectorAll('[data-i18n-en]').forEach(function (el) {
+        if (el.dataset.i18nDe === undefined) el.dataset.i18nDe = el.textContent;
+        el.textContent = lang === 'en' ? el.dataset.i18nEn : el.dataset.i18nDe;
+      });
+      document.querySelectorAll('[data-i18n-en-title]').forEach(function (el) {
+        if (el.dataset.i18nDeTitle === undefined) el.dataset.i18nDeTitle = el.getAttribute('title') || '';
+        el.setAttribute('title', lang === 'en' ? el.dataset.i18nEnTitle : el.dataset.i18nDeTitle);
+      });
+      (window.__i18nRefresh || []).forEach(function (fn) {
+        try { fn(lang); } catch (e) { /* ein defekter Chart-Refresh darf die anderen nicht blockieren */ }
+      });
+      document.querySelectorAll('[data-lang-btn]').forEach(function (btn) {
+        btn.classList.toggle('active', btn.dataset.langBtn === lang);
+      });
+      try { localStorage.setItem('boersenspiel-lang', lang); } catch (e) { /* privater Modus o.ae. */ }
+    }
+    document.querySelectorAll('[data-lang-btn]').forEach(function (btn) {
+      btn.addEventListener('click', function () { applyLanguage(btn.dataset.langBtn); });
+    });
+    var savedLang = 'de';
+    try { savedLang = localStorage.getItem('boersenspiel-lang') || 'de'; } catch (e) { /* privater Modus o.ae. */ }
+    applyLanguage(savedLang);
+  })();
+</script>
 </body>
 </html>

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -1,8 +1,8 @@
 {% extends "base.html.j2" %}
 {% block content %}
   <section class="strategy" id="portfolio">
-    <h2>Das Portfolio</h2>
-    <p class="hint">
+    <h2 data-i18n-en="The Portfolio">Das Portfolio</h2>
+    <p class="hint" data-i18n-en="All strategies and scenarios draw on the same {{ instrumente_anzahl }} instruments; which of them a strategy actually holds and how strongly is decided only by its particular weighting. Every strategy has two buckets: Bucket A - Safety (broad bond ETF, physical gold; the smaller barbell share, 20-30%) and Bucket B - Growth (broad equity ETF, Nasdaq-100 ETF, semiconductor ETF, emerging-markets ETF and Bitcoin; the larger share, 60-80%). One strategy, &quot;Barbell 20/60/20 + Individual Stock Satellite&quot;, adds a third Bucket C - Individual Stock Satellite: 10 equally weighted individual stocks instead of broad ETFs. &quot;Satellite&quot; here means the common core-satellite approach from portfolio theory - a smaller, concentrated, more volatile addition alongside a broadly diversified &quot;core&quot;, not simply &quot;in addition&quot;. The 20 percentage points needed for it come from Bucket B, so the overall risk profile (80% risky / 20% safe) stays the same as Barbell 20/80 - only the growth side becomes more granular. The 10 stocks deliberately mix highly volatile growth/theme stocks with two defensive blue chips (Coca-Cola, Roche) as a counterexample.">
       Alle Strategien und Szenarien speisen sich aus denselben {{ instrumente_anzahl }} Instrumenten;
       welche davon eine Strategie tatsächlich hält und wie stark, entscheidet
       erst die jeweilige Gewichtung. Zwei Töpfe gibt es in jeder Strategie:
@@ -22,7 +22,7 @@
       hoch-volatile Wachstums-/Themenwerte mit zwei defensiven Blue Chips
       (Coca-Cola, Roche) als Gegenbeispiel.
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="All {{ portfolio_instrumente|length }} weekly-fetched data series at a glance (ticker and full name) - which strategy actually holds which instrument is shown on the respective detail page under &quot;Bucket weighting&quot;; not every instrument listed here is part of every strategy (see the Premises page, section &quot;Data series without allocation&quot;).">
       Alle {{ portfolio_instrumente|length }} wöchentlich abgerufenen Datenreihen im
       Überblick (Kürzel und ausgeschriebener Name) - welche Strategie welches
       Instrument tatsächlich hält, zeigt die jeweilige Detailseite unter
@@ -32,7 +32,7 @@
     </p>
     <div class="overflow-x">
       <table class="portfolio-table">
-        <thead><tr><th class="text-left">Kürzel</th><th class="text-left">Instrument</th></tr></thead>
+        <thead><tr><th class="text-left" data-i18n-en="Ticker">Kürzel</th><th class="text-left" data-i18n-en="Instrument">Instrument</th></tr></thead>
         <tbody>
         {% for i in portfolio_instrumente %}
           <tr><td class="text-left">{{ i.ticker }}</td><td class="text-left">{{ i.name }}</td></tr>
@@ -44,25 +44,25 @@
 {% if learnings %}
   <section class="strategy" id="key-learnings">
     <h2>Key Learnings</h2>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Derived freshly from the simulation results on every build - not stored text. If the price history changes, these statements change with it.">
       Bei jedem Build neu aus den Simulationsergebnissen abgeleitet – nicht
       hinterlegter Text. Ändert sich die Kurshistorie, ändern sich diese Aussagen mit.
     </p>
     <ol class="learnings">
     {% for l in learnings %}
       <li>
-        <h3>{{ l.titel }}</h3>
-        <p class="kernaussage">{{ l.kernaussage }}</p>
-        <p class="detail">{{ l.detail }}</p>
+        <h3 data-i18n-en="{{ l.titel_en }}">{{ l.titel_de }}</h3>
+        <p class="kernaussage" data-i18n-en="{{ l.kernaussage_en }}">{{ l.kernaussage_de }}</p>
+        <p class="detail" data-i18n-en="{{ l.detail_en }}">{{ l.detail_de }}</p>
       </li>
     {% endfor %}
     </ol>
   </section>
 {% endif %}
   <section class="strategy" id="uebersicht">
-    <h2>Übersicht: Rendite im Vergleich</h2>
+    <h2 data-i18n-en="Overview: return comparison">Übersicht: Rendite im Vergleich</h2>
     {% if vergleich_verfuegbar %}
-    <p class="hint">
+    <p class="hint" data-i18n-en="Comparison period: every strategy is only simulated over the period in which its complete instrument set was actually tradable (last column) - otherwise a portfolio put together in 2026 would be bought retroactively starting in 2006. But these periods differ in length and cover different market phases, so their metrics cannot be compared directly. Return and risk are therefore consistently reported here over a common period: every strategy is additionally simulated fresh, with its own starting capital, from {{ vergleich_beginn }} - the latest start date of all strategies shown here, i.e. the point from which every one of them has prices. CAGR, volatility, max drawdown, Sharpe and Sortino all come from this run and therefore belong together; the table is sorted by it. {% if vergleich_benchmark %}The &quot;excess return pp p.a.&quot; column is the difference to &quot;{{ vergleich_benchmark }}&quot; ({{ vergleich_benchmark_label }}% p.a. over the same period) - a negative value means the strategy would not have beaten the index over this period.{% endif %} Why this matters for risk too: a strategy with a long history of its own carries crises the others never went through. Over the full history the S&amp;P 500 benchmark shows a max drawdown of around -52% (2008 financial crisis) versus around -30% for the barbell strategies - over the common period it's around -21%, giving it the smallest drawdown in the field instead of the largest. Apparent underperformance on both axes turns into a genuine return/risk trade-off. The &quot;CAGR % p.a. (own period)&quot; appears as a secondary column next to it; the full metrics over a strategy's own period are on its detail page under &quot;Metrics by viewing period&quot;. A short comparison period remains a narrow data basis: it shows how the strategies behaved in the same market environment, not how they will behave in the future.">
       <strong>Vergleichszeitraum:</strong> Jede Strategie wird nur über den Zeitraum
       simuliert, in dem ihr komplettes Instrumentenset tatsächlich handelbar war
       (letzte Spalte) &ndash; sonst würde ein 2026 zusammengestelltes Portfolio
@@ -98,7 +98,7 @@
       künftig verhalten werden.
     </p>
     {% endif %}
-    <p class="hint">
+    <p class="hint" data-i18n-en="CAGR (annualized return, &quot;% p.a.&quot;) is the leading metric: over many years, a total return is barely readable and compares poorly across periods of different lengths, whereas an annual rate does. The total return appears as a secondary column next to it. Volatility (annualized standard deviation of weekly returns) and max drawdown (largest loss of value from the previous high) are deliberately shown next to the return too: a high return from concentrated or untested rules (e.g. chart signals) can come at the cost of correspondingly higher risk, which the return alone doesn't show. The Sharpe and Sortino ratios condense that into a return-per-risk metric: Sharpe divides the annualized return by the overall dispersion, Sortino only by the dispersion of losing weeks (upside dispersion doesn't count as risk there). Higher is better; negative means the risk taken didn't pay off compared to risk-free parking. The risk-free rate for this is derived from the EUR money-market ETF over the evaluated period (see Premises), not fixed in advance - here that means {% if vergleich_zins_label %}{{ vergleich_zins_label }}% p.a. over the comparison period, the same for every row{% else %}per row, over its own period{% endif %}. All return values here are gross (before tax) - the estimated net return per strategy is on the respective detail page.">
       CAGR (annualisierte Rendite, "% p.a.") ist die Leitkennzahl: über viele Jahre
       ist eine Gesamtrendite kaum lesbar und schlecht zwischen unterschiedlich langen
       Zeiträumen vergleichbar, eine jährliche Rate ist es. Die Gesamtrendite steht
@@ -121,7 +121,7 @@
       steht auf der jeweiligen Detailseite.
     </p>
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Return against risk: every point is a strategy/scenario, x-axis CAGR % p.a., y-axis max drawdown % ({% if vergleich_verfuegbar %}from the common comparison period{% else %}from each one's own period{% endif %}). The top right holds the most favorable case (high return, small drawdown), the bottom right the most problematic (high return, but also high drawdown) - makes visible whether a high return comes at the cost of correspondingly higher risk, instead of having to look up the two axes separately in the table.">
       <strong>Rendite gegen Risiko:</strong> jeder Punkt ist eine Strategie/ein
       Szenario, x-Achse CAGR % p.a., y-Achse Max Drawdown % (jeweils
       {% if vergleich_verfuegbar %}aus dem gemeinsamen Vergleichszeitraum{% else %}aus dem eigenen Zeitraum{% endif %}).
@@ -134,7 +134,7 @@
     <div class="summary-chart-box"><canvas id="correlation-chart"></canvas></div>
     <div class="overflow-x">
       <table class="summary-table">
-        <thead><tr><th>Strategie / Szenario</th>{% if vergleich_verfuegbar %}<th>CAGR % p.a. (Vergleichszeitraum)<span class="info-tip" tabindex="0" title="Annualisierte Rendite (Compound Annual Growth Rate): die konstante jährliche Wachstumsrate, die über den gemeinsamen Vergleichszeitraum auf denselben Endwert führt. Vergleichbar auch bei unterschiedlich langen Zeiträumen, anders als die Gesamtrendite.">i</span></th><th>&Uuml;berrendite pp p.a.<span class="info-tip" tabindex="0" title="Differenz der CAGR gegenüber dem Benchmark (S&P 500) im selben Vergleichszeitraum, in Prozentpunkten. Positiv = die Strategie hat den Index über diesen Zeitraum geschlagen, negativ = nicht.">i</span></th>{% endif %}<th>Volatilität % (ann.)<span class="info-tip" tabindex="0" title="Annualisierte Standardabweichung der wöchentlichen Renditen - ein Maß für die Schwankungsbreite des Wertverlaufs. Höher bedeutet unruhiger, nicht zwangsläufig schlechter.">i</span></th><th>Max Drawdown %<span class="info-tip" tabindex="0" title="Der größte prozentuale Rückgang vom bisherigen Höchststand des Portfoliowerts während des Betrachtungszeitraums - der schlimmste Verlust, den ein Anleger tatsächlich ausgehalten hätte.">i</span></th><th>Sharpe<span class="info-tip" tabindex="0" title="Sharpe-Ratio: annualisierte Überrendite über dem risikofreien Zins, geteilt durch die gesamte Volatilität. Höher ist besser; negativ heißt, das Risiko hat sich gegenüber risikolosem Parken nicht gelohnt.">i</span></th><th>Sortino<span class="info-tip" tabindex="0" title="Sortino-Ratio: wie Sharpe, aber es zählt nur die Streuung der Verlustwochen als Risiko (Schwankung nach oben wird nicht bestraft). Meist etwas höher als die Sharpe-Ratio derselben Strategie.">i</span></th><th>CAGR % p.a. (eigener Zeitraum)<span class="info-tip" tabindex="0" title="Annualisierte Rendite über den eigenen, individuell längsten handelbaren Zeitraum dieser Strategie (kann für jede Zeile unterschiedlich lang sein) - Nebenspalte, nicht direkt mit anderen Zeilen vergleichbar.">i</span></th><th>Gesamtrendite % (brutto)<span class="info-tip" tabindex="0" title="Gesamte prozentuale Wertsteigerung über den eigenen Zeitraum, vor Steuer. Bei langen Zeiträumen praktisch unlesbar (z. B. mehrere Tausend Prozent) - die CAGR-Spalten sind deshalb die Leitkennzahl.">i</span></th><th>Gewinn/Verlust &euro;</th><th>Endwert &euro;</th><th>Eigener Zeitraum<span class="info-tip" tabindex="0" title="Der Zeitraum, ab dem für diese Strategie tatsächlich alle ihre Zielinstrumente handelbar waren (kein rückwirkender Kauf eines 2026 zusammengestellten Portfolios ab 2006).">i</span></th></tr></thead>
+        <thead><tr><th data-i18n-en="Strategy / scenario">Strategie / Szenario</th>{% if vergleich_verfuegbar %}<th data-i18n-en="CAGR % p.a. (comparison period)">CAGR % p.a. (Vergleichszeitraum)<span class="info-tip" tabindex="0" title="Annualisierte Rendite (Compound Annual Growth Rate): die konstante jährliche Wachstumsrate, die über den gemeinsamen Vergleichszeitraum auf denselben Endwert führt. Vergleichbar auch bei unterschiedlich langen Zeiträumen, anders als die Gesamtrendite." data-i18n-en-title="Annualized return (Compound Annual Growth Rate): the constant yearly growth rate that leads to the same final value over the common comparison period. Comparable even across periods of different length, unlike the total return.">i</span></th><th data-i18n-en="Excess return pp p.a.">&Uuml;berrendite pp p.a.<span class="info-tip" tabindex="0" title="Differenz der CAGR gegenüber dem Benchmark (S&P 500) im selben Vergleichszeitraum, in Prozentpunkten. Positiv = die Strategie hat den Index über diesen Zeitraum geschlagen, negativ = nicht." data-i18n-en-title="Difference of the CAGR versus the benchmark (S&P 500) over the same comparison period, in percentage points. Positive = the strategy beat the index over this period, negative = it did not.">i</span></th>{% endif %}<th data-i18n-en="Volatility % (ann.)">Volatilität % (ann.)<span class="info-tip" tabindex="0" title="Annualisierte Standardabweichung der wöchentlichen Renditen - ein Maß für die Schwankungsbreite des Wertverlaufs. Höher bedeutet unruhiger, nicht zwangsläufig schlechter." data-i18n-en-title="Annualized standard deviation of weekly returns - a measure of how much the value history swings. Higher means choppier, not necessarily worse.">i</span></th><th data-i18n-en="Max drawdown %">Max Drawdown %<span class="info-tip" tabindex="0" title="Der größte prozentuale Rückgang vom bisherigen Höchststand des Portfoliowerts während des Betrachtungszeitraums - der schlimmste Verlust, den ein Anleger tatsächlich ausgehalten hätte." data-i18n-en-title="The largest percentage decline from the portfolio's previous high during the viewing period - the worst loss an investor would actually have had to endure.">i</span></th><th>Sharpe<span class="info-tip" tabindex="0" title="Sharpe-Ratio: annualisierte Überrendite über dem risikofreien Zins, geteilt durch die gesamte Volatilität. Höher ist besser; negativ heißt, das Risiko hat sich gegenüber risikolosem Parken nicht gelohnt." data-i18n-en-title="Sharpe ratio: annualized excess return over the risk-free rate, divided by the overall volatility. Higher is better; negative means the risk taken didn't pay off compared to risk-free parking.">i</span></th><th>Sortino<span class="info-tip" tabindex="0" title="Sortino-Ratio: wie Sharpe, aber es zählt nur die Streuung der Verlustwochen als Risiko (Schwankung nach oben wird nicht bestraft). Meist etwas höher als die Sharpe-Ratio derselben Strategie." data-i18n-en-title="Sortino ratio: like Sharpe, but only the dispersion of losing weeks counts as risk (upside swings are not penalized). Usually somewhat higher than the same strategy's Sharpe ratio.">i</span></th><th data-i18n-en="CAGR % p.a. (own period)">CAGR % p.a. (eigener Zeitraum)<span class="info-tip" tabindex="0" title="Annualisierte Rendite über den eigenen, individuell längsten handelbaren Zeitraum dieser Strategie (kann für jede Zeile unterschiedlich lang sein) - Nebenspalte, nicht direkt mit anderen Zeilen vergleichbar." data-i18n-en-title="Annualized return over this strategy's own, individually longest tradable period (can be a different length for each row) - a secondary column, not directly comparable across rows.">i</span></th><th data-i18n-en="Total return % (gross)">Gesamtrendite % (brutto)<span class="info-tip" tabindex="0" title="Gesamte prozentuale Wertsteigerung über den eigenen Zeitraum, vor Steuer. Bei langen Zeiträumen praktisch unlesbar (z. B. mehrere Tausend Prozent) - die CAGR-Spalten sind deshalb die Leitkennzahl." data-i18n-en-title="Total percentage increase in value over the strategy's own period, before tax. Practically unreadable over long periods (e.g. several thousand percent) - which is why the CAGR columns are the leading metric.">i</span></th><th data-i18n-en="Profit/loss &euro;">Gewinn/Verlust &euro;</th><th data-i18n-en="Final value &euro;">Endwert &euro;</th><th data-i18n-en="Own period">Eigener Zeitraum<span class="info-tip" tabindex="0" title="Der Zeitraum, ab dem für diese Strategie tatsächlich alle ihre Zielinstrumente handelbar waren (kein rückwirkender Kauf eines 2026 zusammengestellten Portfolios ab 2006)." data-i18n-en-title="The period from which all of this strategy's target instruments were actually tradable (no retroactive purchase of a portfolio put together in 2026, starting in 2006).">i</span></th></tr></thead>
         <tbody>
         {% for s in summary %}
           <tr>
@@ -160,7 +160,7 @@
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.rendite_pct_label }}</td>
             <td class="{{ 'positive' if s.rendite_pct >= 0 else 'negative' }}">{{ s.gewinn_label }}</td>
             <td>{{ s.total_value }}</td>
-            <td class="hint-cell">{{ s.sim_beginn }} &ndash; {{ s.sim_ende }}<br>({{ s.sim_jahre_label }} Jahre)</td>
+            <td class="hint-cell">{{ s.sim_beginn }} &ndash; {{ s.sim_ende }}<br>(<span data-i18n-en="{{ s.sim_jahre_label }} years">{{ s.sim_jahre_label }} Jahre</span>)</td>
           </tr>
         {% endfor %}
         </tbody>
@@ -169,8 +169,8 @@
   </section>
 {% for gruppe in teilszenario_gruppen %}
   <section class="strategy" id="gruppe-{{ gruppe.id }}">
-    <h2>{{ gruppe.name }} im Vergleich</h2>
-    <p class="hint">
+    <h2><span data-i18n-en="{{ gruppe.name }} compared">{{ gruppe.name }} im Vergleich</span></h2>
+    <p class="hint" data-i18n-en="Value history of the combined strategy and its {{ gruppe.mitglieder|length - 1 }} sub-scenarios in one chart, instead of scattered among all the other strategies/scenarios - a direct comparison of how the arithmetic mean of the individual votes (combined strategy) performs relative to each individual vote (#30).">
       Wertverlauf der Kombi-Strategie und ihrer {{ gruppe.mitglieder|length - 1 }}
       Unterszenarien in einem Chart, statt verstreut zwischen allen übrigen
       Strategien/Szenarien - direkter Vergleich, wie das arithmetische Mittel
@@ -182,8 +182,8 @@
 {% endfor %}
 {% if benchmark_optionen %}
   <div class="benchmark-switch" id="benchmark-switch">
-    <span>Benchmark in den Wertverlauf-Charts einblenden:</span>
-    <button type="button" data-benchmark="none" class="active">Kein Benchmark</button>
+    <span data-i18n-en="Show a benchmark in the value-history charts:">Benchmark in den Wertverlauf-Charts einblenden:</span>
+    <button type="button" data-benchmark="none" class="active" data-i18n-en="No benchmark">Kein Benchmark</button>
     {% for b in benchmark_optionen %}
     <button type="button" data-benchmark="{{ b.id }}">{{ b.label }}</button>
     {% endfor %}
@@ -192,17 +192,17 @@
 {% for s in strategies %}
   <section class="strategy" id="{{ s.id }}">
     <h2>{{ s.name }}</h2>
-    {% if s.beschreibung %}<p class="hint">{{ s.beschreibung }}</p>{% endif %}
+    {% if s.beschreibung %}<p class="hint" data-i18n-en="{{ s.beschreibung_en }}">{{ s.beschreibung }}</p>{% endif %}
     {% if s.zeitraum_presets %}
     <div class="zeitraum-switch" id="zeitraum-switch-{{ loop.index }}">
       {% for p in s.zeitraum_presets %}
-      <button type="button" data-preset="{{ p.id }}"{% if p.id == 'alle' %} class="active"{% endif %}>{{ p.label }}</button>
+      <button type="button" data-preset="{{ p.id }}"{% if p.id == 'alle' %} class="active"{% endif %} data-i18n-en="{{ p.label_en }}">{{ p.label }}</button>
       {% endfor %}
       <span class="zeitraum-rendite"></span>
     </div>
     {% endif %}
     <div class="chart-box-large"><canvas id="value-chart-{{ loop.index }}"></canvas></div>
-    <p class="detail-link"><a href="{{ s.id }}.html">Details ansehen (Kennzahlen, Topf-Gewichtung, Instrumente) &rarr;</a></p>
+    <p class="detail-link"><a href="{{ s.id }}.html" data-i18n-en="View details (metrics, bucket weighting, instruments) &rarr;">Details ansehen (Kennzahlen, Topf-Gewichtung, Instrumente) &rarr;</a></p>
   </section>
 {% endfor %}
 {% endblock %}
@@ -223,6 +223,15 @@
     x: { grid: { color: colors.grid }, ticks: { color: colors.text, maxTicksLimit: 8 } },
     y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
   };
+  // Sprachumschalter (Dreipunktmenue): Chart.js-Texte (Titel, Achsen, Legenden) sind
+  // beim Erzeugen des Charts fixe Strings, keine DOM-Knoten - data-i18n-en greift hier
+  // nicht. T() liest die aktuelle Sprache aus <html lang>, chartRefreshers haelt fuer
+  // jeden Chart eine Funktion, die seine uebersetzbaren Texte neu setzt; base.html.j2
+  // ruft beim Umschalten alle window.__i18nRefresh-Funktionen auf.
+  function T(de, en) { return document.documentElement.lang === 'en' ? en : de; }
+  const chartRefreshers = [];
+  window.__i18nRefresh.push(function () { chartRefreshers.forEach(function (fn) { fn(); }); });
+
   // Gemeinsames Maximum ueber alle Wertverlauf-Charts (#24), damit unterschiedliche
   // Strategien optisch vergleichbar bleiben statt jeweils unabhaengig zu skalieren.
   const wertChartMax = {{ wert_chart_max | tojson }};
@@ -231,107 +240,134 @@
     y: { ...commonScales.y, min: 0, suggestedMax: wertChartMax * 1.05 },
   };
 
-  new Chart(document.getElementById('summary-chart'), {
-    type: 'bar',
-    data: {
-      labels: {{ summary | map(attribute='name') | list | tojson }},
-      datasets: [{
-        label: 'CAGR % p.a.',
-        {% if vergleich_verfuegbar %}
-        data: {{ summary | map(attribute='vergleich_cagr_pct') | list | tojson }},
-        backgroundColor: {{ summary | map(attribute='vergleich_cagr_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
-        {% else %}
-        data: {{ summary | map(attribute='cagr_pct') | list | tojson }},
-        backgroundColor: {{ summary | map(attribute='cagr_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
-        {% endif %}
-      }],
-    },
-    options: {
-      indexAxis: 'y',
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: {% if vergleich_verfuegbar %}'Annualisierte Rendite (CAGR, % p.a.) im gemeinsamen Vergleichszeitraum ab {{ vergleich_beginn }}'{% else %}'Annualisierte Rendite (CAGR, % p.a.)'{% endif %}, color: colors.text } },
-      scales: {
-        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
-        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+  {
+    const summaryChart = new Chart(document.getElementById('summary-chart'), {
+      type: 'bar',
+      data: {
+        labels: {{ summary | map(attribute='name') | list | tojson }},
+        datasets: [{
+          label: 'CAGR % p.a.',
+          {% if vergleich_verfuegbar %}
+          data: {{ summary | map(attribute='vergleich_cagr_pct') | list | tojson }},
+          backgroundColor: {{ summary | map(attribute='vergleich_cagr_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+          {% else %}
+          data: {{ summary | map(attribute='cagr_pct') | list | tojson }},
+          backgroundColor: {{ summary | map(attribute='cagr_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+          {% endif %}
+        }],
       },
-    },
-  });
+      options: {
+        indexAxis: 'y',
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: false }, title: { display: true, text: '', color: colors.text } },
+        scales: {
+          x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+          y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        },
+      },
+    });
+    chartRefreshers.push(function () {
+      summaryChart.options.plugins.title.text = {% if vergleich_verfuegbar %}
+        T('Annualisierte Rendite (CAGR, % p.a.) im gemeinsamen Vergleichszeitraum ab {{ vergleich_beginn }}', 'Annualized return (CAGR, % p.a.) over the common comparison period starting {{ vergleich_beginn }}')
+      {% else %}
+        T('Annualisierte Rendite (CAGR, % p.a.)', 'Annualized return (CAGR, % p.a.)')
+      {% endif %};
+      summaryChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
 
   // Korrelationsgrafik (#82): Rendite (CAGR) gegen Risiko (Max Drawdown) je
   // Strategie/Szenario, aus denselben Werten wie die Uebersichtstabelle
   // (Vergleichszeitraum, falls verfuegbar, sonst der jeweils eigene Zeitraum) -
   // keine zusaetzliche Simulation, reine Darstellung bereits vorhandener Zahlen.
-  new Chart(document.getElementById('correlation-chart'), {
-    type: 'scatter',
-    data: {
-      datasets: [{
-        label: 'Strategien/Szenarien',
-        data: [
-          {% for s in summary %}
-          {
-            x: {{ (s.vergleich_cagr_pct if vergleich_verfuegbar else s.cagr_pct) | tojson }},
-            y: {{ (-((s.vergleich_max_drawdown_pct if vergleich_verfuegbar else s.max_drawdown_pct) or 0.0)) | tojson }},
-            name: {{ s.name | tojson }},
-          },
-          {% endfor %}
-        ],
-        backgroundColor: colors.series1,
-        pointRadius: 6,
-        pointHoverRadius: 8,
-      }],
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: {
-        legend: { display: false },
-        title: {
-          display: true,
-          text: {% if vergleich_verfuegbar %}'CAGR gegen Max Drawdown im gemeinsamen Vergleichszeitraum ab {{ vergleich_beginn }}'{% else %}'CAGR gegen Max Drawdown (jeweils eigener Zeitraum)'{% endif %},
-          color: colors.text,
-        },
-        tooltip: {
-          callbacks: {
-            label: (ctx) => `${ctx.raw.name}: CAGR ${ctx.raw.x.toFixed(2)} % p.a., Max Drawdown ${ctx.raw.y.toFixed(2)} %`,
+  {
+    const correlationChart = new Chart(document.getElementById('correlation-chart'), {
+      type: 'scatter',
+      data: {
+        datasets: [{
+          label: 'Strategien/Szenarien',
+          data: [
+            {% for s in summary %}
+            {
+              x: {{ (s.vergleich_cagr_pct if vergleich_verfuegbar else s.cagr_pct) | tojson }},
+              y: {{ (-((s.vergleich_max_drawdown_pct if vergleich_verfuegbar else s.max_drawdown_pct) or 0.0)) | tojson }},
+              name: {{ s.name | tojson }},
+            },
+            {% endfor %}
+          ],
+          backgroundColor: colors.series1,
+          pointRadius: 6,
+          pointHoverRadius: 8,
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          title: { display: true, text: '', color: colors.text },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => `${ctx.raw.name}: CAGR ${ctx.raw.x.toFixed(2)} % p.a., ${T('Max Drawdown', 'Max drawdown')} ${ctx.raw.y.toFixed(2)} %`,
+            },
           },
         },
+        scales: {
+          x: { ...commonScales.x, title: { display: true, text: 'CAGR % p.a.', color: colors.text } },
+          y: { ...commonScales.y, title: { display: true, text: '', color: colors.text } },
+        },
       },
-      scales: {
-        x: { ...commonScales.x, title: { display: true, text: 'CAGR % p.a.', color: colors.text } },
-        y: { ...commonScales.y, title: { display: true, text: 'Max Drawdown %', color: colors.text } },
-      },
-    },
-  });
+    });
+    chartRefreshers.push(function () {
+      correlationChart.options.plugins.title.text = {% if vergleich_verfuegbar %}
+        T('CAGR gegen Max Drawdown im gemeinsamen Vergleichszeitraum ab {{ vergleich_beginn }}', 'CAGR against max drawdown over the common comparison period starting {{ vergleich_beginn }}')
+      {% else %}
+        T('CAGR gegen Max Drawdown (jeweils eigener Zeitraum)', 'CAGR against max drawdown (each over its own period)')
+      {% endif %};
+      correlationChart.options.scales.y.title.text = T('Max Drawdown %', 'Max drawdown %');
+      correlationChart.data.datasets[0].label = T('Strategien/Szenarien', 'Strategies/scenarios');
+      correlationChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
 
   const gruppenSeriesColors = [colors.series1, colors.series2, colors.series3, colors.series4];
 
   {% for gruppe in teilszenario_gruppen %}
-  new Chart(document.getElementById('gruppen-chart-{{ loop.index }}'), {
-    type: 'line',
-    data: {
-      labels: {{ gruppe.mitglieder[0].labels_json | safe }},
-      datasets: [
-        {% for m in gruppe.mitglieder %}
-        {
-          label: {{ m.name | tojson }},
-          data: {{ m.total_values_json | safe }},
-          borderColor: gruppenSeriesColors[{{ loop.index0 }} % gruppenSeriesColors.length],
-          backgroundColor: gruppenSeriesColors[{{ loop.index0 }} % gruppenSeriesColors.length],
-          borderWidth: {{ 3 if loop.first else 1.5 }},
-          pointRadius: 0,
-          tension: 0.15,
-        },
-        {% endfor %}
-      ],
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Wertverlauf im Vergleich', color: colors.text } },
-      scales: {
-        x: commonScales.x,
-        y: { ...commonScales.y, min: 0, suggestedMax: {{ gruppe.chart_max }} * 1.05 },
+  {
+    const gruppenChart{{ loop.index }} = new Chart(document.getElementById('gruppen-chart-{{ loop.index }}'), {
+      type: 'line',
+      data: {
+        labels: {{ gruppe.mitglieder[0].labels_json | safe }},
+        datasets: [
+          {% for m in gruppe.mitglieder %}
+          {
+            label: {{ m.name | tojson }},
+            data: {{ m.total_values_json | safe }},
+            borderColor: gruppenSeriesColors[{{ loop.index0 }} % gruppenSeriesColors.length],
+            backgroundColor: gruppenSeriesColors[{{ loop.index0 }} % gruppenSeriesColors.length],
+            borderWidth: {{ 3 if loop.first else 1.5 }},
+            pointRadius: 0,
+            tension: 0.15,
+          },
+          {% endfor %}
+        ],
       },
-    },
-  });
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: '', color: colors.text } },
+        scales: {
+          x: commonScales.x,
+          y: { ...commonScales.y, min: 0, suggestedMax: {{ gruppe.chart_max }} * 1.05 },
+        },
+      },
+    });
+    chartRefreshers.push(function () {
+      gruppenChart{{ loop.index }}.options.plugins.title.text = T('Wertverlauf im Vergleich', 'Value history compared');
+      gruppenChart{{ loop.index }}.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
   {% endfor %}
 
   // Benchmark-Overlay-Schalter (#72): EIN zentraler Schalter fuer alle
@@ -387,21 +423,29 @@
     if (!switchEl) return;
     const byId = Object.fromEntries(presets.map((p) => [p.id, p]));
     const renditeEl = switchEl.querySelector('.zeitraum-rendite');
+    let currentPreset = null;
+    const setRenditeText = () => {
+      if (renditeEl && currentPreset) {
+        renditeEl.textContent = `${T('Rendite im Zeitraum', 'Return over the period')}: ${currentPreset.rendite_label}%`;
+      }
+    };
     const apply = (id) => {
       const preset = byId[id];
       if (!preset) return;
+      currentPreset = preset;
       chart.data.labels = preset.labels;
       chart.data.datasets[0].data = preset.total_values;
       chart.options.scales.y.max = (preset.chart_max || defaultMax) * 1.05;
       chart.__benchmarks = preset.benchmarks || [];
       applyBenchmarkDataset(chart);
-      if (renditeEl) renditeEl.textContent = `Rendite im Zeitraum: ${preset.rendite_label}%`;
+      setRenditeText();
       switchEl.querySelectorAll('button').forEach((btn) => btn.classList.toggle('active', btn.dataset.preset === id));
     };
     switchEl.querySelectorAll('button').forEach((btn) => {
       btn.addEventListener('click', () => apply(btn.dataset.preset));
     });
     apply('alle');
+    chartRefreshers.push(setRenditeText);
   }
 
   {% for s in strategies %}
@@ -428,7 +472,7 @@
       },
       options: {
         responsive: true, maintainAspectRatio: false,
-        plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Wertverlauf', color: colors.text } },
+        plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: '', color: colors.text } },
         // Eigenes scales-Objekt statt der geteilten wertChartScales-Referenz: der
         // Zeitraum-Umschalter unten mutiert scales.y.max je Chart-Instanz, ein
         // geteiltes Objekt wuerde das auf alle Charts gleichzeitig anwenden. Fixes
@@ -441,6 +485,11 @@
     });
     chart.__benchmarks = {{ s.benchmarks_json | safe }};
     benchmarkCharts.push(chart);
+    chartRefreshers.push(function () {
+      chart.options.plugins.title.text = T('Wertverlauf', 'Value history');
+      chart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
     initZeitraumSwitch(chart, document.getElementById('zeitraum-switch-{{ loop.index }}'), {{ s.zeitraum_presets_json | safe }}, strategieMax);
   }
   {% endfor %}

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -2,11 +2,11 @@
 {% block title %}Prämissen &amp; Annahmen – Barbell-Portfolio Dashboard{% endblock %}
 {% block meta_description %}Welche Annahmen, Konstanten und Vereinfachungen hinter den Zahlen des Barbell-Portfolio-Dashboards stehen.{% endblock %}
 {% block canonical %}https://s540d.github.io/Boersenspiel/praemissen.html{% endblock %}
-{% block header_extra %}<p class="back-link"><a href="index.html">&larr; Zur Übersicht</a></p>{% endblock %}
+{% block header_extra %}<p class="back-link"><a href="index.html" data-i18n-en="&larr; Back to overview">&larr; Zur Übersicht</a></p>{% endblock %}
 {% block content %}
   <section class="strategy" id="praemissen">
-    <h2>Prämissen &amp; Annahmen</h2>
-    <p class="hint">
+    <h2 data-i18n-en="Premises &amp; Assumptions">Prämissen &amp; Annahmen</h2>
+    <p class="hint" data-i18n-en="This page collects what the dashboard's numbers are based on, so the results are at least in principle traceable. Every value here is derived on every build from the same constants and the same price history that the simulation itself uses - none of it is stored text that could go stale relative to the code.">
       Diese Seite sammelt, worauf die Zahlen im Dashboard beruhen, damit die
       Ergebnisse zumindest prinzipiell nachvollziehbar sind. Alle Werte hier
       werden bei jedem Build aus denselben Konstanten und derselben Kurshistorie
@@ -14,15 +14,15 @@
       hinterlegten Texte, die gegenüber dem Code veralten könnten.
     </p>
 
-    <h3>Das Wichtigste zuerst</h3>
-    <p class="hint">
+    <h3 data-i18n-en="The most important thing first">Das Wichtigste zuerst</h3>
+    <p class="hint" data-i18n-en="This is a virtual portfolio for learning purposes, not investment advice, and not a statement about how these strategies will develop in the future. Three limitations weigh heavier here than any return figure on the overview page:">
       Dies ist ein <strong>virtuelles Depot zu Lernzwecken, keine
       Anlageberatung</strong> und keine Aussage darüber, wie sich diese
       Strategien in Zukunft entwickeln. Drei Einschränkungen wiegen dabei
       schwerer als jede Renditezahl auf der Übersichtsseite:
     </p>
     <ul class="hint">
-      <li>
+      <li data-i18n-en="Look-ahead bias in instrument selection. The {{ instrumente|length }} instruments were chosen once their price development was already known. A back-calculated return therefore doesn't answer &quot;what would I have earned?&quot;, but at best &quot;how would these rules have performed on these instruments, selected in hindsight?&quot;. Two effects are therefore deliberately kept out of the simulation (owner decision on #63, F4): Bitcoin is treated as untradable before {{ btc_fruehphase_ende }}, because a German retail investor had no realistic EUR access to Bitcoin before that; and every strategy/scenario only starts its simulation at the point where its complete instrument set was actually tradable - see &quot;simulation start&quot; in the strategy table below - instead of letting the proportional reallocation onto early-existing instruments (next section) also affect the published metrics. Both remain a simplification, not proof of investability at every point in time. The look-ahead bias applies exclusively to these {{ instrumente|length }} instruments actually assigned to a strategy. {% if nicht_allokierte_instrumente %}The {{ nicht_allokierte_instrumente|length }} additionally captured data series (section &quot;Data series without allocation&quot; below) are not a look-ahead bias, because they were added as a neutral benchmark independent of their price development, not selected into a strategy.{% endif %}">
         <strong>Rückschaufehler bei der Instrumentenauswahl.</strong> Die
         {{ instrumente|length }} Instrumente wurden ausgewählt, als ihre
         Kursentwicklung bereits bekannt war. Eine rückgerechnete Rendite
@@ -50,14 +50,14 @@
         hinein ausgewählt.
         {% endif %}
       </li>
-      <li>
+      <li data-i18n-en="The rules are not optimized and not backtested. Thresholds, time windows and quotas of the scenarios are a first approach, not parameters fitted to data. The &quot;Robustness across sub-periods&quot; section on every detail page shows how much a return varies between periods.">
         <strong>Die Regeln sind nicht optimiert und nicht gebacktestet.</strong>
         Schwellen, Zeitfenster und Quoten der Szenarien sind ein erster Ansatz,
         keine an Daten angepassten Parameter. Der Abschnitt „Robustheit über
         Teilperioden“ auf jeder Detailseite zeigt, wie stark eine Rendite
         zwischen Zeiträumen schwankt.
       </li>
-      <li>
+      <li data-i18n-en="One portfolio, one price history. All results rest on exactly one historical price series. There is no Monte Carlo simulation and no confidence intervals - differences of a few percentage points between two strategies therefore aren't statistically robust.">
         <strong>Ein Depot, ein Kursverlauf.</strong> Alle Ergebnisse beruhen auf
         genau einer historischen Kursreihe. Es gibt keine Monte-Carlo-Simulation
         und keine Konfidenzintervalle &ndash; Unterschiede von wenigen
@@ -65,14 +65,14 @@
       </li>
     </ul>
 
-    <h3>Datenbasis</h3>
+    <h3 data-i18n-en="Data basis">Datenbasis</h3>
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Zeitraum</div><div class="value">{{ zeitraum_von }} &ndash; {{ zeitraum_bis }}</div></div>
-      <div class="stat-tile"><div class="label">Kurszeilen</div><div class="value">{{ wochen }}</div></div>
-      <div class="stat-tile"><div class="label">Frequenz</div><div class="value">wöchentlich</div></div>
-      <div class="stat-tile"><div class="label">Währung</div><div class="value">EUR</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Period">Zeitraum</div><div class="value">{{ zeitraum_von }} &ndash; {{ zeitraum_bis }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Price rows">Kurszeilen</div><div class="value">{{ wochen }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Frequency">Frequenz</div><div class="value" data-i18n-en="weekly">wöchentlich</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Currency">Währung</div><div class="value">EUR</div></div>
     </div>
-    <p class="hint">
+    <p class="hint" data-i18n-en="The sole basis is data/price_history.csv: one weekly closing price per instrument, in euros. USD-quoted values are converted at the time of fetching using that same week's exchange rate. Only raw prices are stored - everything derived (position values, rebalancing, tax) is fully recalculated on every build. The same price history plus the same strategy therefore always yields the same result.">
       Grundlage ist ausschließlich <code>data/price_history.csv</code>: ein
       Wochenschlusskurs je Instrument, in Euro. USD-notierte Werte werden beim
       Abruf mit dem Wechselkurs derselben Woche umgerechnet. Es werden
@@ -81,15 +81,15 @@
       berechnet. Gleiche Kurshistorie plus gleiche Strategie ergibt deshalb immer
       dasselbe Ergebnis.
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="If a price couldn't be fetched, the last known price is carried forward instead of leaving a gap. Where this most recently happened is shown as the &quot;price status&quot; column in the instrument table of every detail page.">
       Konnte ein Kurs nicht abgerufen werden, wird der letzte bekannte Kurs
       fortgeschrieben, statt eine Lücke zu lassen. Wo das zuletzt passiert ist,
       steht als Spalte „Kursstatus“ in der Instrumententabelle jeder
       Detailseite.
     </p>
 
-    <h3>Instrumente und ab wann es sie gab</h3>
-    <p class="hint">
+    <h3 data-i18n-en="Instruments and how far back they go">Instrumente und ab wann es sie gab</h3>
+    <p class="hint" data-i18n-en="A large share of the instruments didn't yet exist at the start of the period. Their target share is then proportionally reallocated onto the instruments actually tradable at that time, so the portfolio stays fully invested - in whatever existed at that point. Otherwise a large part of the capital would sit idle without interest at the start, and the early years' return would be barely meaningful. As soon as an instrument first has a price, it is bought up to its target weight (logged as neues_instrument in the trade log). The early years therefore represent a noticeably narrower portfolio than the later ones - ⚠ marks the affected instruments.">
       Ein großer Teil der Instrumente existierte am Anfang des Zeitraums noch
       nicht. Ihr Zielanteil wird dann <strong>anteilig auf die tatsächlich
       handelbaren Instrumente umgelegt</strong>, damit das Depot voll investiert
@@ -103,7 +103,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>TER % p.a.</th><th>Spekulationsfrist</th></tr></thead>
+        <thead><tr><th data-i18n-en="Ticker">Ticker</th><th class="text-left" data-i18n-en="Instrument">Instrument</th><th class="text-left">ISIN</th><th data-i18n-en="First price">Erster Kurs</th><th data-i18n-en="Partial exemption %">Teilfreistellung %</th><th data-i18n-en="Accumulating">Thesaurierend</th><th data-i18n-en="Distributing">Ausschüttend</th><th data-i18n-en="Distribution yield %">Ausschüttungsrendite %</th><th>TER % p.a.</th><th data-i18n-en="Speculation period">Spekulationsfrist</th></tr></thead>
         <tbody>
         {% for i in instrumente %}
           <tr>
@@ -112,11 +112,11 @@
             <td class="text-left">{{ i.isin }}</td>
             <td class="{{ 'warn' if i.fehlt_anfangs else '' }}">{{ i.erster_kurs }}{% if i.fehlt_anfangs %} &#9888;{% endif %}</td>
             <td>{{ i.teilfreistellung }}</td>
-            <td>{{ i.thesaurierend }}</td>
-            <td>{{ i.ausschuettend }}</td>
-            <td>{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
+            <td data-i18n-en="{{ i.thesaurierend_en }}">{{ i.thesaurierend }}</td>
+            <td data-i18n-en="{{ i.ausschuettend_en }}">{{ i.ausschuettend }}</td>
+            <td data-i18n-en="{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (placeholder){% endif %}">{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
             <td>{{ i.ter }}</td>
-            <td>{{ i.spekulationsfrist }}</td>
+            <td data-i18n-en="{{ i.spekulationsfrist_en }}">{{ i.spekulationsfrist }}</td>
           </tr>
         {% endfor %}
         </tbody>
@@ -124,8 +124,8 @@
     </div>
 
     {% if nicht_allokierte_instrumente %}
-    <h3>Datenreihen ohne Allokation</h3>
-    <p class="hint">
+    <h3 data-i18n-en="Data series without allocation">Datenreihen ohne Allokation</h3>
+    <p class="hint" data-i18n-en="The following {{ nicht_allokierte_instrumente|length }} instruments deliberately sit in no bucket of any strategy or scenario - engine.simulate() reads exclusively the strategies' target weights and therefore never trades any of these data series, whatever their price does. They were added as a neutral benchmark (broad indices, money market, real estate, commodities) independent of their price development, not selected into a strategy - see #64. Only a future allocation (see #63) would bring them into the simulation; until then, partial-exemption/accumulating/distributing status is shown here for information only and, unlike the allocated instruments above, has not yet been verified against fund prospectuses.">
       Die folgenden {{ nicht_allokierte_instrumente|length }} Instrumente
       liegen bewusst in <strong>keinem Topf</strong> einer Strategie oder
       eines Szenarios &ndash; <code>engine.simulate()</code> liest
@@ -144,7 +144,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Ticker</th><th class="text-left">Instrument</th><th class="text-left">ISIN</th><th>Erster Kurs</th><th>Teilfreistellung %</th><th>Thesaurierend</th><th>Ausschüttend</th><th>Ausschüttungsrendite %</th><th>TER % p.a.</th><th>Spekulationsfrist</th></tr></thead>
+        <thead><tr><th data-i18n-en="Ticker">Ticker</th><th class="text-left" data-i18n-en="Instrument">Instrument</th><th class="text-left">ISIN</th><th data-i18n-en="First price">Erster Kurs</th><th data-i18n-en="Partial exemption %">Teilfreistellung %</th><th data-i18n-en="Accumulating">Thesaurierend</th><th data-i18n-en="Distributing">Ausschüttend</th><th data-i18n-en="Distribution yield %">Ausschüttungsrendite %</th><th>TER % p.a.</th><th data-i18n-en="Speculation period">Spekulationsfrist</th></tr></thead>
         <tbody>
         {% for i in nicht_allokierte_instrumente %}
           <tr>
@@ -153,11 +153,11 @@
             <td class="text-left">{{ i.isin }}</td>
             <td class="{{ 'warn' if i.fehlt_anfangs else '' }}">{{ i.erster_kurs }}{% if i.fehlt_anfangs %} &#9888;{% endif %}</td>
             <td>{{ i.teilfreistellung }}</td>
-            <td>{{ i.thesaurierend }}</td>
-            <td>{{ i.ausschuettend }}</td>
-            <td>{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
+            <td data-i18n-en="{{ i.thesaurierend_en }}">{{ i.thesaurierend }}</td>
+            <td data-i18n-en="{{ i.ausschuettend_en }}">{{ i.ausschuettend }}</td>
+            <td data-i18n-en="{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (placeholder){% endif %}">{{ i.dividendenrendite }}{% if i.dividendenrendite_platzhalter %} (Platzhalter){% endif %}</td>
             <td>{{ i.ter }}</td>
-            <td>{{ i.spekulationsfrist }}</td>
+            <td data-i18n-en="{{ i.spekulationsfrist_en }}">{{ i.spekulationsfrist }}</td>
           </tr>
         {% endfor %}
         </tbody>
@@ -165,15 +165,15 @@
     </div>
     {% endif %}
 
-    <h3>Handelsregeln</h3>
+    <h3 data-i18n-en="Trading rules">Handelsregeln</h3>
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Ordergebühr je Trade</div><div class="value">{{ ordergebuehr }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Kostenbasis</div><div class="value">Durchschnitt</div></div>
-      <div class="stat-tile"><div class="label">Spread / Slippage</div><div class="value">nicht modelliert</div></div>
-      <div class="stat-tile"><div class="label">Ausschüttungsrendite</div><div class="value">je Instrument</div></div>
-      <div class="stat-tile"><div class="label">Laufende Fondskosten (TER)</div><div class="value">je Instrument</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Order fee per trade">Ordergebühr je Trade</div><div class="value">{{ ordergebuehr }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Cost basis">Kostenbasis</div><div class="value" data-i18n-en="Average">Durchschnitt</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Spread / slippage">Spread / Slippage</div><div class="value" data-i18n-en="not modeled">nicht modelliert</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Distribution yield">Ausschüttungsrendite</div><div class="value" data-i18n-en="per instrument">je Instrument</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Ongoing fund costs (TER)">Laufende Fondskosten (TER)</div><div class="value" data-i18n-en="per instrument">je Instrument</div></div>
     </div>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Every fund's ongoing costs (TER) are deducted weekly on a pro-rata basis (TER &divide; 52) from the holding - as a reduction of units, not a cash outflow: the investor doesn't pay the TER out of pocket, their share of the fund's assets simply shrinks. The cost basis therefore stays unchanged. Individual stocks, physical gold and BTC carry none (&quot;TER % p.a.&quot; column above). Without this modeling, omitting it would not have been neutral but directional: the rates differ by an order of magnitude, the benchmark is the cheapest instrument in the field, and the individual-stock satellite carries none at all - so precisely the most concentrated variant would have been favored (#76).">
       Die <strong>laufenden Fondskosten (TER)</strong> jedes Fonds werden
       wöchentlich anteilig (TER ÷ 52) vom Bestand abgezogen &ndash; als
       Reduktion der Anteile, nicht als Barabfluss: der Anleger zahlt die TER
@@ -186,7 +186,7 @@
       begünstigt worden wäre also ausgerechnet die konzentrierteste Variante
       (<a href="https://github.com/S540d/Boersenspiel/issues/76">#76</a>).
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Buying and selling happens at the weekly closing price, in arbitrary fractions, without a bid-ask spread and without partial fills. Fees from the initial purchase are deducted from the starting capital before it's split up; later trades reduce the realized gain by the fee on sale and add it to the cost basis on purchase. The cost basis runs on the average-cost method, not FIFO. For every distributing instrument, a distribution equal to its own distribution yield (column in the instrument table above) is applied once a year to the portfolio value at the start of the year (#57, per instrument since #74). The distribution is credited as genuine additional cash, automatically reinvested, and taxed like a real capital gain. Accumulating funds by definition distribute nothing; 4GLD (physical gold), BTC-EUR and the individual stocks without a dividend (Tesla, Rivian, Palantir, Strategy, SolarEdge, Lumentum, SMA Solar) correctly receive none. Remaining simplification: the rate per instrument is constant over the entire history and rounded from public fact sheets - no year-accurate distribution history is stored. Until #74, a single flat rate of {{ dividendenrendite }}% applied to all distributing instruments instead; that favored non-distributing growth stocks at the expense of bond and real-estate ETFs, whose return consists largely of the distribution itself.">
       Gekauft und verkauft wird zum Wochenschlusskurs, in beliebigen
       Bruchstücken, ohne Geld-Brief-Spanne und ohne Teilausführung. Gebühren des
       Erstkaufs werden vor der Aufteilung vom Startkapital abgezogen; spätere
@@ -213,7 +213,7 @@
       Wachstumswerte auf Kosten von Anleihen- und Immobilien-ETFs, deren
       Ertrag zum großen Teil gerade aus der Ausschüttung besteht.
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Rebalancing happens as soon as ANY bucket deviates from its own target weight by more than either the strategy's absolute threshold in percentage points or its relative threshold, whichever triggers first (&quot;5/25 rule&quot;, market-standard, owner decision on #63, F5); all instruments are then brought back to their target weight. The trigger checks the bucket level for EVERY bucket of the strategy, not the concentration of individual instruments within a bucket - that's what ⚠ in the detail pages' instrument table points out.">
       Rebalanciert wird, sobald IRGENDEIN Topf entweder um mehr als die
       absolute Schwelle der jeweiligen Strategie in Prozentpunkten oder um
       mehr als deren relative Schwelle vom eigenen Zielgewicht abweicht, je
@@ -227,7 +227,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Strategie</th><th>Startkapital &euro;</th><th>Schwelle pp (absolut)</th><th>Schwelle % (relativ)</th><th class="text-left">Überwachter Topf</th><th>Zielgewicht %</th><th>Zeitabhängige Gewichte</th><th>Simulationsbeginn</th><th>Risikofreier Zins % p.a.</th></tr></thead>
+        <thead><tr><th data-i18n-en="Strategy">Strategie</th><th data-i18n-en="Starting capital &euro;">Startkapital &euro;</th><th data-i18n-en="Threshold pp (absolute)">Schwelle pp (absolut)</th><th data-i18n-en="Threshold % (relative)">Schwelle % (relativ)</th><th class="text-left" data-i18n-en="Monitored bucket">Überwachter Topf</th><th data-i18n-en="Target weight %">Zielgewicht %</th><th data-i18n-en="Time-dependent weights">Zeitabhängige Gewichte</th><th data-i18n-en="Simulation start">Simulationsbeginn</th><th data-i18n-en="Risk-free rate % p.a.">Risikofreier Zins % p.a.</th></tr></thead>
         <tbody>
         {% for s in strategien %}
           <tr>
@@ -235,9 +235,9 @@
             <td>{{ s.startkapital }}</td>
             <td>{{ s.schwelle }}</td>
             <td>{{ s.schwelle_relativ }}</td>
-            <td class="text-left">{{ s.ziel_topf }}</td>
+            <td class="text-left" data-i18n-en="{{ s.ziel_topf_en }}">{{ s.ziel_topf }}</td>
             <td>{{ s.ziel_gewicht }}</td>
-            <td>{{ s.dynamisch }}</td>
+            <td data-i18n-en="{{ s.dynamisch_en }}">{{ s.dynamisch }}</td>
             <td>{{ s.sim_beginn }}</td>
             <td>{{ s.risikofreier_zins_label }}</td>
           </tr>
@@ -246,8 +246,8 @@
       </table>
     </div>
 
-    <h3>Cash und ungenutztes Kapital</h3>
-    <p class="hint">
+    <h3 data-i18n-en="Cash and uninvested capital">Cash und ungenutztes Kapital</h3>
+    <p class="hint" data-i18n-en="No strategy has its own cash target allocation. When a scenario switches to &quot;defensive&quot; (e.g. &quot;Sell in May&quot;, SMA death cross, trailing stop), the capital moves entirely into bucket A (safety) - bucket A takes on the cash role, instead of an unremunerated cash position or one carrying a made-up interest rate. A genuine cash position would have two downsides: it would need a fictional interest rate instead of one derivable from the price history, and it would duplicate bucket A without a purpose of its own.">
       Keine Strategie hat eine eigene Cash-Zielallokation. Schaltet ein
       Szenario auf „defensiv“ (z.&nbsp;B. „Sell in May“, SMA-Death-Cross,
       Trailing-Stop), wandert das Kapital vollständig in Topf A (Sicherheit)
@@ -257,7 +257,7 @@
       Phantasiezins statt eines aus der Kurshistorie ableitbaren Werts, und
       sie würde Topf A ohne eigenen Zweck duplizieren.
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Cash in the technical sense (pending_cash in engine.py) still arises briefly when a capital share has no tradable target at all - e.g. because an instrument doesn't yet have a price, or, in the extreme case, no single target instrument of a bucket exists. That's not a bug, it's the only honest representation of &quot;out of the market with no instrument available&quot;. {% if cash_ueberall_null %}Looking at the entire price history, every strategy and every scenario currently holds 0% cash throughout.{% else %}Looking at the entire price history, not every strategy currently holds 0% cash throughout - the table below shows the highest share ever reached and when it occurred.{% endif %}">
       Cash im technischen Sinn (<code>pending_cash</code> in
       <code>engine.py</code>) entsteht trotzdem kurzzeitig, wenn ein
       Kapitalanteil <em>überhaupt kein</em> handelbares Ziel hat &ndash; etwa
@@ -276,7 +276,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Strategie</th><th>Cash-Höchststand %</th><th>Datum</th></tr></thead>
+        <thead><tr><th data-i18n-en="Strategy">Strategie</th><th data-i18n-en="Max cash share %">Cash-Höchststand %</th><th data-i18n-en="Date">Datum</th></tr></thead>
         <tbody>
         {% for s in strategien %}
           <tr>
@@ -289,14 +289,14 @@
       </table>
     </div>
 
-    <h3>Steuerannahmen</h3>
+    <h3 data-i18n-en="Tax assumptions">Steuerannahmen</h3>
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Steuersatz</div><div class="value">{{ steuersatz }} %</div></div>
-      <div class="stat-tile"><div class="label">Sparerpauschbetrag / Jahr</div><div class="value">{{ sparerpauschbetrag }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Freigrenze § 23 EStG</div><div class="value">{{ spek_freigrenze }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Vorabpauschale-Basiszins</div><div class="value">{{ vorabpauschale_basiszins }} % (Platzhalter)</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Tax rate">Steuersatz</div><div class="value">{{ steuersatz }} %</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Savings allowance / year">Sparerpauschbetrag / Jahr</div><div class="value">{{ sparerpauschbetrag }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Exemption threshold &sect; 23 EStG">Freigrenze § 23 EStG</div><div class="value">{{ spek_freigrenze }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Vorabpauschale base rate">Vorabpauschale-Basiszins</div><div class="value" data-i18n-en="{{ vorabpauschale_basiszins }} % (placeholder)">{{ vorabpauschale_basiszins }} % (Platzhalter)</div></div>
     </div>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Calculated with the flat German capital-gains tax rate (Abgeltungsteuer plus solidarity surcharge), not a personal income tax rate; church tax is left out. The savings allowance resets at the start of the year, unused losses are carried forward. Equity fund ETFs get their partial exemption applied to both gains and losses (see table above).">
       Gerechnet wird mit dem pauschalen Abgeltungsteuersatz (Kapitalertragsteuer
       plus Solidaritätszuschlag), <strong>nicht mit einem persönlichen
       Einkommensteuersatz</strong>; Kirchensteuer bleibt außen vor. Der
@@ -305,7 +305,7 @@
       bekommen ihre Teilfreistellung auf Gewinn <em>und</em> Verlust angerechnet
       (siehe Tabelle oben).
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="A simplified Vorabpauschale (advance lump-sum tax) is applied for accumulating funds: value at the start of the year &times; {{ vorabpauschale_basiszins }}% &times; {{ vorabpauschale_faktor }}%, capped at the actual increase in value. The base rate is a fixed placeholder, not a real annual rate published by the Federal Ministry of Finance, and the lump sum is applied at year-end instead of the first business day of the following year. Crypto is subject to the speculation-period rules instead of the flat capital-gains tax, with its own loss carryforward and an exemption threshold (not an allowance: above the threshold, the entire year's gain is taxable). The holding-period date is a quantity-weighted average purchase date, not genuine per-lot tracking.">
       Für thesaurierende Fonds wird eine vereinfachte Vorabpauschale angesetzt:
       Wert zu Jahresbeginn &times; {{ vorabpauschale_basiszins }} % &times;
       {{ vorabpauschale_faktor }} %, gedeckelt auf die tatsächliche
@@ -318,14 +318,14 @@
       ist ein stückzahlgewichtetes Durchschnittskaufdatum, kein echtes
       Per-Lot-Tracking.
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="Important for interpretation: the reported tax is pure tracking - the simulated portfolio value itself is never reduced by tax.">
       Wichtig für die Interpretation: Die ausgewiesene Steuer ist reines
       Tracking &ndash; <strong>der simulierte Depotwert selbst wird nirgends um
       Steuer gemindert</strong>.
     </p>
 
-    <h3>Kennzahlen auf der Übersicht</h3>
-    <p class="hint">
+    <h3 data-i18n-en="Metrics on the overview">Kennzahlen auf der Übersicht</h3>
+    <p class="hint" data-i18n-en="Volatility is the annualized standard deviation of weekly returns (&times; &radic;52), max drawdown the largest decline from the previous high. Sharpe divides the annualized return by the overall dispersion, Sortino only by the dispersion of losing weeks. Both measure the excess return over a risk-free rate; since #75 that is no longer hardcoded, but derived from the EUR money-market ETF {{ geldmarkt_ticker }} over exactly the same period the respective strategy is evaluated over - it's therefore shown per strategy/period in the table below and in the detail pages' period sections. This makes the metric automatically track the interest-rate environment (2006-2008 around 3-4%, 2012-2022 near 0%, from 2023 back to 3-4%). Previously a fixed {{ risikofreier_zins }}% applied; Sharpe was then effectively &quot;return &divide; risk&quot; instead of &quot;excess return &divide; risk&quot; and could by construction never show that a strategy did not beat the money market - an error that acted unevenly: it boosted low-volatility strategies (small denominator) more, i.e. precisely the defensive ones. If {{ geldmarkt_ticker }} is missing over the period or too short, the placeholder of {{ risikofreier_zins }}% still applies. If a series has no losing weeks at all, Sortino is reported as 0 instead of undefined.">
       Volatilität ist die annualisierte Standardabweichung der Wochenrenditen
       (&times; &radic;52), Max Drawdown der größte Rückgang vom bisherigen
       Höchststand. Sharpe teilt die annualisierte Rendite durch die gesamte
@@ -348,7 +348,7 @@
       Platzhalter von {{ risikofreier_zins }} %. Hat eine Reihe gar keine
       Verlustwochen, wird Sortino als 0 ausgewiesen statt als undefiniert.
     </p>
-    <p class="hint">
+    <p class="hint" data-i18n-en="The moving averages on the detail pages approximate the classic 50-/200-day lines with {{ sma_kurz }} and {{ sma_lang }} weeks respectively (5 trading days per week) - on weekly data, not daily data. The walk-forward section splits the history into up to {{ walk_forward_segmente }} equal-sized periods and simulates each independently with fresh starting capital; it is omitted below {{ walk_forward_min_wochen }} weeks per segment.">
       Die gleitenden Durchschnitte auf den Detailseiten nähern die klassischen
       50-/200-Tage-Linien mit {{ sma_kurz }} bzw. {{ sma_lang }} Wochen (5
       Handelstage je Woche) an &ndash; auf Wochendaten, nicht auf Tagesdaten. Der
@@ -358,21 +358,21 @@
       {{ walk_forward_min_wochen }} Wochen je Segment entfällt er.
     </p>
 
-    <h3>Was nicht modelliert wird</h3>
+    <h3 data-i18n-en="What is not modeled">Was nicht modelliert wird</h3>
     <ul class="hint">
-      <li>
+      <li data-i18n-en="Year-accurate dividend/distribution histories - a constant rate rounded from fact sheets applies per instrument (table above), not the dividends actually paid in a given year">
         Jahresgenaue Dividenden-/Ausschüttungshistorien &ndash; je Instrument
         gilt ein konstanter, aus Fact-Sheets gerundeter Satz (Tabelle oben),
         nicht die tatsächlich gezahlten Dividenden des jeweiligen Jahres
       </li>
-      <li>Inflation &ndash; alle Beträge sind nominal</li>
-      <li>Geld-Brief-Spanne, Slippage, Teilausführungen, Handelsaussetzungen</li>
-      <li>Depot- und Ausgabeaufschlagskosten &ndash; die laufenden Fondskosten (TER) werden seit
+      <li data-i18n-en="Inflation - all amounts are nominal">Inflation &ndash; alle Beträge sind nominal</li>
+      <li data-i18n-en="Bid-ask spread, slippage, partial fills, trading halts">Geld-Brief-Spanne, Slippage, Teilausführungen, Handelsaussetzungen</li>
+      <li data-i18n-en="Custody and front-load fees - ongoing fund costs (TER) have been modeled since #76 (table above), custody fees and front-load charges have not">Depot- und Ausgabeaufschlagskosten &ndash; die laufenden Fondskosten (TER) werden seit
         <a href="https://github.com/S540d/Boersenspiel/issues/76">#76</a> modelliert (Tabelle oben),
         Depotgebühren und Ausgabeaufschläge nicht</li>
-      <li>Zinsen auf nicht investiertes Kapital</li>
-      <li>Kapitalmaßnahmen wie Splits oder Fusionen über den Kursabruf hinaus</li>
-      <li>Steuerliche Effekte über das Abgeltungsteuer- und § 23-Regime hinaus</li>
+      <li data-i18n-en="Interest on uninvested capital">Zinsen auf nicht investiertes Kapital</li>
+      <li data-i18n-en="Corporate actions such as splits or mergers beyond what the price fetch captures">Kapitalmaßnahmen wie Splits oder Fusionen über den Kursabruf hinaus</li>
+      <li data-i18n-en="Tax effects beyond the flat capital-gains tax and &sect; 23 regime">Steuerliche Effekte über das Abgeltungsteuer- und § 23-Regime hinaus</li>
     </ul>
   </section>
 {% endblock %}

--- a/src/boersenspiel/templates/strategy_detail.html.j2
+++ b/src/boersenspiel/templates/strategy_detail.html.j2
@@ -2,27 +2,27 @@
 {% block title %}{{ s.name }} – Barbell-Portfolio Dashboard{% endblock %}
 {% block meta_description %}{% if s.beschreibung %}{{ s.beschreibung }}{% else %}{{ s.name }}: Kursverlauf, Kennzahlen und Steuerdetails im Barbell-Portfolio-Dashboard.{% endif %}{% endblock %}
 {% block canonical %}https://s540d.github.io/Boersenspiel/{{ s.id }}.html{% endblock %}
-{% block header_extra %}<p class="back-link"><a href="index.html">&larr; Zur Übersicht</a></p>{% endblock %}
+{% block header_extra %}<p class="back-link"><a href="index.html" data-i18n-en="&larr; Back to overview">&larr; Zur Übersicht</a></p>{% endblock %}
 {% block content %}
   <section class="strategy" id="{{ s.id }}">
     <h2>{{ s.name }}</h2>
-    {% if s.beschreibung %}<p class="hint">{{ s.beschreibung }}</p>{% endif %}
+    {% if s.beschreibung %}<p class="hint" data-i18n-en="{{ s.beschreibung_en }}">{{ s.beschreibung }}</p>{% endif %}
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Gesamtwert</div><div class="value">{{ s.total_value }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Startkapital</div><div class="value">{{ s.startkapital }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Trades gesamt</div><div class="value">{{ s.trade_count }}</div></div>
-      <div class="stat-tile"><div class="label">Letztes Rebalancing</div><div class="value">{{ s.last_rebalance_date }}</div></div>
-      <div class="stat-tile"><div class="label">Letzter Dez.-Harvest</div><div class="value">{{ s.last_harvest_date }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Total value">Gesamtwert</div><div class="value">{{ s.total_value }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Starting capital">Startkapital</div><div class="value">{{ s.startkapital }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Total trades">Trades gesamt</div><div class="value">{{ s.trade_count }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Last rebalance">Letztes Rebalancing</div><div class="value">{{ s.last_rebalance_date }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Last Dec. harvest">Letzter Dez.-Harvest</div><div class="value">{{ s.last_harvest_date }}</div></div>
     </div>
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Bruttorendite % (CAGR p.a.)</div><div class="value">{{ s.cagr_label }}</div></div>
-      <div class="stat-tile"><div class="label">Geschätzte Nettorendite % (CAGR p.a.)</div><div class="value">{{ s.netto_cagr_label }}</div></div>
-      <div class="stat-tile"><div class="label">Freibetrag verbraucht ({{ s.tax.year }})</div><div class="value">{{ s.tax.freibetrag_verbraucht }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Freibetrag verbleibend</div><div class="value">{{ s.tax.freibetrag_verbleibend }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Verlustvortrag</div><div class="value">{{ s.tax.verlustvortrag }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Kumulierte Steuer (nur nachrichtlich)</div><div class="value">{{ s.tax.kumulierte_steuer }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Gross return % (CAGR p.a.)">Bruttorendite % (CAGR p.a.)</div><div class="value">{{ s.cagr_label }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Estimated net return % (CAGR p.a.)">Geschätzte Nettorendite % (CAGR p.a.)</div><div class="value">{{ s.netto_cagr_label }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Allowance used ({{ s.tax.year }})">Freibetrag verbraucht ({{ s.tax.year }})</div><div class="value">{{ s.tax.freibetrag_verbraucht }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Allowance remaining">Freibetrag verbleibend</div><div class="value">{{ s.tax.freibetrag_verbleibend }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Loss carryforward">Verlustvortrag</div><div class="value">{{ s.tax.verlustvortrag }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Cumulative tax (informational only)">Kumulierte Steuer (nur nachrichtlich)</div><div class="value">{{ s.tax.kumulierte_steuer }} &euro;</div></div>
     </div>
-    <p class="hint">
+    <p class="hint" data-i18n-en="All return and value figures on this page are gross values (before tax) - the cumulative tax is tracked for information but is never subtracted from the simulated portfolio value. The &quot;estimated net return&quot; above subtracts the cumulative tax once from the final value to give a rough order of magnitude; in reality taxes are due at different points throughout the year, not as a single deduction at the end (#63, F6a).">
       Alle Rendite- und Wertangaben auf dieser Seite sind
       <strong>Bruttowerte (vor Steuer)</strong> &ndash; die kumulierte Steuer
       wird nachrichtlich mitgeführt, aber nirgends vom simulierten Depotwert
@@ -32,12 +32,12 @@
       nicht als einmaliger Abzug am Ende (#63, F6a).
     </p>
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Wert nach Steuern beim sofortigen Verkauf<span class="info-tip" tabindex="0" title="Hypothetischer Verkauf des GESAMTEN Depots zum Stichtag der letzten Kurszeile: Bruttoendwert minus Ordergebühren minus Steuer auf die bislang unrealisierten Gewinne jeder noch gehaltenen Position (Sparerpauschbetrag/Verlustvortrag bzw. bei BTC die eigene Spekulationsfrist-Freigrenze werden dabei berücksichtigt).">i</span></div><div class="value">{{ s.liquidationswert_label }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">davon Steuer auf unrealisierte Gewinne</div><div class="value">{{ s.liquidationssteuer_label }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">davon Ordergebühren</div><div class="value">{{ s.liquidationsgebuehren_label }} &euro;</div></div>
-      <div class="stat-tile"><div class="label">Rendite % nach vollständiger Versteuerung</div><div class="value">{{ s.liquidations_rendite_pct_label }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Value after tax on immediate sale">Wert nach Steuern beim sofortigen Verkauf<span class="info-tip" tabindex="0" title="Hypothetischer Verkauf des GESAMTEN Depots zum Stichtag der letzten Kurszeile: Bruttoendwert minus Ordergebühren minus Steuer auf die bislang unrealisierten Gewinne jeder noch gehaltenen Position (Sparerpauschbetrag/Verlustvortrag bzw. bei BTC die eigene Spekulationsfrist-Freigrenze werden dabei berücksichtigt)." data-i18n-en-title="Hypothetical sale of the ENTIRE portfolio as of the last price row: gross final value minus order fees minus tax on the unrealized gains of every position still held (the savings allowance/loss carryforward, or BTC's own speculation-period exemption threshold, are taken into account).">i</span></div><div class="value">{{ s.liquidationswert_label }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="of which: tax on unrealized gains">davon Steuer auf unrealisierte Gewinne</div><div class="value">{{ s.liquidationssteuer_label }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="of which: order fees">davon Ordergebühren</div><div class="value">{{ s.liquidationsgebuehren_label }} &euro;</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Return % after full taxation">Rendite % nach vollständiger Versteuerung</div><div class="value">{{ s.liquidations_rendite_pct_label }}</div></div>
     </div>
-    <p class="hint">
+    <p class="hint" data-i18n-en="The difference to the &quot;estimated net return&quot; above: that one only subtracts the tax already actually realized (from rebalancing and December-harvest sales) from the final value. &quot;Value after tax on immediate sale&quot; goes a step further and additionally accounts for the tax that would become due on the still unrealized gains of the currently held positions if the entire portfolio were sold today - plus the order fees that would incur. That's the more realistic answer to &quot;what actually remains of the capital invested&quot;.">
       Der Unterschied zur "Geschätzten Nettorendite" oben: die zieht nur die
       bereits <em>tatsächlich realisierte</em> Steuer (aus Rebalancing- und
       Dezember-Harvest-Verkäufen) vom Endwert ab. Der "Wert nach Steuern beim
@@ -49,8 +49,8 @@
       tatsächlich übrig".
     </p>
     {% if s.zeitraum_presets %}
-    <h3>Kennzahlen nach Betrachtungszeitraum</h3>
-    <p class="hint">
+    <h3 data-i18n-en="Metrics by viewing period">Kennzahlen nach Betrachtungszeitraum</h3>
+    <p class="hint" data-i18n-en="Each period is an independent, fresh re-simulation with new starting capital (no continued portfolio) - similar to the walk-forward section below, just with fixed rather than equal-sized periods (#54). {% if 'erweitert' in (s.zeitraum_presets | map(attribute='id') | list) %}The &quot;Extended (replacement bond assumption)&quot; period (#80) runs over the full available price history instead of only from the point at which all of this strategy's target instruments were tradable: as long as a target instrument didn't yet exist, its capital share is treated as invested in IBCL (euro government bonds, 15-30 years) - the same bond ETF for ALL strategies and scenarios, instead of different replacement instruments per strategy. This avoids the over-concentration of early-existing instruments (Bitcoin above all) that would otherwise arise (see Premises, &quot;Look-ahead bias, leveraged&quot;), but shows a longer period at the cost of an additional assumption: in reality, a strategy assembled in 2026 wouldn't have existed yet in 2006.{% endif %}">
       Jeder Zeitraum ist eine eigenständige Neu-Simulation mit frischem
       Startkapital (kein fortgeführtes Depot) - analog zum Walk-Forward-
       Abschnitt unten, nur mit festen statt gleich großen Perioden (#54).
@@ -71,28 +71,28 @@
     </p>
     <div class="zeitraum-switch" id="detail-zeitraum-switch">
       {% for p in s.zeitraum_presets %}
-      <button type="button" data-preset="{{ p.id }}"{% if p.id == 'alle' %} class="active"{% endif %}>{{ p.label }}</button>
+      <button type="button" data-preset="{{ p.id }}"{% if p.id == 'alle' %} class="active"{% endif %} data-i18n-en="{{ p.label_en }}">{{ p.label }}</button>
       {% endfor %}
     </div>
     {% if s.benchmarks %}
     <div class="benchmark-switch" id="benchmark-switch">
-      <span>Benchmark einblenden:</span>
-      <button type="button" data-benchmark="none" class="active">Kein Benchmark</button>
+      <span data-i18n-en="Show benchmark:">Benchmark einblenden:</span>
+      <button type="button" data-benchmark="none" class="active" data-i18n-en="No benchmark">Kein Benchmark</button>
       {% for b in s.benchmarks %}
       <button type="button" data-benchmark="{{ b.id }}">{{ b.label }}</button>
       {% endfor %}
     </div>
     {% endif %}
     <div class="stat-row">
-      <div class="stat-tile"><div class="label">Rendite % (brutto, im Zeitraum)</div><div class="value" id="zeitraum-rendite">{{ s.rendite_pct_label }}</div></div>
-      <div class="stat-tile"><div class="label">Volatilität % (ann.)</div><div class="value" id="zeitraum-volatilitaet">{{ s.volatilitaet_label }}</div></div>
-      <div class="stat-tile"><div class="label">Max Drawdown %</div><div class="value" id="zeitraum-max-drawdown">{{ s.max_drawdown_label }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Return % (gross, over period)">Rendite % (brutto, im Zeitraum)</div><div class="value" id="zeitraum-rendite">{{ s.rendite_pct_label }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Volatility % (ann.)">Volatilität % (ann.)</div><div class="value" id="zeitraum-volatilitaet">{{ s.volatilitaet_label }}</div></div>
+      <div class="stat-tile"><div class="label" data-i18n-en="Max drawdown %">Max Drawdown %</div><div class="value" id="zeitraum-max-drawdown">{{ s.max_drawdown_label }}</div></div>
       <div class="stat-tile"><div class="label">Sharpe</div><div class="value" id="zeitraum-sharpe">{{ s.sharpe_label }}</div></div>
       <div class="stat-tile"><div class="label">Sortino</div><div class="value" id="zeitraum-sortino">{{ s.sortino_label }}</div></div>
     </div>
     <div class="chart-box-large"><canvas id="zeitraum-chart"></canvas></div>
     {% endif %}
-    <p class="hint">
+    <p class="hint" data-i18n-en="Moving averages of the value history as a weekly approximation of the classic 50-/200-day lines (10 and 40 weeks at 5 trading days each) - the same approach as the &quot;Chart technique: SMA crossover&quot; scenario. Always over the entire history, independent of the viewing period selected above, since the moving averages themselves need enough lead-in.">
       Gleitende Durchschnitte des Wertverlaufs als Wochen-Näherung der klassischen
       50-/200-Tage-Linien (10 bzw. 40 Wochen à 5 Handelstage) - derselbe Ansatz wie
       beim Szenario "Charttechnik: SMA-Crossover". Immer über die gesamte Historie,
@@ -105,8 +105,8 @@
     </div>
     {% if s.beitraege %}
     <div class="beitraege">
-      <h3>Effekt der einzelnen Börsenweisheiten</h3>
-      <p class="hint">
+      <h3 data-i18n-en="Effect of the individual market sayings">Effekt der einzelnen Börsenweisheiten</h3>
+      <p class="hint" data-i18n-en="Leave-one-out: CAGR (annualized return) of this strategy minus the CAGR of the same strategy without the respective saying. Positive = the saying added return, negative = it cost return. On a CAGR rather than total-return basis, because the difference of two total returns is no longer a meaningful percentage-point figure once the base and comparison runs differ by orders of magnitude (#63). The rules influence each other, so the individual contributions don't sum exactly to the total CAGR.">
         Leave-one-out: CAGR (annualisierte Rendite) dieser Strategie minus CAGR
         derselben Strategie <em>ohne</em> den jeweiligen Spruch. Positiv = der Spruch
         hat Rendite gebracht, negativ = er hat gekostet. Auf CAGR- statt
@@ -119,7 +119,7 @@
       <div class="chart-box"><canvas id="beitrag-chart"></canvas></div>
       <div class="overflow-x">
         <table>
-          <thead><tr><th>Börsenweisheit</th><th>Effekt (CAGR-Prozentpunkte p.a.)</th><th>CAGR ohne diesen Spruch % p.a.</th><th>Gesamtrendite ohne diesen Spruch %</th></tr></thead>
+          <thead><tr><th data-i18n-en="Market saying">Börsenweisheit</th><th data-i18n-en="Effect (CAGR percentage points p.a.)">Effekt (CAGR-Prozentpunkte p.a.)</th><th data-i18n-en="CAGR without this saying % p.a.">CAGR ohne diesen Spruch % p.a.</th><th data-i18n-en="Total return without this saying %">Gesamtrendite ohne diesen Spruch %</th></tr></thead>
           <tbody>
           {% for b in s.beitraege %}
             <tr>
@@ -135,8 +135,8 @@
     </div>
     {% endif %}
     <div class="beitraege">
-      <h3>Effekt der Optimierungs-Schalter</h3>
-      <p class="hint">
+      <h3 data-i18n-en="Effect of the optimization switches">Effekt der Optimierungs-Schalter</h3>
+      <p class="hint" data-i18n-en="Leave-one-out per mechanism: CAGR (annualized return) of this strategy minus the CAGR of the same strategy with exactly this one mechanism switched off (December harvest, rebalancing, order fees, taxation, ongoing fund costs). Positive = the mechanism added return, negative = it cost return. On a CAGR rather than total-return basis, because the difference of two total returns is no longer a meaningful percentage-point figure once the base and comparison runs differ by orders of magnitude - e.g. when rebalancing repeatedly brings a dominant position like Bitcoin back to its target weight (#63).">
         Leave-one-out je Mechanismus: CAGR (annualisierte Rendite) dieser Strategie
         minus CAGR derselben Strategie mit genau diesem einen Mechanismus
         ausgeschaltet (Dezember-Harvest, Rebalancing, Ordergebühren, Besteuerung,
@@ -151,11 +151,11 @@
       <div class="chart-box"><canvas id="opt-chart"></canvas></div>
       <div class="overflow-x">
         <table>
-          <thead><tr><th>Mechanismus</th><th>Effekt (CAGR-Prozentpunkte p.a.)</th><th>CAGR ohne diesen Mechanismus % p.a.</th><th>Gesamtrendite ohne diesen Mechanismus %</th></tr></thead>
+          <thead><tr><th data-i18n-en="Mechanism">Mechanismus</th><th data-i18n-en="Effect (CAGR percentage points p.a.)">Effekt (CAGR-Prozentpunkte p.a.)</th><th data-i18n-en="CAGR without this mechanism % p.a.">CAGR ohne diesen Mechanismus % p.a.</th><th data-i18n-en="Total return without this mechanism %">Gesamtrendite ohne diesen Mechanismus %</th></tr></thead>
           <tbody>
           {% for o in s.optimierungs_effekte %}
             <tr>
-              <td>{{ o.name }}</td>
+              <td data-i18n-en="{{ o.name_en }}">{{ o.name }}</td>
               <td class="{{ 'positive' if o.delta_pp >= 0 else 'negative' }}">{{ o.delta_label }}</td>
               <td>{{ o.ohne_cagr_label }}</td>
               <td>{{ o.ohne_rendite_label }}</td>
@@ -167,8 +167,8 @@
     </div>
     {% if s.walk_forward_segmente %}
     <div class="beitraege">
-      <h3>Robustheit über Teilperioden (Walk-Forward)</h3>
-      <p class="hint">
+      <h3 data-i18n-en="Robustness across sub-periods (walk-forward)">Robustheit über Teilperioden (Walk-Forward)</h3>
+      <p class="hint" data-i18n-en="The same strategy simulated independently over several consecutive periods - each with its own starting capital, not as one continuous position. Shows whether the return is reasonably consistent over time or arose only from a single period (in which case the total return would be a poor predictor of the future). Spread across the periods: {{ s.walk_forward_spread_label }} percentage points (largest minus smallest period return).">
         Dieselbe Strategie unabhängig auf mehreren aufeinanderfolgenden Zeiträumen
         simuliert - jeweils mit eigenem Startkapital, nicht als eine durchlaufende
         Position. Zeigt, ob die Rendite über die Zeit einigermaßen konsistent ist
@@ -180,7 +180,7 @@
       <div class="chart-box"><canvas id="walk-chart"></canvas></div>
       <div class="overflow-x">
         <table>
-          <thead><tr><th>Zeitraum</th><th>Rendite %</th></tr></thead>
+          <thead><tr><th data-i18n-en="Period">Zeitraum</th><th data-i18n-en="Return %">Rendite %</th></tr></thead>
           <tbody>
           {% for seg in s.walk_forward_segmente %}
             <tr>
@@ -193,7 +193,7 @@
       </div>
     </div>
     {% endif %}
-    <p class="hint">
+    <p class="hint" data-i18n-en="&quot;Dev. pp&quot; is this instrument's actual minus target weight, in percentage points; ⚠ marks a deviation above this strategy's rebalancing threshold ({{ s.rebalancing_schwelle_pp }} pp) - the rebalancing trigger itself checks the deviation of each bucket (5/25 rule, #63), not the concentration of individual instruments within a bucket. &quot;Price status&quot; shows when the most recently used price was carried forward rather than freshly fetched, for lack of a successful fetch.">
       "Abw. pp" ist die Abweichung des Ist- vom Ziel-Gewicht dieses Instruments in
       Prozentpunkten; ⚠ markiert eine Abweichung über der Rebalancing-Schwelle dieser
       Strategie ({{ s.rebalancing_schwelle_pp }} pp) - der Rebalancing-Trigger selbst
@@ -204,7 +204,7 @@
     </p>
     <div class="overflow-x">
       <table>
-        <thead><tr><th>Instrument</th><th>Einheiten</th><th>Kurs</th><th>Wert</th><th>Ist-Gewicht %</th><th>Ziel-Gewicht %</th><th>Abw. pp</th><th>Kursstatus</th></tr></thead>
+        <thead><tr><th data-i18n-en="Instrument">Instrument</th><th data-i18n-en="Units">Einheiten</th><th data-i18n-en="Price">Kurs</th><th data-i18n-en="Value">Wert</th><th data-i18n-en="Actual weight %">Ist-Gewicht %</th><th data-i18n-en="Target weight %">Ziel-Gewicht %</th><th data-i18n-en="Dev. pp">Abw. pp</th><th data-i18n-en="Price status">Kursstatus</th></tr></thead>
         <tbody>
         {% for row in s.holdings_table %}
           <tr>
@@ -215,7 +215,7 @@
             <td>{{ row.ist_gewicht }}</td>
             <td>{{ row.ziel_gewicht }}</td>
             <td class="{{ 'warn' if row.konzentration_warnung else '' }}">{{ row.abweichung_pp_label }}{% if row.konzentration_warnung %} &#9888;{% endif %}</td>
-            <td class="{{ 'warn' if row.carry_forward_wochen > 0 else '' }}">
+            <td class="{{ 'warn' if row.carry_forward_wochen > 0 else '' }}" data-i18n-en="{% if row.carry_forward_wochen > 0 %}&#9888; frozen for {{ row.carry_forward_wochen }} week{{ 's' if row.carry_forward_wochen != 1 else '' }}{% else %}&ndash;{% endif %}">
               {% if row.carry_forward_wochen > 0 %}&#9888; seit {{ row.carry_forward_wochen }} Woche{{ 'n' if row.carry_forward_wochen != 1 else '' }} eingefroren{% else %}&ndash;{% endif %}
             </td>
           </tr>
@@ -243,6 +243,14 @@
     y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
   };
   const seriesPalette = [colors.series1, colors.series2, colors.series3, colors.series4];
+  const topfNamenEn = {{ topf_namen_en_json | safe }};
+
+  // Sprachumschalter (Dreipunktmenue), siehe dashboard.html.j2 fuer die
+  // ausfuehrliche Begruendung: Chart.js-Texte sind bei der Erzeugung fixe
+  // Strings, keine DOM-Knoten - data-i18n-en greift hier nicht.
+  function T(de, en) { return document.documentElement.lang === 'en' ? en : de; }
+  const chartRefreshers = [];
+  window.__i18nRefresh.push(function () { chartRefreshers.forEach(function (fn) { fn(); }); });
 
   {% if s.zeitraum_presets %}
   // Benchmark-Overlay-Schalter (#72), siehe dashboard.html.j2 fuer die ausfuehrliche
@@ -292,10 +300,15 @@
       }] },
       options: {
         responsive: true, maintainAspectRatio: false,
-        plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Wertverlauf im gewählten Zeitraum', color: colors.text } },
+        plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: '', color: colors.text } },
         scales: { x: commonScales.x, y: { ...commonScales.y, min: 0 } },
       },
     });
+    chartRefreshers.push(function () {
+      zeitraumChart.options.plugins.title.text = T('Wertverlauf im gewählten Zeitraum', 'Value history over the selected period');
+      zeitraumChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
     const tileIds = {
       rendite: 'zeitraum-rendite', volatilitaet: 'zeitraum-volatilitaet',
       maxDrawdown: 'zeitraum-max-drawdown', sharpe: 'zeitraum-sharpe', sortino: 'zeitraum-sortino',
@@ -333,141 +346,187 @@
   }
   {% endif %}
 
-  new Chart(document.getElementById('sma-chart'), {
-    type: 'line',
-    data: {
-      labels: {{ s.labels_json | safe }},
-      datasets: [
-        {
-          label: 'Gesamtwert (€)',
-          data: {{ s.total_values_json | safe }},
-          borderColor: colors.series1,
-          backgroundColor: colors.series1,
-          borderWidth: 2,
-          pointRadius: 0,
-          tension: 0.15,
-        },
-        {
-          label: '50-Tage-Näherung (10 Wochen)',
-          data: {{ s.sma_kurz_json | safe }},
-          borderColor: colors.series4,
-          backgroundColor: colors.series4,
-          borderWidth: 1.5,
-          pointRadius: 0,
-          tension: 0.15,
-        },
-        {
-          label: '200-Tage-Näherung (40 Wochen)',
-          data: {{ s.sma_lang_json | safe }},
-          borderColor: colors.series2,
-          backgroundColor: colors.series2,
-          borderWidth: 1.5,
-          pointRadius: 0,
-          tension: 0.15,
-        },
-      ],
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Wertverlauf mit 50-/200-Tage-Näherung', color: colors.text } },
-      scales: commonScales,
-    },
-  });
+  {
+    const smaChart = new Chart(document.getElementById('sma-chart'), {
+      type: 'line',
+      data: {
+        labels: {{ s.labels_json | safe }},
+        datasets: [
+          {
+            label: 'Gesamtwert (€)',
+            data: {{ s.total_values_json | safe }},
+            borderColor: colors.series1,
+            backgroundColor: colors.series1,
+            borderWidth: 2,
+            pointRadius: 0,
+            tension: 0.15,
+          },
+          {
+            label: '50-Tage-Näherung (10 Wochen)',
+            data: {{ s.sma_kurz_json | safe }},
+            borderColor: colors.series4,
+            backgroundColor: colors.series4,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            tension: 0.15,
+          },
+          {
+            label: '200-Tage-Näherung (40 Wochen)',
+            data: {{ s.sma_lang_json | safe }},
+            borderColor: colors.series2,
+            backgroundColor: colors.series2,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            tension: 0.15,
+          },
+        ],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: '', color: colors.text } },
+        scales: commonScales,
+      },
+    });
+    chartRefreshers.push(function () {
+      smaChart.options.plugins.title.text = T('Wertverlauf mit 50-/200-Tage-Näherung', 'Value history with 50-/200-day approximation');
+      smaChart.data.datasets[1].label = T('50-Tage-Näherung (10 Wochen)', '50-day approximation (10 weeks)');
+      smaChart.data.datasets[2].label = T('200-Tage-Näherung (40 Wochen)', '200-day approximation (40 weeks)');
+      smaChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
 
   {% if s.beitraege %}
-  new Chart(document.getElementById('beitrag-chart'), {
-    type: 'bar',
-    data: {
-      labels: {{ s.beitraege | map(attribute='name') | list | tojson }},
-      datasets: [{
-        label: 'Effekt (CAGR-Prozentpunkte p.a.)',
-        data: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }},
-        backgroundColor: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
-      }],
-    },
-    options: {
-      indexAxis: 'y',
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'CAGR-Beitrag je Börsenweisheit (Prozentpunkte p.a.)', color: colors.text } },
-      scales: {
-        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
-        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+  {
+    const beitragChart = new Chart(document.getElementById('beitrag-chart'), {
+      type: 'bar',
+      data: {
+        labels: {{ s.beitraege | map(attribute='name') | list | tojson }},
+        datasets: [{
+          label: 'Effekt (CAGR-Prozentpunkte p.a.)',
+          data: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }},
+          backgroundColor: {{ s.beitraege | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+        }],
       },
-    },
-  });
+      options: {
+        indexAxis: 'y',
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: false }, title: { display: true, text: '', color: colors.text } },
+        scales: {
+          x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+          y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        },
+      },
+    });
+    chartRefreshers.push(function () {
+      beitragChart.options.plugins.title.text = T('CAGR-Beitrag je Börsenweisheit (Prozentpunkte p.a.)', 'CAGR contribution per market saying (percentage points p.a.)');
+      beitragChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
   {% endif %}
 
-  new Chart(document.getElementById('opt-chart'), {
-    type: 'bar',
-    data: {
-      labels: {{ s.optimierungs_effekte | map(attribute='name') | list | tojson }},
-      datasets: [{
-        label: 'Effekt (CAGR-Prozentpunkte p.a.)',
-        data: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }},
-        backgroundColor: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
-      }],
-    },
-    options: {
-      indexAxis: 'y',
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'CAGR-Beitrag je Optimierungs-Schalter (Prozentpunkte p.a.)', color: colors.text } },
-      scales: {
-        x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
-        y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+  {
+    const optChart = new Chart(document.getElementById('opt-chart'), {
+      type: 'bar',
+      data: {
+        labels: {{ s.optimierungs_effekte | map(attribute='name') | list | tojson }},
+        datasets: [{
+          label: 'Effekt (CAGR-Prozentpunkte p.a.)',
+          data: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }},
+          backgroundColor: {{ s.optimierungs_effekte | map(attribute='delta_pp') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+        }],
       },
-    },
-  });
+      options: {
+        indexAxis: 'y',
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: false }, title: { display: true, text: '', color: colors.text } },
+        scales: {
+          x: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+          y: { grid: { color: colors.grid }, ticks: { color: colors.text }, border: { color: colors.axis } },
+        },
+      },
+    });
+    const optNamenEn = {{ s.optimierungs_effekte | map(attribute='name_en') | list | tojson }};
+    chartRefreshers.push(function () {
+      optChart.options.plugins.title.text = T('CAGR-Beitrag je Optimierungs-Schalter (Prozentpunkte p.a.)', 'CAGR contribution per optimization switch (percentage points p.a.)');
+      optChart.data.labels = document.documentElement.lang === 'en' ? optNamenEn : {{ s.optimierungs_effekte | map(attribute='name') | list | tojson }};
+      optChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
 
   {% if s.walk_forward_segmente %}
-  new Chart(document.getElementById('walk-chart'), {
-    type: 'bar',
-    data: {
-      labels: {{ s.walk_forward_segmente | map(attribute='label') | list | tojson }},
-      datasets: [{
-        label: 'Rendite % im Zeitraum',
-        data: {{ s.walk_forward_segmente | map(attribute='rendite_pct') | list | tojson }},
-        backgroundColor: {{ s.walk_forward_segmente | map(attribute='rendite_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
-      }],
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: true, text: 'Rendite je Teilperiode (Walk-Forward)', color: colors.text } },
-      scales: commonScales,
-    },
-  });
+  {
+    const walkChart = new Chart(document.getElementById('walk-chart'), {
+      type: 'bar',
+      data: {
+        labels: {{ s.walk_forward_segmente | map(attribute='label') | list | tojson }},
+        datasets: [{
+          label: 'Rendite % im Zeitraum',
+          data: {{ s.walk_forward_segmente | map(attribute='rendite_pct') | list | tojson }},
+          backgroundColor: {{ s.walk_forward_segmente | map(attribute='rendite_pct') | list | tojson }}.map((v) => v >= 0 ? colors.series3 : colors.series2),
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: false }, title: { display: true, text: '', color: colors.text } },
+        scales: commonScales,
+      },
+    });
+    chartRefreshers.push(function () {
+      walkChart.data.datasets[0].label = T('Rendite % im Zeitraum', 'Return % over the period');
+      walkChart.options.plugins.title.text = T('Rendite je Teilperiode (Walk-Forward)', 'Return per sub-period (walk-forward)');
+      walkChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
   {% endif %}
 
-  new Chart(document.getElementById('topf-chart'), {
-    type: 'line',
-    data: {
-      labels: {{ s.labels_json | safe }},
-      datasets: [
-        {% for topf_name, target in s.topf_targets.items() %}
-        {
-          label: {{ topf_name | tojson }} + ' Ist %',
-          data: {{ s.topf_series_json | safe }}[{{ topf_name | tojson }}],
-          borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
-          backgroundColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
-          borderWidth: 2,
-          pointRadius: 0,
-          tension: 0.15,
-        },
-        {
-          label: {{ topf_name | tojson }} + ' Ziel %',
-          data: {{ s.labels_json | safe }}.map(() => {{ target }}),
-          borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
-          borderDash: [6, 4],
-          borderWidth: 1.5,
-          pointRadius: 0,
-        },
-        {% endfor %}
-      ],
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: 'Topf-Gewichtung Ist vs. Ziel (%)', color: colors.text } },
-      scales: commonScales,
-    },
-  });
+  {
+    const topfChart = new Chart(document.getElementById('topf-chart'), {
+      type: 'line',
+      data: {
+        labels: {{ s.labels_json | safe }},
+        datasets: [
+          {% for topf_name, target in s.topf_targets.items() %}
+          {
+            label: {{ topf_name | tojson }} + ' Ist %',
+            data: {{ s.topf_series_json | safe }}[{{ topf_name | tojson }}],
+            borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
+            backgroundColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
+            borderWidth: 2,
+            pointRadius: 0,
+            tension: 0.15,
+          },
+          {
+            label: {{ topf_name | tojson }} + ' Ziel %',
+            data: {{ s.labels_json | safe }}.map(() => {{ target }}),
+            borderColor: seriesPalette[{{ loop.index0 }} % seriesPalette.length],
+            borderDash: [6, 4],
+            borderWidth: 1.5,
+            pointRadius: 0,
+          },
+          {% endfor %}
+        ],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: true, labels: { color: colors.text } }, title: { display: true, text: '', color: colors.text } },
+        scales: commonScales,
+      },
+    });
+    const topfNamenDe = [{% for topf_name, target in s.topf_targets.items() %}{{ topf_name | tojson }},{% endfor %}];
+    chartRefreshers.push(function () {
+      topfChart.options.plugins.title.text = T('Topf-Gewichtung Ist vs. Ziel (%)', 'Bucket weighting actual vs. target (%)');
+      topfNamenDe.forEach(function (name, idx) {
+        const anzeigename = document.documentElement.lang === 'en' ? (topfNamenEn[name] || name) : name;
+        topfChart.data.datasets[idx * 2].label = anzeigename + (document.documentElement.lang === 'en' ? ' actual %' : ' Ist %');
+        topfChart.data.datasets[idx * 2 + 1].label = anzeigename + (document.documentElement.lang === 'en' ? ' target %' : ' Ziel %');
+      });
+      topfChart.update();
+    });
+    chartRefreshers[chartRefreshers.length - 1]();
+  }
 </script>
 {% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -119,7 +119,7 @@ def test_build_dashboard_erzeugt_detailseite_je_strategie(tmp_path: Path):
     assert (tmp_path / "b-verlierer.html").exists()
     detail = _detail_html(tmp_path, "a-verdoppler")
     assert "A: Verdoppler" in detail
-    assert '<a href="index.html">' in detail  # Ruecklink zur Startseite
+    assert '<a href="index.html"' in detail  # Ruecklink zur Startseite
 
 
 def test_startseite_zeigt_nur_wertverlauf_alles_andere_auf_detailseite(tmp_path: Path):
@@ -132,11 +132,11 @@ def test_startseite_zeigt_nur_wertverlauf_alles_andere_auf_detailseite(tmp_path:
     assert "Wertverlauf" in index_html
     # Stat-Kacheln, Topf-Gewichtung und Instrumententabelle sind Detailseiten-Inhalt,
     # nicht (mehr) auf der Startseite.
-    assert '<div class="label">Gesamtwert</div>' not in index_html
+    assert '>Gesamtwert<' not in index_html
     assert "Topf-Gewichtung Ist vs. Ziel" not in index_html
     assert "Ist-Gewicht %" not in index_html
 
-    assert '<div class="label">Gesamtwert</div>' in detail_html
+    assert '>Gesamtwert<' in detail_html
     assert "Topf-Gewichtung Ist vs. Ziel" in detail_html
     assert "Ist-Gewicht %" in detail_html
     # 50-/200-Tage-Naeherung (#31) nur auf der Detailseite.
@@ -984,8 +984,8 @@ def test_praemissen_seite_trennt_allokierte_von_nicht_allokierten_instrumenten(t
     build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
     html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
 
-    assert "<h3>Datenreihen ohne Allokation</h3>" in html
-    vor_abschnitt, nach_abschnitt = html.split("<h3>Datenreihen ohne Allokation</h3>", 1)
+    assert "Datenreihen ohne Allokation</h3>" in html
+    vor_abschnitt, nach_abschnitt = html.split("Datenreihen ohne Allokation</h3>", 1)
     assert "EUNL" not in vor_abschnitt.split("Instrumente und ab wann es sie gab", 1)[1]
     assert "EUNL" in nach_abschnitt
 
@@ -1011,7 +1011,7 @@ def test_praemissen_seite_versteckt_abschnitt_wenn_alles_allokiert_ist(tmp_path:
     build_dashboard(rows, [alles_strategy], output_path=tmp_path / "index.html")
     html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
 
-    assert "<h3>Datenreihen ohne Allokation</h3>" not in html
+    assert "Datenreihen ohne Allokation</h3>" not in html
 
 
 # --- Benchmark-Overlay-Schalter (#72) ---------------------------------------------
@@ -1353,7 +1353,7 @@ def test_ohne_gemeinsamen_zeitraum_bleibt_die_uebersicht_bei_den_eigenen_werten(
     )
 
     assert "Vergleichszeitraum" not in tabelle
-    kopf = len(re.findall(r"<th>", tabelle))
+    kopf = len(re.findall(r"<th[ >]", tabelle))
     zeilen = re.findall(r"<tr>\s*<td>.*?</tr>", tabelle, re.S)
     assert zeilen
     for zeile in zeilen:
@@ -1371,7 +1371,7 @@ def test_spaltenzahl_passt_zum_tabellenkopf_mit_vergleichszeitraum(tmp_path: Pat
     )
 
     assert "Vergleichszeitraum" in tabelle
-    kopf = len(re.findall(r"<th>", tabelle))
+    kopf = len(re.findall(r"<th[ >]", tabelle))
     zeilen = re.findall(r"<tr>\s*<td>.*?</tr>", tabelle, re.S)
     assert zeilen
     for zeile in zeilen:

--- a/tests/test_learnings.py
+++ b/tests/test_learnings.py
@@ -55,17 +55,17 @@ def _view(
 
 
 def _titel(learnings) -> list[str]:
-    return [l.titel for l in learnings]
+    return [l.titel_de for l in learnings]
 
 
 def test_spannweite_nennt_beste_und_schlechteste_regel():
     views = [_view("Gut", 50.0), _view("Mittel", 10.0), _view("Schlecht", -20.0)]
-    learning = next(l for l in derive_learnings(views) if l.titel == "Die Regel entscheidet, nicht der Markt")
+    learning = next(l for l in derive_learnings(views) if l.titel_de == "Die Regel entscheidet, nicht der Markt")
 
     # Spread 50 - (-20) = 70 pp
-    assert "+70,00 pp" in learning.kernaussage
-    assert "Gut" in learning.detail and "+50,00 %" in learning.detail
-    assert "Schlecht" in learning.detail and "-20,00 %" in learning.detail
+    assert "+70,00 pp" in learning.kernaussage_de
+    assert "Gut" in learning.detail_de and "+50,00 %" in learning.detail_de
+    assert "Schlecht" in learning.detail_de and "-20,00 %" in learning.detail_de
 
 
 def test_aktivitaet_nennt_platzierung_der_handelsintensivsten_regel():
@@ -74,12 +74,12 @@ def test_aktivitaet_nennt_platzierung_der_handelsintensivsten_regel():
         _view("Mittel", 20.0, trade_count=100),
         _view("Ruhig", 80.0, trade_count=5),
     ]
-    learning = next(l for l in derive_learnings(views) if l.titel == "Mehr Handeln ist nicht mehr Rendite")
+    learning = next(l for l in derive_learnings(views) if l.titel_de == "Mehr Handeln ist nicht mehr Rendite")
 
-    assert "400 Trades" in learning.kernaussage
-    assert "Platz 3 von 3" in learning.kernaussage
-    assert "5 Trades" in learning.kernaussage
-    assert "Platz 1" in learning.kernaussage
+    assert "400 Trades" in learning.kernaussage_de
+    assert "Platz 3 von 3" in learning.kernaussage_de
+    assert "5 Trades" in learning.kernaussage_de
+    assert "Platz 1" in learning.kernaussage_de
 
 
 def test_aktivitaet_dreht_sich_mit_den_daten():
@@ -89,18 +89,18 @@ def test_aktivitaet_dreht_sich_mit_den_daten():
         _view("Mittel", 20.0, trade_count=100),
         _view("Ruhig", -5.0, trade_count=5),
     ]
-    learning = next(l for l in derive_learnings(views) if l.titel == "Mehr Handeln ist nicht mehr Rendite")
-    assert "Platz 1 von 3" in learning.kernaussage
+    learning = next(l for l in derive_learnings(views) if l.titel_de == "Mehr Handeln ist nicht mehr Rendite")
+    assert "Platz 1 von 3" in learning.kernaussage_de
 
 
 def test_reibungskosten_rechnet_gebuehren_aus_trade_count():
     views = [_view("A", 10.0, trade_count=250, steuer=150.0), _view("B", 5.0, trade_count=3)]
-    learning = next(l for l in derive_learnings(views) if l.titel.startswith("Reibung"))
+    learning = next(l for l in derive_learnings(views) if l.titel_de.startswith("Reibung"))
 
     # 250 Trades * 1 EUR + 150 EUR Steuer = 400 EUR = 4,0 % von 10.000 EUR
-    assert "400 €" in learning.kernaussage
-    assert "4,0 %" in learning.kernaussage
-    assert "250 €" in learning.detail and "150 €" in learning.detail
+    assert "400 €" in learning.kernaussage_de
+    assert "4,0 %" in learning.kernaussage_de
+    assert "250 €" in learning.detail_de and "150 €" in learning.detail_de
 
 
 def test_kombinationseffekt_zaehlt_negative_beitraege():
@@ -111,13 +111,13 @@ def test_kombinationseffekt_zaehlt_negative_beitraege():
         {"name": "Regel D", "delta_pp": +3.0},
     ]
     views = [_view("Solo", 40.0), _view("Kombi", -10.0, beitraege=beitraege)]
-    learning = next(l for l in derive_learnings(views) if l.titel.startswith("Regeln zusammenwerfen"))
+    learning = next(l for l in derive_learnings(views) if l.titel_de.startswith("Regeln zusammenwerfen"))
 
-    assert "2 von 4" in learning.kernaussage
-    assert "Regel A" in learning.detail and "-30,00 pp" in learning.detail
-    assert "Regel B" in learning.detail and "+12,00 pp" in learning.detail
+    assert "2 von 4" in learning.kernaussage_de
+    assert "Regel A" in learning.detail_de and "-30,00 pp" in learning.detail_de
+    assert "Regel B" in learning.detail_de and "+12,00 pp" in learning.detail_de
     # Zwei positive Beitraege -> "einziger Rückhalt" waere falsch
-    assert "stärkster Rückhalt" in learning.detail
+    assert "stärkster Rückhalt" in learning.detail_de
 
 
 def test_kombinationseffekt_formuliert_einzigen_rueckhalt():
@@ -126,8 +126,8 @@ def test_kombinationseffekt_formuliert_einzigen_rueckhalt():
         {"name": "Regel B", "delta_pp": +12.0},
     ]
     views = [_view("Solo", 40.0), _view("Kombi", -10.0, beitraege=beitraege)]
-    learning = next(l for l in derive_learnings(views) if l.titel.startswith("Regeln zusammenwerfen"))
-    assert "einziger Rückhalt" in learning.detail
+    learning = next(l for l in derive_learnings(views) if l.titel_de.startswith("Regeln zusammenwerfen"))
+    assert "einziger Rückhalt" in learning.detail_de
 
 
 def test_kombinationseffekt_faellt_ohne_zusammengesetzte_strategie_weg():


### PR DESCRIPTION
## Summary

- Fügt einen clientseitigen Sprachumschalter (Deutsch/Englisch) zum bestehenden Dreipunktmenü hinzu, verfügbar auf jeder Seite (Startseite, jede Strategie-/Szenario-Detailseite, Prämissen-Seite).
- Übersetzt sowohl **statischen Template-Text** (Überschriften, Tabellenspalten, Tooltips, feste Erklärabschnitte, Chart-Titel/-Legenden) als auch **dynamisch aus der Kurshistorie generierten Text** (die "Key Learnings"-Sätze, Strategie-/Szenario-Kurzbeschreibungen).
- Die Sprachwahl wird in `localStorage` gemerkt und gilt seitenübergreifend.

## Umsetzung

- `base.html.j2`: neue Buttons "Deutsch"/"English" im Menü, ein `applyLanguage()`-JS, das alle `[data-i18n-en]`/`[data-i18n-en-title]`-Elemente umschaltet und zusätzlich registrierte `window.__i18nRefresh`-Callbacks aufruft (für Chart.js-Texte, die keine DOM-Knoten sind).
- `dashboard.html.j2`, `strategy_detail.html.j2`, `praemissen.html.j2`: alle sichtbaren deutschen Texte bekommen ein englisches Gegenstück über `data-i18n-en`; Chart.js-Titel/-Achsenbeschriftungen/-Legenden laufen über einen `T(de, en)`-Helfer plus Refresh-Callback, der beim Sprachwechsel `chart.update()` aufruft.
- `learnings.py`: `Learning` liefert `titel`/`kernaussage`/`detail` jetzt als `_de`/`_en`-Paare; für die englische Fassung gibt es eigene Zahlenformatierungs-Helfer (`_zahl_en`, `_pp_en`, `_pct_en`, `_eur_en`) mit englischer statt deutscher Dezimalschreibweise.
- `strategies.py` / `scenarios.py`: neues optionales Feld `Strategy.beschreibung_en` – für alle 16 vorhandenen Strategien/Szenarien mit einer eigenständigen englischen Beschreibung befüllt (keine Maschinenübersetzung 1:1, sondern eigenständig formuliert).
- `dashboard.py`: englische Gegenstücke für die restlichen dynamisch erzeugten Labels (`_OPTIMIERUNGS_LABELS_EN`, `_ZEITRAUM_PRESET_LABELS_EN`, `_TOPF_NAMEN_EN` für die Chart-Legenden der Topf-Gewichtung).

**Bewusste Abgrenzung:** Strategie-/Szenario-Namen (z. B. "Barbell 20/80", "Benchmark: S&P 500") und Instrumentennamen bleiben unübersetzt – das sind stabile Identifier (URL-Slugs, Chart.js-Dataset-Keys, Verweise aus anderen Seiten), keine Prosa, und ein Umbenennen hätte URLs/Legenden destabilisiert, ohne inhaltlichen Mehrwert.

## Test plan

- [x] `pytest -q` – alle 260 Tests grün (zwei Tests mussten an die neuen `data-i18n-en`-Attribute in den `<th>`/`<a>`/`<div class="label">`-Tags angepasst werden, da sie zuvor exakte Tag-Strings ohne Attribute erwartet hatten)
- [x] `python scripts/build_dashboard.py` – Build läuft durch, keine unaufgelösten Jinja-Platzhalter in der Ausgabe
- [x] Manuell im Browser (Playwright) geprüft: Menü öffnen → "English" klicken → Überschriften, Stat-Kacheln, Footer, Menüpunkte wechseln korrekt auf Englisch; Sprachwahl bleibt nach Seitenwechsel/Reload erhalten (localStorage)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WcKg9cdj1qJhf4zPuVtnwS)_