### PR TITLE
Key Learning "Die Regel entscheidet, nicht der Markt" vergleicht jetzt den gemeinsamen Zeitraum

### DIFF
--- a/src/boersenspiel/learnings.py
+++ b/src/boersenspiel/learnings.py
@@ -71,9 +71,73 @@ def _eur_en(wert: float) -> str:
     return f"€{wert:,.0f}"
 
 
+def _gleiche_kurshistorie(views: list[dict]) -> bool:
+    """Deckt jede Strategie tatsächlich denselben Zeitraum ab?
+
+    Strategien mit unterschiedlichen Zielinstrumenten werden je auf den
+    Zeitpunkt zurechtgeschnitten, ab dem ALLE ihre Instrumente handelbar sind
+    (F4/#63, ``dashboard._real_investierbarer_zeitraum()``) - der
+    S&P-500-Benchmark läuft dadurch z. B. seit ~2006, eine dreitöpfige
+    Barbell-Strategie erst seit ~2021. ``rendite_pct``/``cagr_pct`` sind dann
+    NICHT über dieselbe Kurshistorie berechnet, auch wenn beide aus derselben
+    ``price_history.csv`` stammen.
+    """
+    beginne = {v.get("sim_beginn") for v in views}
+    enden = {v.get("sim_ende") for v in views}
+    return len(beginne) == 1 and None not in beginne and len(enden) == 1 and None not in enden
+
+
 def _spannweite(views: list[dict]) -> Learning | None:
-    """Wie viel hängt überhaupt an der Regel - bei identischer Kurshistorie?"""
+    """Wie viel hängt überhaupt an der Regel - im vergleichbaren Zeitraum?"""
     if len(views) < 2:
+        return None
+
+    # Bevorzugt: annualisierte Rendite (CAGR) im gemeinsamen Vergleichszeitraum
+    # (#73/#78, dashboard._vergleichs_kennzahlen()) - vergleicht Gleiches mit
+    # Gleichem, auch wenn die Strategien unterschiedlich lange eigene
+    # Simulationszeiträume haben.
+    vergleichbar = [v for v in views if v.get("vergleich_cagr_pct") is not None]
+    if len(vergleichbar) >= 2:
+        rangliste = sorted(vergleichbar, key=lambda v: v["vergleich_cagr_pct"], reverse=True)
+        bester, schlechtester = rangliste[0], rangliste[-1]
+        spread = bester["vergleich_cagr_pct"] - schlechtester["vergleich_cagr_pct"]
+        return Learning(
+            titel_de="Die Regel entscheidet, nicht der Markt",
+            titel_en="The rule decides, not the market",
+            kernaussage_de=(
+                f"{_pp(spread)} CAGR-Unterschied zwischen bester und schlechtester Regel - "
+                f"im selben, gemeinsamen Vergleichszeitraum."
+            ),
+            kernaussage_en=(
+                f"{_pp_en(spread)} CAGR difference between the best and worst rule - "
+                f"over the same shared comparison period."
+            ),
+            detail_de=(
+                f"„{bester['name']}\" kommt auf {_pp(bester['vergleich_cagr_pct'])} p. a., "
+                f"„{schlechtester['name']}\" auf {_pp(schlechtester['vergleich_cagr_pct'])} p. a. "
+                f"Beide Werte sind auf den gleichen, gemeinsamen Vergleichszeitraum "
+                f"zurückgerechnet (siehe Vergleichsseite) - die eigenen Simulationszeiträume "
+                f"der Strategien unterscheiden sich sonst, weil jede erst dort startet, wo "
+                f"alle ihre Zielinstrumente tatsächlich handelbar waren. Der verbleibende "
+                f"Unterschied entsteht daraus, wann umgeschichtet wird, nicht aus "
+                f"unterschiedlich langen Kurshistorien."
+            ),
+            detail_en=(
+                f"\"{bester['name']}\" reaches {_pp_en(bester['vergleich_cagr_pct'])} p.a., "
+                f"\"{schlechtester['name']}\" reaches {_pp_en(schlechtester['vergleich_cagr_pct'])} p.a. "
+                f"Both figures are recomputed over the same shared comparison period (see the "
+                f"comparison page) - the strategies' own simulation periods otherwise differ, "
+                f"since each one only starts once all of its target instruments were actually "
+                f"tradeable. The remaining difference comes from when the portfolio gets "
+                f"reshuffled, not from differently long price histories."
+            ),
+        )
+
+    # Fallback: nur zulässig, wenn alle übergebenen Läufe wirklich denselben
+    # Zeitraum abdecken (z. B. Test-Fixtures oder zu kurze Historien ohne
+    # gemeinsamen Vergleichszeitraum) - sonst würde die Aussage "bei exakt
+    # derselben Kurshistorie" nicht aus den Daten folgen.
+    if not _gleiche_kurshistorie(views):
         return None
     rangliste = _nach_rendite(views)
     bester, schlechtester = rangliste[0], rangliste[-1]

--- a/tests/test_learnings.py
+++ b/tests/test_learnings.py
@@ -43,6 +43,9 @@ def _view(
     trade_count: int = 10,
     steuer: float = 0.0,
     beitraege: list[dict] | None = None,
+    sim_beginn: str = "2024-01-01",
+    sim_ende: str = "2024-01-08",
+    vergleich_cagr_pct: float | None = None,
 ) -> dict:
     return {
         "name": name,
@@ -51,6 +54,14 @@ def _view(
         "steuer_num": steuer,
         "startkapital_num": 10000.0,
         "beitraege": beitraege or [],
+        # Default: alle Fixtures teilen denselben Zeitraum, damit bestehende
+        # Tests weiterhin die "identische Kurshistorie"-Aussage abdecken
+        # (siehe _gleiche_kurshistorie() in learnings.py). Ein abweichender
+        # Wert simuliert unterschiedlich lange Simulationszeiträume je
+        # Strategie (F4/#63).
+        "sim_beginn": sim_beginn,
+        "sim_ende": sim_ende,
+        "vergleich_cagr_pct": vergleich_cagr_pct,
     }
 
 
@@ -66,6 +77,48 @@ def test_spannweite_nennt_beste_und_schlechteste_regel():
     assert "+70,00 pp" in learning.kernaussage_de
     assert "Gut" in learning.detail_de and "+50,00 %" in learning.detail_de
     assert "Schlecht" in learning.detail_de and "-20,00 %" in learning.detail_de
+
+
+def test_spannweite_faellt_bei_unterschiedlichen_zeitraeumen_ohne_vergleichszeitraum_weg():
+    """Regressionstest: unterschiedlich lange Simulationszeiträume (F4/#63, z. B.
+    S&P-500-Benchmark seit ~2006 vs. eine Barbell-Strategie seit ~2021) dürfen die
+    Aussage "bei exakt derselben Kurshistorie" nicht erfinden, wenn kein
+    gemeinsamer Vergleichszeitraum (#73) vorliegt."""
+    views = [
+        _view("Benchmark", 706.40, sim_beginn="2006-01-06", sim_ende="2026-08-14"),
+        _view("Barbell", 70.96, sim_beginn="2021-11-19", sim_ende="2026-08-14"),
+    ]
+    assert "Die Regel entscheidet, nicht der Markt" not in _titel(derive_learnings(views))
+
+
+def test_spannweite_nutzt_vergleichs_cagr_bei_unterschiedlichen_zeitraeumen():
+    """Sobald ein gemeinsamer Vergleichszeitraum (#73) verfügbar ist, vergleicht die
+    Regel annualisierte CAGR-Werte über diesen gemeinsamen Zeitraum statt der
+    Gesamtrendite über je eigene, unterschiedlich lange Zeiträume."""
+    views = [
+        _view(
+            "Benchmark",
+            706.40,
+            sim_beginn="2006-01-06",
+            sim_ende="2026-08-14",
+            vergleich_cagr_pct=8.0,
+        ),
+        _view(
+            "Barbell",
+            70.96,
+            sim_beginn="2021-11-19",
+            sim_ende="2026-08-14",
+            vergleich_cagr_pct=15.0,
+        ),
+    ]
+    learning = next(l for l in derive_learnings(views) if l.titel_de == "Die Regel entscheidet, nicht der Markt")
+
+    # Spread 15.0 - 8.0 = 7 pp CAGR, nicht 706.40 - 70.96 Gesamtrendite-pp.
+    assert "+7,00 pp" in learning.kernaussage_de
+    assert "CAGR" in learning.kernaussage_de
+    assert "Barbell" in learning.detail_de and "+15,00 pp" in learning.detail_de
+    assert "Benchmark" in learning.detail_de and "+8,00 pp" in learning.detail_de
+    assert "706,40" not in learning.detail_de and "70,96" not in learning.detail_de
 
 
 def test_aktivitaet_nennt_platzierung_der_handelsintensivsten_regel():


### PR DESCRIPTION
## Problem

Das Key Learning „Die Regel entscheidet, nicht der Markt" behauptete, alle Läufe sähen „exakt dieselbe Kurshistorie", und verglich dazu die rohe Gesamtrendite (`rendite_pct`) über den jeweils **eigenen** Simulationszeitraum jeder Strategie.

Das ist sachlich falsch: `dashboard._real_investierbarer_zeitraum()` (F4/#63) schneidet jede Strategie erst dort zu, wo alle ihre Zielinstrumente handelbar sind. Der S&P-500-Benchmark läuft dadurch seit ~2006, eine dreitöpfige Barbell-Strategie erst seit ~2021. Der zitierte Vergleich „Benchmark +706,40 % vs. Barbell 20/80 (breiter diversifiziert) +70,96 %, Spread +635,44 pp" stellt also zwei unterschiedlich lange Zeiträume mit unterschiedlichen Marktphasen als reinen Regel-Effekt dar — genau die Verzerrung, die das Projekt an anderer Stelle (#73/#78, `vergleich_cagr_pct`) bereits explizit korrigiert hat, nur eben nicht in diesem Learning.

## Fix

`_spannweite()` in `learnings.py`:

- Nutzt bevorzugt `vergleich_cagr_pct` (annualisierte Rendite im gemeinsamen Vergleichszeitraum, #73/#78) für Ranking und Spread, sobald mindestens zwei Läufe diesen Wert haben. Text und Zahlen sprechen dann explizit von CAGR im gemeinsamen Vergleichszeitraum statt von Gesamtrendite über „dieselbe" Kurshistorie.
- Fällt nur dann auf die alte Gesamtrendite-Logik zurück, wenn kein Vergleichszeitraum verfügbar ist **und** alle übergebenen Läufe nachweislich denselben `sim_beginn`/`sim_ende` teilen (neue Hilfsfunktion `_gleiche_kurshistorie()`).
- Liefert sonst `None` — das Learning entfällt still, statt eine durch die Daten nicht gedeckte Aussage zu treffen (folgt demselben Prinzip wie die übrigen Regeln in `learnings.py`).

Reiner Darstellungslayer-Fix, keine Änderung an `engine.py`, den Simulationen oder anderen Learnings.

## Test plan

- [x] `pytest -q` — alle 276 Tests grün
- [x] Neuer Regressionstest: unterschiedliche `sim_beginn`/`sim_ende` ohne Vergleichszeitraum → Learning entfällt
- [x] Neuer Test: mit `vergleich_cagr_pct` verfügbar → Spread/Text basieren auf CAGR im Vergleichszeitraum, nicht auf der alten Gesamtrendite
- [x] `scripts/build_dashboard.py` gegen die echte Kurshistorie gebaut und den gerenderten Abschnitt manuell geprüft: zeigt jetzt z. B. „+10,71 pp CAGR-Unterschied ... im selben, gemeinsamen Vergleichszeitraum" statt der alten +635,44-pp-Aussage

---
_Generated by [Claude Code](https://claude.ai/code/session_018vZFhodAWRbQQMMnWwCAuW)_