### PR TITLE
Zentraler Zeitraum-Schalter auf der Startseite (#95)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -621,11 +621,35 @@ inkrementell fortgeschrieben).
   `_jahre_zurueck()`, sowie "Gesamte Historie") jeweils VOLLSTÄNDIG NEU
   (frisches Startkapital, analog `_walk_forward_segmente()`) inklusive
   Rendite/Volatilität/Max-Drawdown/Sharpe/Sortino und eigenem
-  Wertverlauf-Chart. Auf der Startseite bekommt dafür jeder Wertverlauf-Chart
-  einen Zeitraum-Umschalter (reines Chart.js-Datenwechsel im Browser, `<script>`
-  `initZeitraumSwitch()`); auf der Detailseite ergänzt ein eigener Abschnitt
-  "Kennzahlen nach Betrachtungszeitraum" (eigener Chart + fünf Kennzahl-
-  Kacheln) denselben Umschalter — die bislang nur auf der Startseite
+  Wertverlauf-Chart. Auf der Startseite gab es dafür zunächst je Strategie/
+  Szenario einen eigenen Zeitraum-Umschalter unter dem jeweiligen Chart;
+  seit #95 ist das EIN zentraler Schalter (`id="zeitraum-switch"`, in der
+  Nähe des Benchmark-Schalters #72 platziert, denselben "ein Schalter steuert
+  alle Charts der Seite"-Aufbau nachbildend) für ALLE Wertverlauf-Charts der
+  Startseite gleichzeitig — inklusive des Börsenweisheiten-Gruppen-Charts
+  (#30/#93), der vorher gar keinen Zeitraum-Umschalter hatte. Nur Preset-Ids,
+  die WIRKLICH JEDE angezeigte Strategie/Szenario auch hat, werden als Button
+  angeboten (`dashboard._zeitraum_presets_optionen()`); ein Klick ruft
+  `applyZeitraumDataset()` für jeden registrierten Chart-Eintrag
+  (`zeitraumEntries`, reines Chart.js-Datenwechsel im Browser, kein
+  Server-Request) auf, das je Chart nur austauscht, welcher bereits fertig
+  simulierte Preset-Datensatz angezeigt wird. Für den Gruppen-Chart bekommt
+  jeder Eintrag statt einer einzelnen Wertreihe ein `reihen`-Array (eine
+  Reihe je Mitglied, Kombi zuerst) — `dashboard._teilszenario_gruppen()`
+  baut das je Preset-Id aus den `zeitraum_presets` ALLER Mitglieder
+  (`presets_json`). Der bisherige, auf "erweitert" (#91) beschränkte
+  Sondermechanismus des Gruppen-Charts läuft jetzt über denselben zentralen
+  Mechanismus: `entry.presets['erweitert']` wird von `applyZeitraumDataset()`
+  bevorzugt vor der aktuell gewählten Preset-Id angewendet, sobald der
+  separate "Verlängerter Auswertezeitraum"-Schalter im Drei-Punkt-Menü aktiv
+  ist — für Einzelstrategien weiterhin aus dem optionalen "erweitert"-Preset
+  in `zeitraum_presets` (#80), für den Gruppen-Chart weiterhin aus
+  `view["erweitert"]` (#91, `_erweiterte_kennzahlen()`), da nicht jedes
+  Mitglied notwendigerweise einen eigenen #80-Preset hat. Die Detailseite ist
+  von #95 unberührt: sie behält ihren eigenen, lokalen Zeitraum-Umschalter
+  (`id="detail-zeitraum-switch"`) für den einen dort gezeigten Chart, ergänzt
+  um den Abschnitt "Kennzahlen nach Betrachtungszeitraum" (eigener Chart plus
+  fünf Kennzahl-Kacheln) — die bislang nur auf der Startseite
   gezeigten Kennzahlen Volatilität/Max Drawdown/Sharpe/Sortino (#40/#41)
   erscheinen dadurch jetzt auch auf der Detailseite, aber ausschließlich
   innerhalb dieses neuen, periodenabhängigen Abschnitts (nicht als

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -538,6 +538,34 @@ def _zeitraum_presets(
     return presets
 
 
+def _zeitraum_presets_optionen(views: list[dict]) -> list[dict]:
+    """#95: Button-Liste fuer den EINEN zentralen Zeitraum-Schalter auf der
+    Startseite, der alle Wertverlauf-Charts (Einzelstrategien UND den
+    Boersenweisheiten-Gruppen-Chart) gleichzeitig umschaltet - vorher hatte
+    jede Strategie/jedes Szenario ihren/seinen eigenen Schalter. Angeboten
+    wird nur ein Preset, das WIRKLICH JEDE angezeigte Strategie auch hat
+    (sonst gaebe es einen Klick, fuer den einzelne Charts keinen Datensatz
+    haben). "erweitert" (#80) bleibt bewusst aussen vor - das ist weiterhin
+    der separate Schalter im Drei-Punkt-Menue (#91), der Chart-Daten direkt
+    ueber ``entry.presets['erweitert']`` austauscht, ohne ueber diese
+    Buttons gerendert zu werden."""
+    if not views:
+        return []
+    gemeinsame_ids = {p["id"] for p in views[0]["zeitraum_presets"]}
+    for view in views[1:]:
+        gemeinsame_ids &= {p["id"] for p in view["zeitraum_presets"]}
+    gemeinsame_ids.discard("erweitert")
+    return [
+        {
+            "id": preset_id,
+            "label": _ZEITRAUM_PRESET_LABELS[preset_id],
+            "label_en": _ZEITRAUM_PRESET_LABELS_EN[preset_id],
+        }
+        for preset_id, _jahre in _ZEITRAUM_PRESETS
+        if preset_id in gemeinsame_ids
+    ]
+
+
 # --- Eingefrorene Kurse (#42) ------------------------------------------------------
 
 
@@ -591,6 +619,42 @@ def _teilszenario_gruppen(views: list[dict], strategies: list[Strategy]) -> list
         eltern_view = views_by_id[_slug(eltern_name)]
         mitglieder = [eltern_view] + kinder
         alle_werte = [wert for m in mitglieder for wert in m["total_values"]]
+
+        # #95: der zentrale Zeitraum-Schalter der Startseite steuert seither auch
+        # diesen Gruppen-Chart - je Preset-Id ein fertiger Datensatz mit einer Reihe
+        # je Mitglied (Kombi zuerst, dann die Unterszenarien in Dataset-Reihenfolge),
+        # generisch analog zu den Einzelstrategie-Chart-Presets unten. Nur Preset-Ids,
+        # die JEDES Mitglied hat, werden aufgenommen - alle Mitglieder teilen
+        # dieselbe Kurshistorie/dasselbe Instrumentenset, i.d.R. also identisch, die
+        # Absicherung bleibt trotzdem generisch statt fest verdrahtet.
+        member_presets = [{p["id"]: p for p in m["zeitraum_presets"]} for m in mitglieder]
+        gemeinsame_preset_ids = set(member_presets[0].keys())
+        for pm in member_presets[1:]:
+            gemeinsame_preset_ids &= set(pm.keys())
+        presets_json: dict[str, dict] = {}
+        for preset_id in gemeinsame_preset_ids:
+            reihen = [pm[preset_id]["total_values"] for pm in member_presets]
+            werte = [wert for reihe in reihen for wert in reihe]
+            presets_json[preset_id] = {
+                "labels": member_presets[0][preset_id]["labels"],
+                "reihen": reihen,
+                "chart_max": max(werte) if werte else 0.0,
+                "benchmarks": member_presets[0][preset_id]["benchmarks"],
+            }
+        # #91: der separate Schalter fuer den verlaengerten Auswertezeitraum im
+        # Drei-Punkt-Menue nutzt eine andere Datenquelle (`view["erweitert"]`, aus
+        # _erweiterte_kennzahlen() - jede Strategie hat das, unabhaengig davon, ob
+        # sie ueber die Ersatzbond-Annahme einen eigenen "erweitert"-Preset hat)
+        # und wird deshalb, wie zuvor, gesondert unter demselben Schluessel
+        # "erweitert" abgelegt, damit ihn derselbe zentrale JS-Mechanismus greift.
+        if all(m.get("erweitert") for m in mitglieder):
+            presets_json["erweitert"] = {
+                "labels": mitglieder[0]["erweitert"]["labels"],
+                "reihen": [m["erweitert"]["total_values"] for m in mitglieder],
+                "chart_max": max(max(m["erweitert"]["total_values"]) for m in mitglieder),
+                "benchmarks": eltern_view["erweitert"]["benchmarks"],
+            }
+
         gruppen.append(
             {
                 "name": eltern_name,
@@ -602,21 +666,7 @@ def _teilszenario_gruppen(views: list[dict], strategies: list[Strategy]) -> list
                 # Strategie passen ohne Datumsabgleich, weil alle Mitglieder ueber
                 # dieselben `rows` simuliert werden (gleiches Instrumentenset).
                 "benchmarks_json": json.dumps(eltern_view["benchmarks"]),
-                # #91: dieselbe Grafik ueber den verlaengerten Auswertezeitraum,
-                # sofern jedes Mitglied dort eine Reihe hat (sonst haetten die
-                # Datensaetze unterschiedliche Laengen).
-                "erweitert_json": json.dumps(
-                    {
-                        "labels": mitglieder[0]["erweitert"]["labels"],
-                        "reihen": [m["erweitert"]["total_values"] for m in mitglieder],
-                        "chart_max": max(
-                            max(m["erweitert"]["total_values"]) for m in mitglieder
-                        ),
-                        "benchmarks": eltern_view["erweitert"]["benchmarks"],
-                    }
-                    if all(m.get("erweitert") for m in mitglieder)
-                    else None
-                ),
+                "presets_json": json.dumps(presets_json),
             }
         )
     return gruppen
@@ -1420,6 +1470,9 @@ def build_dashboard(
         summary = sorted(views, key=lambda v: v["cagr_pct"], reverse=True)
     learnings = derive_learnings(views)
     teilszenario_gruppen = _teilszenario_gruppen(views, strategies)
+    # #95: EIN zentraler Zeitraum-Schalter fuer alle Wertverlauf-Charts der
+    # Startseite statt eines Schalters je Strategie/Szenario.
+    zeitraum_presets_optionen = _zeitraum_presets_optionen(views)
 
     # Gemeinsames Y-Achsen-Maximum ueber alle Wertverlauf-Charts (#24): ohne das skaliert
     # jeder Chart unabhaengig, wodurch unterschiedliche Strategien optisch nicht mehr
@@ -1485,6 +1538,7 @@ def build_dashboard(
         learnings=learnings,
         wert_chart_max=wert_chart_max,
         teilszenario_gruppen=teilszenario_gruppen,
+        zeitraum_presets_optionen=zeitraum_presets_optionen,
         **common_context,
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/boersenspiel/templates/dashboard.html.j2
+++ b/src/boersenspiel/templates/dashboard.html.j2
@@ -69,6 +69,14 @@
     <div class="summary-chart-box"><canvas id="summary-chart"></canvas></div>
     <p class="detail-link"><a href="vergleich.html" data-i18n-en="All metrics compared &rarr;">Alle Kennzahlen im Vergleich &rarr;</a></p>
   </section>
+{% if zeitraum_presets_optionen %}
+  <div class="zeitraum-switch" id="zeitraum-switch">
+    <span data-i18n-en="Show a period in the value-history charts:">Zeitraum in den Wertverlauf-Charts anzeigen:</span>
+    {% for p in zeitraum_presets_optionen %}
+    <button type="button" data-preset="{{ p.id }}"{% if p.id == 'alle' %} class="active"{% endif %} data-i18n-en="{{ p.label_en }}">{{ p.label }}</button>
+    {% endfor %}
+  </div>
+{% endif %}
 {% if benchmark_optionen %}
   <div class="benchmark-switch" id="benchmark-switch">
     <span data-i18n-en="Show a benchmark in the value-history charts:">Benchmark in den Wertverlauf-Charts einblenden:</span>
@@ -98,14 +106,6 @@
   <section class="strategy" id="{{ s.id }}">
     <h2>{{ s.name }}</h2>
     {% if s.beschreibung %}<p class="hint" data-i18n-en="{{ s.beschreibung_en }}">{{ s.beschreibung }}</p>{% endif %}
-    {% if s.zeitraum_presets %}
-    <div class="zeitraum-switch" id="zeitraum-switch-{{ loop.index }}">
-      {% for p in s.zeitraum_presets %}
-      <button type="button" data-preset="{{ p.id }}"{% if p.id == 'alle' %} class="active"{% endif %} data-i18n-en="{{ p.label_en }}">{{ p.label }}</button>
-      {% endfor %}
-      <span class="zeitraum-rendite"></span>
-    </div>
-    {% endif %}
     <div class="chart-box-large"><canvas id="value-chart-{{ loop.index }}"></canvas></div>
     <p class="detail-link"><a href="{{ s.id }}.html" data-i18n-en="View details (metrics, bucket weighting, instruments) &rarr;">Details ansehen (Kennzahlen, Topf-Gewichtung, Instrumente) &rarr;</a></p>
   </section>
@@ -269,6 +269,53 @@
     });
   }
 
+  // Zentraler Zeitraum-Schalter (#95): EIN Schalter fuer ALLE Wertverlauf-Charts der
+  // Startseite (Einzelstrategien UND der Boersenweisheiten-Gruppen-Chart) statt eines
+  // Schalters je Strategie/Szenario - analog zum Benchmark-Schalter oben.
+  // `entry.presets` haelt je Preset-Id (1j/3j/5j/alle, siehe dashboard._zeitraum_presets())
+  // einen bereits beim Build fertig neu simulierten Datensatz; ein Klick tauscht hier nur
+  // aus, welcher davon angezeigt wird, ohne neu zu rechnen. "erweitert" ist bewusst KEIN
+  // Button dieses Schalters (dashboard._zeitraum_presets_optionen()) - das bleibt der
+  // separate Schalter im Drei-Punkt-Menue (#91), der bei aktivem verlaengertem
+  // Auswertezeitraum denselben Mechanismus ueber `entry.presets['erweitert']` ansteuert
+  // und damit vorrangig vor der hier gewaehlten Preset-Id ist.
+  let currentZeitraumId = 'alle';
+  let erweitertAktiv = false;
+  const zeitraumEntries = [];
+
+  function applyZeitraumDataset(entry) {
+    const id = (erweitertAktiv && entry.presets.erweitert) ? 'erweitert' : currentZeitraumId;
+    const preset = entry.presets[id] || entry.presets.alle;
+    if (!preset) return;
+    entry.chart.data.labels = preset.labels;
+    if (preset.reihen) {
+      preset.reihen.forEach((reihe, i) => { entry.chart.data.datasets[i].data = reihe; });
+    } else {
+      entry.chart.data.datasets[0].data = preset.total_values;
+    }
+    entry.chart.options.scales.y.max = (preset.chart_max || entry.defaultMax) * 1.05;
+    entry.chart.__benchmarks = preset.benchmarks || [];
+    applyBenchmarkDataset(entry.chart);
+  }
+
+  const zeitraumSwitchEl = document.getElementById('zeitraum-switch');
+  if (zeitraumSwitchEl) {
+    zeitraumSwitchEl.querySelectorAll('button').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        currentZeitraumId = btn.dataset.preset;
+        zeitraumSwitchEl.querySelectorAll('button').forEach((b) => b.classList.toggle('active', b === btn));
+        zeitraumEntries.forEach(applyZeitraumDataset);
+      });
+    });
+  }
+  // #91: derselbe Mechanismus reagiert auch auf den Schalter im Drei-Punkt-Menue -
+  // aktiviert er den verlaengerten Auswertezeitraum, gewinnt (wo vorhanden) dessen
+  // "erweitert"-Datensatz vor der aktuell gewaehlten Preset-Id (siehe applyZeitraumDataset).
+  window.__erweitertRefresh.push(function (erweitert) {
+    erweitertAktiv = erweitert;
+    zeitraumEntries.forEach(applyZeitraumDataset);
+  });
+
   const gruppenSeriesColors = [
     colors.series1, colors.series2, colors.series3,
     colors.series5, colors.series6, colors.series7,
@@ -306,27 +353,13 @@
     gruppenChart{{ loop.index }}.__baseDatasetCount = {{ gruppe.mitglieder|length }};
     gruppenChart{{ loop.index }}.__benchmarks = {{ gruppe.benchmarks_json | safe }};
     benchmarkCharts.push(gruppenChart{{ loop.index }});
-    // #91: dieser Chart hat keinen Zeitraum-Umschalter - der Schalter im
-    // Drei-Punkt-Menue tauscht deshalb Reihen, Skala und Benchmark direkt aus.
-    {
-      const eigen = {
-        labels: gruppenChart{{ loop.index }}.data.labels,
-        reihen: gruppenChart{{ loop.index }}.data.datasets.map((d) => d.data),
-        chart_max: {{ gruppe.chart_max }},
-        benchmarks: gruppenChart{{ loop.index }}.__benchmarks,
-      };
-      const erweitertDaten = {{ gruppe.erweitert_json | safe }};
-      if (erweitertDaten) {
-        window.__erweitertRefresh.push(function (erweitert) {
-          const q = erweitert ? erweitertDaten : eigen;
-          gruppenChart{{ loop.index }}.data.labels = q.labels;
-          q.reihen.forEach((reihe, i) => { gruppenChart{{ loop.index }}.data.datasets[i].data = reihe; });
-          gruppenChart{{ loop.index }}.options.scales.y.max = q.chart_max * 1.05;
-          gruppenChart{{ loop.index }}.__benchmarks = q.benchmarks;
-          applyBenchmarkDataset(gruppenChart{{ loop.index }});
-        });
-      }
-    }
+    // #95: haengt jetzt wie die Einzelstrategie-Charts unten am zentralen
+    // Zeitraum-Schalter (vorher: eigener, auf "erweitert" beschraenkter Mechanismus).
+    zeitraumEntries.push({
+      chart: gruppenChart{{ loop.index }},
+      presets: {{ gruppe.presets_json | safe }},
+      defaultMax: {{ gruppe.chart_max }},
+    });
     chartRefreshers.push(function () {
       gruppenChart{{ loop.index }}.options.plugins.title.text = T('Wertverlauf im Vergleich', 'Value history compared');
       gruppenChart{{ loop.index }}.update();
@@ -334,45 +367,6 @@
     chartRefreshers[chartRefreshers.length - 1]();
   }
   {% endfor %}
-
-  // Zeitraum-Presets (#54, Variante B): jeder Preset ist bereits fertig aus einer
-  // eigenen engine.simulate()-Neu-Simulation (frisches Startkapital, siehe
-  // dashboard._zeitraum_presets()) - der Umschalter hier wechselt nur, welcher
-  // bereits vorhandene Datensatz im Chart angezeigt wird, ohne neu zu rechnen.
-  function initZeitraumSwitch(chart, switchEl, presets, defaultMax) {
-    if (!switchEl) return;
-    const byId = Object.fromEntries(presets.map((p) => [p.id, p]));
-    const renditeEl = switchEl.querySelector('.zeitraum-rendite');
-    let currentPreset = null;
-    const setRenditeText = () => {
-      if (renditeEl && currentPreset) {
-        renditeEl.textContent = `${T('Rendite im Zeitraum', 'Return over the period')}: ${currentPreset.rendite_label}%`;
-      }
-    };
-    const apply = (id) => {
-      const preset = byId[id];
-      if (!preset) return;
-      currentPreset = preset;
-      chart.data.labels = preset.labels;
-      chart.data.datasets[0].data = preset.total_values;
-      chart.options.scales.y.max = (preset.chart_max || defaultMax) * 1.05;
-      chart.__benchmarks = preset.benchmarks || [];
-      applyBenchmarkDataset(chart);
-      setRenditeText();
-      switchEl.querySelectorAll('button').forEach((btn) => btn.classList.toggle('active', btn.dataset.preset === id));
-    };
-    switchEl.querySelectorAll('button').forEach((btn) => {
-      btn.addEventListener('click', () => apply(btn.dataset.preset));
-    });
-    apply('alle');
-    chartRefreshers.push(setRenditeText);
-    // #91: der Schalter im Drei-Punkt-Menue waehlt den bereits vorberechneten
-    // "Erweitert"-Preset (#80), wo es ihn gibt - Charts ohne zusaetzliche
-    // Historie bleiben auf "Gesamte Historie".
-    window.__erweitertRefresh.push(function (erweitert) {
-      apply(erweitert && byId['erweitert'] ? 'erweitert' : 'alle');
-    });
-  }
 
   {% for s in strategies %}
   {
@@ -416,8 +410,17 @@
       chart.update();
     });
     chartRefreshers[chartRefreshers.length - 1]();
-    initZeitraumSwitch(chart, document.getElementById('zeitraum-switch-{{ loop.index }}'), {{ s.zeitraum_presets_json | safe }}, strategieMax);
+    zeitraumEntries.push({
+      chart: chart,
+      presets: Object.fromEntries({{ s.zeitraum_presets_json | safe }}.map((p) => [p.id, p])),
+      defaultMax: strategieMax,
+    });
   }
   {% endfor %}
+
+  // Initialen Datensatz ('alle') auf allen registrierten Charts anwenden - deckt
+  // sich mit den bereits beim Erzeugen gesetzten Daten, haelt aber Skala/Benchmarks
+  // konsistent mit dem, was ein Klick auf "Gesamte Historie" liefern wuerde.
+  zeitraumEntries.forEach(applyZeitraumDataset);
 </script>
 {% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -726,8 +726,12 @@ def test_build_dashboard_zeigt_zeitraum_umschalter_auf_startseite(tmp_path: Path
     output = build_dashboard(_mehrjaehrige_rows(), [ZWEI_STRATEGIEN[0]], output_path=tmp_path / "index.html")
     html = output.read_text(encoding="utf-8")
 
-    assert 'id="zeitraum-switch-1"' in html
-    assert "initZeitraumSwitch" in html
+    # #95: EIN zentraler Schalter statt eines Schalters je Strategie/Szenario.
+    assert 'id="zeitraum-switch"' in html
+    assert 'id="zeitraum-switch-1"' not in html
+    assert "zeitraumEntries" in html
+    for preset_id in ("1j", "3j", "5j", "alle"):
+        assert f'data-preset="{preset_id}"' in html
 
 
 # --- Praemissen-Seite -------------------------------------------------------------
@@ -1535,6 +1539,31 @@ def test_gruppen_chart_haengt_am_benchmark_schalter(tmp_path: Path, monkeypatch)
     assert "suggestedMax" not in gruppen_js.split("chartRefreshers", 1)[0]
     # Schalter steht ueber dem Gruppen-Abschnitt.
     assert html.index('id="benchmark-switch"') < html.index('id="gruppe-kombi"')
+
+
+def test_zentraler_zeitraum_schalter_steht_nahe_am_benchmark_schalter_und_erfasst_gruppen_chart(
+    tmp_path: Path, monkeypatch
+):
+    """#95: EIN Zeitraum-Schalter fuer die gesamte Startseite, in der Naehe des
+    Benchmark-Schalters, der auch den Boersenweisheiten-Gruppen-Chart erfasst
+    (vorher hing dort nur der separate Erweitert-Mechanismus)."""
+    monkeypatch.setattr(dashboard_module, "BENCHMARK_STRATEGIEN", [_benchmark_fixture(ticker="T1")])
+    output = build_dashboard(
+        _mehrjaehrige_rows(),
+        _strategien_mit_unterszenarien(),
+        output_path=tmp_path / "index.html",
+    )
+    html = output.read_text(encoding="utf-8")
+
+    assert 'id="zeitraum-switch"' in html
+    # Beide zentralen Schalter stehen direkt beieinander, vor dem Gruppen-Abschnitt.
+    zeitraum_pos = html.index('id="zeitraum-switch"')
+    benchmark_pos = html.index('id="benchmark-switch"')
+    gruppe_pos = html.index('id="gruppe-kombi"')
+    assert zeitraum_pos < benchmark_pos < gruppe_pos
+
+    gruppen_js = html.split("getElementById('gruppen-chart-1')", 1)[1].split("{% endfor %}", 1)[0]
+    assert "zeitraumEntries.push" in gruppen_js
 
 
 def test_startseite_verweist_fuers_kombinationsverfahren_auf_die_praemissen(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Ersetzt den bisherigen Zeitraum-Umschalter je Strategie/Szenario auf der Startseite durch einen zentralen Schalter (`id="zeitraum-switch"`), platziert direkt neben dem bestehenden Benchmark-Schalter.
- Der Schalter steuert jetzt alle Wertverlauf-Charts der Startseite gleichzeitig — inklusive des Börsenweisheiten-Gruppen-Charts, der vorher gar keinen eigenen Zeitraum-Umschalter hatte.
- Nur Preset-Ids, die wirklich jede angezeigte Strategie/jedes Szenario hat, werden als Button angeboten (`dashboard._zeitraum_presets_optionen()`).
- Der separate "Verlängerter Auswertezeitraum"-Schalter im Drei-Punkt-Menü (#91) läuft für den Gruppen-Chart jetzt über denselben zentralen Mechanismus statt über einen eigenen Sondercode-Pfad.
- Detailseiten sind unverändert: sie behalten ihren eigenen, lokalen Zeitraum-Umschalter.

## Test plan
- [x] `pytest -q` (277 passed)
- [x] `python scripts/build_dashboard.py --strategy "Barbell 20/80"` und generiertes `docs/index.html` manuell auf korrekte Platzierung/Rendering des neuen Schalters geprüft

Closes #95

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpesrQQsNhsbpBtb6ncAVj)_