### PR TITLE
Zwei verbreitete klassische Portfolio-Strategien ergänzen (60/40, Permanent Portfolio)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,33 @@ inkrementell fortgeschrieben).
   worden, ein hartes `max` schneidet die Linie stattdessen oben am
   Chart-Rand ab. Reine Darstellungsschicht, keine neue Instrumentenzuordnung
   und kein Eingriff in `engine.py`.
+  **`PORTFOLIO_60_40` und `PERMANENT_PORTFOLIO` (verbreitete klassische
+  Portfolios):** zwei weitere, zusätzliche Strategien neben den bestehenden
+  Barbell-Varianten und `SP500_BENCHMARK` - eigene Rubrik
+  `RUBRIK_KLASSISCHE_PORTFOLIOS` statt `RUBRIK_BARBELL`/`RUBRIK_REFERENZ`,
+  da beide strukturell weder Barbell-Extreme (sicherer Sockel + volatile
+  Beimischung) noch eine reine "einfach den Index kaufen"-Vergleichslinie
+  sind, sondern eigenständige, verbreitete Allokationsregeln. Beide nutzen
+  ausschließlich bereits vorhandene Instrumente (`EUNL`/`EUNA`/`4GLD`/
+  `XEON`/`IBCL`), kein 25. Instrument, keine Änderung am
+  Alpha-Vantage-Request-Budget. `PORTFOLIO_60_40` ist das meistzitierte
+  Referenzportfolio überhaupt: zwei Töpfe, 60% `EUNL` (breiter
+  Aktienmarkt), 40% `EUNA` (breite Anleihen) - eine einzige glatte
+  Aufteilung zwischen zwei Anlageklassen statt eines Extrem-Ansatzes.
+  `PERMANENT_PORTFOLIO` (Harry Browne) hält stattdessen vier gleich große
+  Töpfe zu je 25%: `EUNL` (Aktien), `IBCL` (lange Anleihen), `4GLD`
+  (Gold), `XEON` (Cash) - konzipiert, um in jedem der vier
+  Wirtschaftsklimata (Wachstum, Rezession, Inflation, Deflation)
+  mindestens einen gut laufenden Baustein zu halten, und damit inhaltlich
+  der interessanteste Kontrast zur Barbell-Idee. Beide setzen wie alle
+  neueren Strategien explizit `rebalancing_schwelle_pp=5` und
+  `rebalancing_schwelle_relativ=Decimal("0.25")` (die 5/25-Regel, siehe
+  unten) und verwenden je Topf genau ein Instrument mit `sub_gewichte={
+  ticker: Decimal("1")}` - anders als die Barbell-Strategien, deren Töpfe
+  mehrere Instrumente mischen. Erster Ansatz wie alle Strategien/Szenarien:
+  die 60/40- und 25/25/25/25-Gewichte sind die literarisch bzw. historisch
+  überlieferten Werte, nicht für dieses Instrumentenset optimiert oder
+  gebacktestet.
   **Rebalancing-Trigger, "5/25-Regel je Topf" (#63, F5):** Optionales Feld
   `Strategy.rebalancing_schwelle_relativ` (Decimal, Default `1` = 100%)
   ergänzt `rebalancing_schwelle_pp` um eine relative Zusatzschwelle. Die

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ All 24 tracked instruments, and which strategy actually holds each one:
 
 | Ticker | Instrument | Held by |
 |---|---|---|
-| `EUNL` | MSCI World ETF (iShares Core) | Barbell 20/80, 30/70, Satellite, Diversified |
-| `EUNA` | Global Aggregate Bond ETF (iShares Core) | Barbell 20/80, 30/70, Satellite, Diversified |
-| `4GLD` | Xetra-Gold | Barbell 20/80, 30/70, Satellite, Diversified |
+| `EUNL` | MSCI World ETF (iShares Core) | Barbell 20/80, 30/70, Satellite, Diversified, 60/40, Permanent Portfolio |
+| `EUNA` | Global Aggregate Bond ETF (iShares Core) | Barbell 20/80, 30/70, Satellite, Diversified, 60/40 |
+| `4GLD` | Xetra-Gold | Barbell 20/80, 30/70, Satellite, Diversified, Permanent Portfolio |
 | `LYMS` | Nasdaq-100 ETF (Amundi Core) | Barbell 20/80, 30/70, Satellite, Diversified |
 | `SEMI` | Global Semiconductors ETF (iShares) | Barbell 20/80, 30/70, Satellite, Diversified |
 | `EIMI` | Emerging Markets IMI ETF (iShares Core) | Barbell 20/80, 30/70, Satellite, Diversified |
@@ -70,9 +70,9 @@ All 24 tracked instruments, and which strategy actually holds each one:
 | `KO` | Coca-Cola | Barbell 20/60/20 + Single-Stock Satellite |
 | `RHHBY` | Roche Holding (ADR) | Barbell 20/60/20 + Single-Stock Satellite |
 | `IUSA` | S&P 500 ETF (iShares Core) | Benchmark only |
-| `XEON` | EUR money-market ETF (Xtrackers Overnight Rate) | Barbell 20/80 (diversified) |
+| `XEON` | EUR money-market ETF (Xtrackers Overnight Rate) | Barbell 20/80 (diversified), Permanent Portfolio |
 | `EXSA` | STOXX Europe 600 ETF (iShares) | Barbell 20/80 (diversified) |
-| `IBCL` | Euro government bonds 15–30y ETF (iShares) | Barbell 20/80 (diversified) |
+| `IBCL` | Euro government bonds 15–30y ETF (iShares) | Barbell 20/80 (diversified), Permanent Portfolio |
 | `IBCI` | Inflation-linked Euro government bonds ETF (iShares) | Barbell 20/80 (diversified) |
 | `IQQ6` | Real estate ETF (iShares Developed Markets Property Yield) | Barbell 20/80 (diversified) |
 | `EXXY` | Broad commodities ETF (iShares Diversified Commodity Swap) | Barbell 20/80 (diversified) |

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -173,6 +173,7 @@ RUBRIK_BOERSENWEISHEITEN = "Börsenweisheiten"
 RUBRIK_CHARTTECHNIK = "Charttechnik"
 RUBRIK_WEITERE_ANALYSEN = "Weitere Analysen"
 RUBRIK_REFERENZ = "Referenz"
+RUBRIK_KLASSISCHE_PORTFOLIOS = "Klassische Portfolios"
 
 # --- Strategie 1: Barbell 20/80 (Pflichtenheft v2.0) -----------------------
 
@@ -451,12 +452,114 @@ SP500_BENCHMARK = Strategy(
     eigene_chart_skala=True,
 )
 
+# --- Strategie 6: Klassisches 60/40-Portfolio -------------------------------
+#
+# Das meistzitierte Referenzportfolio überhaupt: 60% breiter Aktienmarkt,
+# 40% Anleihen. Anders als die Barbell-Strategien kein Extrem-Ansatz
+# (sicherer Sockel + volatile Beimischung), sondern eine einzige, glatte
+# Aufteilung zwischen den beiden Anlageklassen - die naheliegendste
+# Vergleichslinie neben "einfach den Index kaufen" (SP500_BENCHMARK). Nutzt
+# ausschließlich bereits vorhandene Instrumente (EUNL/EUNA), kein
+# zusätzlicher API-Request.
+
+PORTFOLIO_60_40 = Strategy(
+    name="60/40-Portfolio",
+    rubrik=RUBRIK_KLASSISCHE_PORTFOLIOS,
+    startkapital=Decimal("10000"),
+    toepfe=[
+        Topf(
+            name="Topf A - Aktien",
+            gewicht_gesamt=Decimal("0.60"),
+            sub_gewichte={"EUNL": Decimal("1")},
+        ),
+        Topf(
+            name="Topf B - Anleihen",
+            gewicht_gesamt=Decimal("0.40"),
+            sub_gewichte={"EUNA": Decimal("1")},
+        ),
+    ],
+    ziel_topf="Topf A - Aktien",
+    ziel_gewicht=Decimal("0.60"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
+    beschreibung=(
+        "Das klassische 60/40-Depot: 60% breiter Aktienmarkt (MSCI World), 40% "
+        "breite Anleihen. Kein Extrem-Ansatz wie die Barbell-Strategien, sondern "
+        "eine einzige glatte Aufteilung zwischen den beiden Anlageklassen. "
+        "Rebalancing nach der 5/25-Regel wie bei den übrigen Strategien."
+    ),
+    beschreibung_en=(
+        "The classic 60/40 portfolio: 60% broad equities (MSCI World), 40% broad "
+        "bonds. Unlike the barbell strategies, not an extreme-allocation approach "
+        "but a single smooth split between the two asset classes. Rebalances "
+        "using the same 5/25 rule as the other strategies."
+    ),
+)
+
+# --- Strategie 7: Permanent Portfolio (Harry Browne) ------------------------
+#
+# Vier gleich große Töpfe (je 25%) über Aktien, lange Anleihen, Gold und
+# Cash - konzipiert, um in jedem der vier Wirtschaftsklimata (Wachstum,
+# Rezession, Inflation, Deflation) mindestens einen gut laufenden Baustein zu
+# halten. Inhaltlich der interessanteste Kontrast zur Barbell-Idee: statt
+# zwei Extremen (sicher/riskant) vier gleichgewichtete, unterschiedlich auf
+# Marktphasen reagierende Bausteine. Nutzt ausschließlich bereits vorhandene
+# Instrumente (EUNL/IBCL/4GLD/XEON), kein zusätzlicher API-Request.
+
+PERMANENT_PORTFOLIO = Strategy(
+    name="Permanent Portfolio",
+    rubrik=RUBRIK_KLASSISCHE_PORTFOLIOS,
+    startkapital=Decimal("10000"),
+    toepfe=[
+        Topf(
+            name="Topf A - Aktien",
+            gewicht_gesamt=Decimal("0.25"),
+            sub_gewichte={"EUNL": Decimal("1")},
+        ),
+        Topf(
+            name="Topf B - Lange Anleihen",
+            gewicht_gesamt=Decimal("0.25"),
+            sub_gewichte={"IBCL": Decimal("1")},
+        ),
+        Topf(
+            name="Topf C - Gold",
+            gewicht_gesamt=Decimal("0.25"),
+            sub_gewichte={"4GLD": Decimal("1")},
+        ),
+        Topf(
+            name="Topf D - Cash",
+            gewicht_gesamt=Decimal("0.25"),
+            sub_gewichte={"XEON": Decimal("1")},
+        ),
+    ],
+    ziel_topf="Topf A - Aktien",
+    ziel_gewicht=Decimal("0.25"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
+    beschreibung=(
+        "Harry Brownes Permanent Portfolio: je 25% Aktien (MSCI World), lange "
+        "Staatsanleihen, Gold und Cash - ein Baustein je Wirtschaftsklima "
+        "(Wachstum, Rezession, Inflation, Deflation). Vier gleichgewichtete Töpfe "
+        "statt zweier Extreme wie bei den Barbell-Strategien. Rebalancing nach "
+        "der 5/25-Regel."
+    ),
+    beschreibung_en=(
+        "Harry Browne's Permanent Portfolio: 25% each in equities (MSCI World), "
+        "long-term government bonds, gold and cash - one building block for each "
+        "economic climate (growth, recession, inflation, deflation). Four "
+        "equally weighted buckets instead of the two extremes used by the "
+        "barbell strategies. Rebalances using the 5/25 rule."
+    ),
+)
+
 STRATEGIES: list[Strategy] = [
     BARBELL_20_80,
     BARBELL_30_70,
     BARBELL_20_60_20_SATELLIT,
     BARBELL_20_80_DIVERSIFIZIERT,
     SP500_BENCHMARK,
+    PORTFOLIO_60_40,
+    PERMANENT_PORTFOLIO,
 ]
 
 STRATEGIES_BY_NAME: dict[str, Strategy] = {s.name: s for s in STRATEGIES}

--- a/tests/test_klassische_portfolios.py
+++ b/tests/test_klassische_portfolios.py
@@ -1,0 +1,96 @@
+"""Tests für die zwei verbreiteten klassischen Portfolio-Strategien.
+
+``PORTFOLIO_60_40`` (60% Aktien/40% Anleihen) und ``PERMANENT_PORTFOLIO``
+(Harry Browne, je 25% Aktien/lange Anleihen/Gold/Cash) sind zusätzliche
+Strategien neben den bestehenden Barbell-Varianten und dem S&P-500-Benchmark
+- beide nutzen ausschließlich bereits vorhandene Instrumente (EUNL, EUNA,
+IBCL, 4GLD, XEON), kein neuer API-Request nötig. Regressionsschutz, dass
+Sub-Gewichte zu 1 summieren und die Simulation End-to-End durchläuft.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from boersenspiel.engine import simulate
+from boersenspiel.history_store import PriceRow
+from boersenspiel.strategies import (
+    PERMANENT_PORTFOLIO,
+    PORTFOLIO_60_40,
+    STRATEGIES,
+)
+
+
+def test_neue_strategien_sind_in_strategies_list_registriert():
+    assert PORTFOLIO_60_40 in STRATEGIES
+    assert PERMANENT_PORTFOLIO in STRATEGIES
+
+
+def test_60_40_ticker_gewichte_summieren_zu_eins():
+    gewichte = PORTFOLIO_60_40.alle_ticker_gewichte()
+    assert sum(gewichte.values()) == Decimal("1")
+
+
+def test_60_40_haelt_klassisches_risikoprofil():
+    aktien_topf = PORTFOLIO_60_40.toepfe[0]
+    anleihen_topf = PORTFOLIO_60_40.toepfe[1]
+    assert aktien_topf.gewicht_gesamt == Decimal("0.60")
+    assert anleihen_topf.gewicht_gesamt == Decimal("0.40")
+    assert aktien_topf.sub_gewichte == {"EUNL": Decimal("1")}
+    assert anleihen_topf.sub_gewichte == {"EUNA": Decimal("1")}
+
+
+def test_permanent_portfolio_ticker_gewichte_summieren_zu_eins():
+    gewichte = PERMANENT_PORTFOLIO.alle_ticker_gewichte()
+    assert sum(gewichte.values()) == Decimal("1")
+
+
+def test_permanent_portfolio_haelt_vier_gleich_grosse_toepfe():
+    assert len(PERMANENT_PORTFOLIO.toepfe) == 4
+    for topf in PERMANENT_PORTFOLIO.toepfe:
+        assert topf.gewicht_gesamt == Decimal("0.25")
+        assert sum(topf.sub_gewichte.values()) == Decimal("1")
+
+
+def test_permanent_portfolio_nutzt_je_ein_instrument_pro_anlageklasse():
+    gewichte = PERMANENT_PORTFOLIO.alle_ticker_gewichte()
+    assert gewichte == {
+        "EUNL": Decimal("0.25"),
+        "IBCL": Decimal("0.25"),
+        "4GLD": Decimal("0.25"),
+        "XEON": Decimal("0.25"),
+    }
+
+
+def _rows_60_40() -> list[PriceRow]:
+    return [
+        PriceRow(date(2024, 1, 1), {"EUNL": Decimal("80"), "EUNA": Decimal("5")}),
+        PriceRow(date(2024, 6, 1), {"EUNL": Decimal("88"), "EUNA": Decimal("5.5")}),
+    ]
+
+
+def test_60_40_runs_end_to_end():
+    result = simulate(_rows_60_40(), PORTFOLIO_60_40)
+    assert result.strategy_name == "60/40-Portfolio"
+    assert result.value_history[-1].total_value > 0
+
+
+def _rows_permanent_portfolio() -> list[PriceRow]:
+    ticker_kurse_1 = {
+        "EUNL": Decimal("80"),
+        "IBCL": Decimal("150"),
+        "4GLD": Decimal("60"),
+        "XEON": Decimal("100"),
+    }
+    ticker_kurse_2 = {t: v * Decimal("1.1") for t, v in ticker_kurse_1.items()}
+    return [
+        PriceRow(date(2024, 1, 1), dict(ticker_kurse_1)),
+        PriceRow(date(2024, 6, 1), ticker_kurse_2),
+    ]
+
+
+def test_permanent_portfolio_runs_end_to_end():
+    result = simulate(_rows_permanent_portfolio(), PERMANENT_PORTFOLIO)
+    assert result.strategy_name == "Permanent Portfolio"
+    assert result.value_history[-1].total_value > 0


### PR DESCRIPTION
## Summary

Ergänzt zwei der bekanntesten klassischen Referenzportfolios, die neben den Barbell-Varianten und dem S&P-500-Benchmark bisher fehlten:

- **`PORTFOLIO_60_40`** – das meistzitierte Referenzportfolio überhaupt: 60% breiter Aktienmarkt (`EUNL`), 40% breite Anleihen (`EUNA`). Eine glatte Aufteilung zwischen zwei Anlageklassen statt eines Extrem-Ansatzes wie bei Barbell.
- **`PERMANENT_PORTFOLIO`** (Harry Browne) – vier gleich große Töpfe zu je 25%: Aktien (`EUNL`), lange Anleihen (`IBCL`), Gold (`4GLD`), Cash (`XEON`) – ein Baustein je Wirtschaftsklima. Inhaltlich der interessanteste Kontrast zur Barbell-Idee.

Beide nutzen ausschließlich bereits vorhandene Instrumente – **kein neues Instrument, kein zusätzlicher Alpha-Vantage-Request**, das Tagesbudget bleibt bei 25/25. Beide setzen die kanonische 5/25-Rebalancing-Regel (wie alle neueren Strategien) und bekommen eine eigene Rubrik `RUBRIK_KLASSISCHE_PORTFOLIOS` auf der Startseite, da sie strukturell weder Barbell noch reine Benchmark sind.

Nicht Teil dieser PR: eine Dividenden-/Value-Strategie fehlt ebenfalls, braucht aber neue Instrumente und damit ein zusätzliches API-Request-Budget – dafür wird ein separates Issue angelegt.

## Changes

- `src/boersenspiel/strategies.py`: `PORTFOLIO_60_40`, `PERMANENT_PORTFOLIO`, neue Rubrik `RUBRIK_KLASSISCHE_PORTFOLIOS`, beide in `STRATEGIES` registriert.
- `tests/test_klassische_portfolios.py`: Sub-Gewichte summieren zu 1, Risikoprofil/Topf-Struktur, End-to-End-Smoke-Test je Strategie.
- `README.md`: Portfolio-overview-Tabelle um die neuen Halter der betroffenen Ticker (`EUNL`, `EUNA`, `4GLD`, `XEON`, `IBCL`) ergänzt.
- `CLAUDE.md`: Dokumentationsabschnitt zu den beiden neuen Strategien.

## Test plan

- [x] `pytest -q` – 285 passed (277 vorher + 8 neue)
- [x] `python scripts/build_dashboard.py` erfolgreich, beide Strategien erscheinen auf Start- und Detailseite mit eigener Rubrik "Klassische Portfolios"


---
_Generated by [Claude Code](https://claude.ai/code/session_017p2KSWCeW6XWEEYB6K3fjB)_