### PR TITLE
Dividenden-/Value-Strategie ergänzen, Kursabruf auf zwei Tage aufteilen

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -3,13 +3,25 @@ name: Historischer Backfill (manuell)
 # Einmaliger historischer Backfill von data/price_history.csv, siehe Issue #6.
 #
 # Bewusst ein EIGENER, ausschliesslich manuell startbarer Workflow (kein
-# Cron): der Backfill ERSETZT die Kurshistorie komplett und verbraucht ~18
-# der 25 taeglichen Alpha-Vantage-Free-Tier-Requests. Er laeuft hier statt
+# Cron): der Backfill ERSETZT die Kurshistorie komplett. Er laeuft hier statt
 # lokal, weil der API-Key als Repo-Secret vorliegt und nicht auf jeder
 # Entwicklermaschine verfuegbar ist.
 #
+# Seit #99 braucht ein Backfill aller 26 Ticker 27 Requests und passt damit
+# nicht mehr in das Alpha-Vantage-Tageslimit von 25. Ein vollstaendiger
+# Backfill braucht deshalb ZWEI Laeufe an zwei aufeinanderfolgenden Tagen, in
+# dieser Reihenfolge:
+#
+#   Tag 1: batch=1  (Fremdwaehrungs-/Krypto-Ticker, 11 Requests) - setzt
+#          price_history.csv zurueck und baut die Historie neu auf
+#   Tag 2: batch=2  (EUR/XETRA-Ticker, 16 Requests) - setzt NICHT zurueck,
+#          sondern mischt seine Ticker additiv in die Zeilen von Tag 1
+#
+# Nach Tag 1 ist die Historie also bewusst unvollstaendig (die Batch-2-Ticker
+# stehen leer) - das Dashboard laesst Strategien ohne Kurse solange weg.
+#
 # WICHTIG: nicht am selben Tag wie der woechentliche Kursabruf starten -
-# beide zusammen (18 + 18 Requests) reissen das Tageslimit.
+# beide zusammen reissen das Tageslimit.
 
 on:
   workflow_dispatch:
@@ -18,8 +30,14 @@ on:
         description: "Wie viele Jahre Historie zurueck (nur untere Schranke - laeuft immer bis zur aeltesten verfuegbaren Historie je Ticker)"
         required: true
         default: "20"
+      batch:
+        description: "Ticker-Batch: 1 = Fremdwaehrung/Krypto (setzt die Historie zurueck), 2 = EUR/XETRA (mischt additiv dazu). 'alle' holt alle Ticker auf einmal und braucht 27 Requests, also einen Premium-Key."
+        type: choice
+        required: true
+        default: "1"
+        options: ["1", "2", "alle"]
       confirm:
-        description: "Ersetzt data/price_history.csv KOMPLETT. Zum Bestaetigen 'REPLACE' eintippen."
+        description: "Batch 1 / 'alle' ersetzt data/price_history.csv KOMPLETT (Batch 2 mischt nur dazu). Zum Bestaetigen 'REPLACE' eintippen."
         required: true
         default: ""
 
@@ -57,7 +75,12 @@ jobs:
       - name: Backfill ausführen
         env:
           ALPHAVANTAGE_API_KEY: ${{ secrets.ALPHAVANTAGE_API_KEY }}
-        run: python scripts/backfill_history.py --years "${{ inputs.years }}"
+        run: |
+          if [ "${{ inputs.batch }}" = "alle" ]; then
+            python scripts/backfill_history.py --years "${{ inputs.years }}"
+          else
+            python scripts/backfill_history.py --years "${{ inputs.years }}" --batch "${{ inputs.batch }}"
+          fi
 
       - name: Ergebnis prüfen
         run: |
@@ -88,7 +111,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/price_history.csv data/fetch_log.csv
-          git diff --cached --quiet || git commit -m "chore: historischer Backfill (${{ inputs.years }} Jahre)"
+          git diff --cached --quiet || git commit -m "chore: historischer Backfill (${{ inputs.years }} Jahre, Batch ${{ inputs.batch }})"
           git push
 
       - name: Pages-Artefakt hochladen

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -2,9 +2,31 @@ name: Wöchentliches Kurs-Update & Dashboard
 
 on:
   schedule:
-    # Montag 06:00 UTC - nach Xetra-Vorwochenschluss, vor Xetra-Handelsbeginn.
+    # Zwei Laeufe an aufeinanderfolgenden Tagen, je 06:00 UTC. Seit #99 braucht
+    # ein Abruf aller 26 Ticker 27 Alpha-Vantage-Requests und passt damit nicht
+    # mehr in das Free-Tier-Tageslimit von 25 (das pro Kalendertag und API-Key
+    # gilt). Jeder Lauf holt deshalb nur seinen Batch - Sonntag die
+    # Fremdwaehrungs-/Krypto-Ticker inkl. des einen EUR/USD-Requests, Montag
+    # die EUR/XETRA-Ticker. Jeder Ticker wird weiterhin genau einmal pro Woche
+    # aktualisiert; record_week() mischt den Montagslauf additiv in die am
+    # Sonntag geschriebene Zeile derselben ISO-Woche (siehe history_store.py).
+    #
+    # SONNTAG + MONTAG, nicht Montag + Dienstag: einsortiert werden die Kurse
+    # ueber den von der Quelle gemeldeten HANDELSTAG (row_date_from_quotes),
+    # nicht ueber das Abrufdatum. Beide Laeufe liegen so vor dem
+    # Xetra-Handelsbeginn am Montag und sehen denselben letzten Handelstag
+    # (Freitag) - und landen damit in derselben ISO-Woche. Ein Dienstagslauf
+    # saehe bereits den Montagsschluss, also die FOLGEWOCHE, und die Ticker
+    # seines Batches haengen dann dauerhaft eine Woche hinterher.
+    - cron: "0 6 * * 0"
     - cron: "0 6 * * 1"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      batch:
+        description: "Ticker-Batch (1 = Fremdwaehrung/Krypto, sonntags; 2 = EUR/XETRA, montags)"
+        type: choice
+        default: "1"
+        options: ["1", "2"]
 
 permissions:
   contents: write
@@ -33,7 +55,10 @@ jobs:
       - name: Kurse abrufen (Alpha Vantage)
         env:
           ALPHAVANTAGE_API_KEY: ${{ secrets.ALPHAVANTAGE_API_KEY }}
-        run: python scripts/run_fetch.py
+          # Der Sonntags-Cron holt Batch 1, jeder andere Ausloeser (Montags-Cron)
+          # Batch 2; bei manuellem Start entscheidet der Workflow-Input.
+          BATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.batch || (github.event.schedule == '0 6 * * 0' && '1' || '2') }}
+        run: python scripts/run_fetch.py --batch "$BATCH"
 
       - name: Dashboard neu bauen
         run: python scripts/build_dashboard.py
@@ -47,6 +72,8 @@ jobs:
         # verpasster Commit holt sich beim naechsten erfolgreichen Lauf von
         # selbst nach, es geht also keine Kurswoche verloren.
         continue-on-error: true
+        env:
+          BATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.batch || (github.event.schedule == '0 6 * * 0' && '1' || '2') }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ umgeschrieben, auf Wunsch des Owners aber wieder auf die ausführliche
 technische Fassung zurückgesetzt): Architektur-Diagramm, Engine-
 Modellierungsentscheidungen, volle Steuerlogik, Szenario-Tabellen und
 bekannte Einschränkungen stehen direkt im README, nicht nur verlinkt auf die
-Dashboard-Seiten. Ein `## Portfolio overview`-Abschnitt listet alle 24
+Dashboard-Seiten. Ein `## Portfolio overview`-Abschnitt listet alle 26
 Instrumente mit der Strategie, die sie tatsächlich hält. Die Ableitung aus
 dem ursprünglichen Anforderungsdokument (Pflichtenheft) wurde auf
 Owner-Wunsch aus dem README gestrichen — das Dokument ist ohnehin nicht Teil
@@ -35,8 +35,10 @@ pytest -q                          # gesamte Testsuite
 pytest tests/test_engine.py -q     # einzelne Testdatei
 pytest tests/test_engine.py::test_simple_strategy_end_to_end_exact_values -q  # einzelner Test
 
-python scripts/run_fetch.py                        # Kursabruf via Alpha Vantage (benötigt ALPHAVANTAGE_API_KEY env var)
-python scripts/backfill_history.py --years 20       # einmaliger historischer Backfill (ersetzt price_history.csv, 25 API-Requests = Tageslimit)
+python scripts/run_fetch.py --batch 1               # Kursabruf via Alpha Vantage, Batch 1 (benötigt ALPHAVANTAGE_API_KEY env var)
+python scripts/run_fetch.py --batch 2               # Batch 2, am Folgetag (zusammen decken beide alle Ticker ab, #99)
+python scripts/backfill_history.py --years 20 --batch 1   # historischer Backfill Tag 1 (ersetzt price_history.csv)
+python scripts/backfill_history.py --years 20 --batch 2   # Tag 2, mischt additiv dazu (27 Requests > Tageslimit 25)
 python scripts/build_dashboard.py                  # baut docs/index.html aus data/price_history.csv (Strategien + Szenarien)
 python scripts/build_dashboard.py --strategy "Barbell 20/80"  # nur eine Strategie/ein Szenario rendern
 ```
@@ -63,8 +65,8 @@ inkrementell fortgeschrieben).
 
 ### Trennung der Verantwortlichkeiten (wichtig beim Erweitern)
 
-- `instruments.py` — die 24 Instrumente (7 Barbell-Basisinstrumente + 10
-  Einzelaktien-Satellit + 7 im Zuge von #64 ergänzte Instrumente),
+- `instruments.py` — die 26 Instrumente (7 Barbell-Basisinstrumente + 10
+  Einzelaktien-Satellit + 7 im Zuge von #64 ergänzte Instrumente + 2 aus #99),
   **quellenunabhängig**. Kein Provider-Symbol-Mapping hier.
   **Sieben zusätzliche Instrumente (#64):** `IUSA`, `XEON`, `EXSA`, `IBCL`,
   `IBCI`, `IQQ6`, `EXXY` wurden ergänzt, um das tägliche Alpha-Vantage-Budget
@@ -82,10 +84,29 @@ inkrementell fortgeschrieben).
   waren aber zunächst fälschlich als ausschüttend markiert (relevant, weil
   sie jetzt tatsächlich alloziert sind und die Vorabpauschale-/
   Dividendenmodellierung dadurch beeinflusst wird).
-  **Request-Budget:** Mit 24 Instrumenten brauchen Backfill *und* Wochenabruf
-  je **genau 25** Requests — das volle Alpha-Vantage-Tageslimit, kein Puffer.
-  `tests/test_backfill_history.py` hält das als Test fest, damit ein
-  18. Instrument nicht still beide Workflows unmöglich macht.
+  **Zwei Instrumente für Dividende/Value (#99):** `ISPA` (iShares STOXX
+  Global Select Dividend 100, ausschüttend, Kurse ab 2009-11) und `IS3S`
+  (iShares Edge MSCI World Value Factor, thesaurierend, erst ab 2014-11) —
+  beide wie die #64-Instrumente XETRA/EUR, kein FX-Request. Der im Issue
+  vorgeschlagene Value-Ticker `IUVL` löst bei Alpha Vantage NICHT auf; die
+  XETRA-Notierung desselben Fonds läuft unter `IS3S.DEX` (`IWVL.LON` wäre USD),
+  entsprechend ist auch die ISIN die der real gehandelten Acc-Anteilsklasse
+  (IE00BP3QZB59) statt der im Issue vorgeschlagenen. Beide gehören
+  ausschließlich zu `strategies.DIVIDENDE_UND_VALUE`.
+  **Request-Budget (seit #99 je Batch):** Mit 26 Instrumenten brauchen Backfill
+  *und* Wochenabruf je **27** Requests und passen damit NICHT mehr in das
+  Alpha-Vantage-Tageslimit von 25. Beide laufen deshalb in zwei Batches an zwei
+  aufeinanderfolgenden Tagen (`sources/alphavantage.batch_tickers()`,
+  `--batch`): Batch 1 sind genau die Ticker mit Fremdwährungs-/Krypto-Endpunkt
+  (alle 9 USD-Ticker + BTC-EUR, 11 Requests inkl. des einen EUR/USD-Requests),
+  Batch 2 der Rest (16 EUR/XETRA-Ticker). Die Aufteilung ist bewusst
+  ABGELEITET statt als zwei feste Listen hinterlegt — damit landet ein künftig
+  ergänztes Instrument automatisch im richtigen Batch, und der eine
+  FX-Request fällt zwangsläufig nur in einem Lauf an.
+  `tests/test_backfill_history.py` hält das als Test fest, jetzt mit der neuen
+  Zählweise: nicht mehr „die Gesamtzahl passt in einen Tag", sondern „JEDER
+  EINZELNE Batch passt in einen Tag" (plus: die Batches decken jeden Ticker
+  genau einmal ab, und nur einer braucht den FX-Request).
   **Darstellung nicht allokierter Instrumente (#66):** Weder das Dashboard
   noch die Prämissen-Seite leiten eine Instrumentenzahl mehr aus einer
   hartkodierten Konstante ab. Die README enthält seit der #64-Nachfolgearbeit
@@ -308,7 +329,24 @@ inkrementell fortgeschrieben).
   der erfolgreichen Quotes, bei Gleichstand der frühere) statt aus dem
   Abrufdatum: ein Montagslauf vor Börsenbeginn liefert den Freitagsschluss
   der Vorwoche, der sonst eine ISO-Woche zu spät und damit versetzt zum
-  Backfill einsortiert würde. `read_fetch_log()` liest `fetch_log.csv`
+  Backfill einsortiert würde.
+  **Teilabrufe derselben ISO-Woche sind additiv (#99):** Seit der Wochenabruf
+  in zwei Batches an zwei Tagen läuft, existiert beim zweiten Lauf bereits eine
+  Zeile für die Zielwoche. Für einen Ticker ohne frischen Kurs gilt deshalb
+  ZUERST der bereits in dieser Zeile stehende Wert und erst danach der
+  Carry-Forward aus früheren Wochen — sonst würde der zweite Batch die am
+  Vortag frisch geholten Kurse des ersten auf den Stand der Vorwoche
+  zurücksetzen (`last_known` ist bewusst nur aus Wochen VOR der Zielwoche
+  gespeist). Nur ein Ticker, der auch in der bestehenden Wochenzeile fehlt
+  (Sicherheitsnetz), fällt weiterhin auf den alten Carry-Forward zurück. Der
+  neue Parameter `angefragte_ticker` benennt die Ticker, für die dieser Lauf
+  zuständig war (Default: alle): nur für sie wird ein fehlender Kurs in
+  `fetch_log.csv` protokolliert — ein Ticker aus dem anderen Batch ist nicht
+  „eingefroren", und ein Log-Eintrag dafür würde im Dashboard (#42) eine
+  Kurslücke melden, die es nicht gibt. Das Zeilendatum ist bei einer
+  bestehenden Wochenzeile das FRÜHERE der beiden Daten (vorher gewann das
+  spätere), damit die Historie nicht davon abhängt, welcher der beiden Läufe
+  zuletzt durchlief. `read_fetch_log()` liest `fetch_log.csv`
   zurück (`FetchLogEntry(date, ticker, status, source, note)`) – bislang nur
   geschrieben, seit #42 auch gelesen, um im Dashboard sichtbar zu machen,
   welche Kurse zuletzt fortgeschrieben statt frisch abgerufen wurden.
@@ -755,6 +793,19 @@ inkrementell fortgeschrieben).
   unveränderten Historie berechnet, da es nur die jüngsten Wochen betrifft.
   Die Prämissen-Seite nennt den Stichtag sowie je Strategie den tatsächlichen
   `sim_beginn` in der Handelsregeln-Tabelle.
+  **Strategien ohne Kursdaten (#99):** `_hat_kurshistorie(rows, strategy)`
+  prüft, ob es überhaupt EINEN Zeitpunkt gibt, an dem alle Zielinstrumente
+  einen Kurs haben; `build_dashboard()` lässt Strategien ohne solchen Zeitpunkt
+  komplett weg (kein Tabelleneintrag, keine Detailseite). Ein frisch ergänztes
+  Instrument steht bis zum nächsten Kursabruf/Backfill mit leerer Spalte in
+  `price_history.csv` — ohne diese Prüfung liefe seine Strategie über die volle
+  Historie mit dauerhaft geparktem Kapital (`handelbare_gewichte()` findet kein
+  handelbares Ziel) und stünde mit flacher Linie und 0% Rendite in der
+  Vergleichstabelle, also mit einer Aussage, die die Daten gar nicht hergeben.
+  `_real_investierbarer_zeitraum()` kann das nicht abfangen: es gibt keinen
+  Zeitraum, auf den es zuschneiden könnte. Genau das trifft aktuell
+  `DIVIDENDE_UND_VALUE`, bis der erste Abruf/Backfill Kurse für `ISPA`/`IS3S`
+  geliefert hat.
   **CAGR als Leitkennzahl (#63, F6b/c):** `_cagr_pct(rendite_pct, tage)`
   liefert die annualisierte Rendite aus der Gesamtrendite über die
   tatsächliche Simulationsdauer (`_tage_zwischen()`, Differenz aus erster und
@@ -1082,8 +1133,14 @@ eine aussagekräftige Exception aus. Der FX-Abruf läuft bewusst **vor** den
 Ticker-Abrufen, damit ein Fehlschlag einen statt 17 Requests kostet. Für den Lauf gibt es den manuell startbaren
 Workflow `.github/workflows/backfill.yml` (nutzt das Repo-Secret, verlangt
 `confirm=REPLACE`, schreibt eine Plausibilitätsprüfung in die Job-Summary) -
-nicht am selben Tag wie den wöchentlichen Kursabruf starten (25 + 25
-Requests > Tageslimit 25). `--years` ist nur eine untere Schranke, die
+nicht am selben Tag wie den wöchentlichen Kursabruf starten (beide zusammen
+reißen das Tageslimit 25). Seit #99 hat der Workflow zusätzlich einen
+`batch`-Input (1 / 2 / „alle"): ein vollständiger Backfill aller 26 Ticker
+braucht 27 Requests und läuft deshalb als ZWEI Läufe an zwei
+aufeinanderfolgenden Tagen — Batch 1 setzt `price_history.csv` zurück und baut
+neu auf, Batch 2 mischt seine Ticker über denselben `record_week()`-Merge
+additiv dazu. Die Reihenfolge ist bindend: Batch 2 zuerst ließe die Historie
+der Batch-1-Ticker leer. Nach Tag 1 ist die Historie bewusst unvollständig. `--years` ist nur eine untere Schranke, die
 `AlphaVantageSource.fetch_weekly_history()`/`fetch_crypto_weekly_history()`
 zum Filtern der von Alpha Vantage gelieferten Zeitreihe nutzen - ein Wert,
 der weiter zurückliegt als die tatsächlich verfügbare Historie eines
@@ -1098,10 +1155,20 @@ Werts ein, dieselbe Lücken-Behandlung wie beim laufenden Live-Abruf.
 
 ### GitHub Actions (`.github/workflows/weekly-update.yml`)
 
-Läuft wöchentlich (Montag 06:00 UTC) + `workflow_dispatch`: Tests →
-Kursabruf (Alpha Vantage) → Dashboard-Build → Commit von
-`data/price_history.csv`/`data/fetch_log.csv` zurück ins Repo →
-GitHub-Pages-Deploy. Braucht die Secrets/Settings: Repo-Secret
+Läuft seit #99 an ZWEI aufeinanderfolgenden Tagen (Sonntag und Montag, je
+06:00 UTC) + `workflow_dispatch` (mit Auswahl-Input `batch`): Tests →
+Kursabruf (Alpha Vantage, `run_fetch.py --batch N`) → Dashboard-Build →
+Commit von `data/price_history.csv`/`data/fetch_log.csv` zurück ins Repo →
+GitHub-Pages-Deploy. Welcher Batch läuft, leitet der Workflow aus
+`github.event.schedule` ab (Sonntags-Cron → Batch 1, sonst Batch 2); bei
+manuellem Start entscheidet der Input. **Sonntag+Montag statt Montag+Dienstag
+(wichtig beim Verschieben der Cron-Zeiten):** einsortiert werden die Kurse über
+den von der Quelle gemeldeten HANDELSTAG, nicht über das Abrufdatum
+(`row_date_from_quotes()`). Beide Läufe liegen so vor dem Xetra-Handelsbeginn
+am Montag und sehen denselben letzten Handelstag (Freitag) — und landen damit
+in derselben ISO-Woche, die `record_week()` dann additiv zusammenführt. Ein
+Dienstagslauf sähe bereits den Montagsschluss, also die FOLGEWOCHE, und die
+Ticker seines Batches hingen dauerhaft eine Woche hinterher. Braucht die Secrets/Settings: Repo-Secret
 `ALPHAVANTAGE_API_KEY`; Settings → Actions → Workflow permissions → "Read
 and write permissions"; Settings → Pages → Source → "GitHub Actions".
 **Der Commit-Schritt trägt bewusst `continue-on-error: true`:** ein
@@ -1144,7 +1211,17 @@ ein Test-Paar mit identischem Kursverlauf, das mit gesetztem
 auslöst und mit dem Default (`1`, effektiv deaktiviert) exakt das Verhalten
 vor #63 reproduziert (kein Rebalancing).
 `tests/test_history_store.py` prüft Wochen-Idempotenz, Carry-Forward und
-`read_fetch_log()`.
+`read_fetch_log()`; seit #99 zusätzlich die additiven Teilabrufe: ein zweiter
+Batch derselben Woche darf die Kurse des ersten nicht auf die Vorwoche
+zurückwerfen, protokolliert nur seine eigenen Ticker, hält das frühere
+Zeilendatum — und ein Ticker, der in KEINEM Batch war, fällt weiterhin auf den
+alten Carry-Forward zurück (Sicherheitsnetz).
+`tests/test_dividende_value.py` prüft die #99-Strategie: Registrierung und
+Rubrik, Gewichte summieren zu 1, zwei gleich große Töpfe, 5/25-Regel,
+Symbol-Mapping vorhanden und EUR/XETRA-notiert, die belegten Steuerattribute
+(ISPA ausschüttend mit eigenem Satz, IS3S thesaurierend, beide 30%
+Teilfreistellung), End-to-End-Lauf sowie ein Regressionstest analog zu #64,
+dass keine bestehende Strategie die zwei neuen Instrumente hält.
 `tests/test_sources.py` / `tests/test_alphavantage.py` mocken die jeweilige
 Provider-API vollständig (kein echter Netzwerkzugriff in Tests).
 `tests/test_scenarios.py` verifiziert die generische `gewichte_fn`-Mechanik

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ dashboard on GitHub Pages.
 
 ## The portfolio
 
-24 instruments are tracked in `instruments.py`; which of them a given
+26 instruments are tracked in `instruments.py`; which of them a given
 strategy actually holds, and at what weight, is decided separately in
 `strategies.py`. Two buckets recur in most strategies:
 
@@ -46,9 +46,20 @@ Hold)`, is not a barbell at all — a single, never-rebalanced position in an
 S&P 500 ETF, included purely as the "just buy the index" comparison line
 that was otherwise missing from the dashboard.
 
+`Dividend & Value` splits differently again: not across asset classes but
+*within* equities, by a selection criterion — 50% a dividend strategy (`ISPA`,
+STOXX Global Select Dividend 100) and 50% the value factor (`IS3S`, MSCI World
+Value). Dividend and value investing are among the most widely discussed
+approaches there are, and no instrument in the set had a targeted exposure to
+either: `Instrument.dividendenrendite` only models the *payout* of instruments
+held for other reasons. Both instruments are new, which is what forced the
+two-day price fetch described below. Their weights are the obvious equal split,
+not optimized or backtested — `IS3S` only has prices from November 2014, so the
+strategy starts later than the rest.
+
 ### Portfolio overview
 
-All 24 tracked instruments, and which strategy actually holds each one:
+All 26 tracked instruments, and which strategy actually holds each one:
 
 | Ticker | Instrument | Held by |
 |---|---|---|
@@ -76,6 +87,8 @@ All 24 tracked instruments, and which strategy actually holds each one:
 | `IBCI` | Inflation-linked Euro government bonds ETF (iShares) | Barbell 20/80 (diversified) |
 | `IQQ6` | Real estate ETF (iShares Developed Markets Property Yield) | Barbell 20/80 (diversified) |
 | `EXXY` | Broad commodities ETF (iShares Diversified Commodity Swap) | Barbell 20/80 (diversified) |
+| `ISPA` | Global dividend ETF (iShares STOXX Global Select Dividend 100) | Dividend & Value |
+| `IS3S` | Value factor ETF (iShares Edge MSCI World Value Factor) | Dividend & Value |
 
 `engine.simulate()` only ever reads `strategy.alle_ticker_gewichte()` — an
 instrument only moves the numbers of the strategies that actually list it.
@@ -98,14 +111,14 @@ computes analytics from them.
 flowchart TB
     subgraph beschaffung["① Data acquisition — weekly, writing"]
         direction TB
-        cron["GitHub Actions<br/>Mon 06:00 UTC"] --> fetch["run_fetch.py"]
+        cron["GitHub Actions<br/>Sun + Mon 06:00 UTC<br/>(one ticker batch each)"] --> fetch["run_fetch.py --batch"]
         fetch --> av["AlphaVantageSource<br/>symbol mapping · USD→EUR"]
         av --> store
         back["backfill_history.py<br/>one-off, years back"] --> store
         store["history_store.record_week()<br/><b>only write path</b><br/>weekly idempotency · carry-forward"]
     end
 
-    store ==> csv[("<b>data/price_history.csv</b><br/>date × 24 tickers<br/><i>raw prices only, nothing derived</i>")]
+    store ==> csv[("<b>data/price_history.csv</b><br/>date × 26 tickers<br/><i>raw prices only, nothing derived</i>")]
     store -.log.-> log[("data/fetch_log.csv")]
 
     subgraph auswertung["② Analytics — fresh on every build, reading"]
@@ -125,7 +138,7 @@ flowchart TB
 ### Process overview
 
 **① Data acquisition.** Once a week, the workflow fetches a price for each of
-the 24 tickers. Everything source-specific — Alpha Vantage symbols, the
+the 26 tickers. Everything source-specific — Alpha Vantage symbols, the
 USD→EUR conversion of the satellite stocks, the dedicated crypto endpoint —
 stays inside `sources/`. The result is always the same: one `PriceQuote` per
 ticker. Which provider delivered the price is no longer visible, or relevant,
@@ -139,6 +152,17 @@ missing, the last known price is carried forward (carry-forward) and noted in
 to is decided by the **trading day** reported by the source, not the day of
 the fetch: a Monday-morning run before the market opens returns Friday's
 closing price from the previous week, and that belongs in Friday's week.
+
+**Partial fetches of the same week are additive.** Since 26 instruments no
+longer fit into Alpha Vantage's daily free-tier budget, the weekly fetch runs
+on two consecutive days, each covering one ticker batch (see "Two-day price
+fetch" below). When a row for the target week already exists, a ticker without
+a fresh quote keeps **the value already in that row** and only falls back to
+the carry-forward from earlier weeks if it is missing there too — otherwise the
+second run would reset the first run's fresh prices to last week's state. A
+partial run also only logs missing prices for the tickers it was responsible
+for: a ticker from the other batch is not frozen, it simply arrives on the
+other day.
 
 **Only the raw price is persisted.** No position values, no share counts, no
 tax state. That is the project's central design decision: everything derived
@@ -187,9 +211,9 @@ Three properties that are easy to miss:
   runs could happen in any order or in parallel.
 - **Scenarios only use part of the data.** All scenarios in `scenarios.py`
   build on the buckets of `Barbell 20/80` and therefore only touch **7 of the
-  24** tickers; the other 17 (the 10 satellite stocks and the 7 instruments
-  from `Barbell 20/80 (diversified)`/the benchmark) only appear in specific
-  strategies. The price history is deliberately broader than any single
+  26** tickers; the other 19 (the 10 satellite stocks, the 7 instruments from
+  `Barbell 20/80 (diversified)`/the benchmark, and the 2 from `Dividend &
+  Value`) only appear in specific strategies. The price history is deliberately broader than any single
   evaluation.
 - **No lookahead.** Every `gewichte_fn` may only read `rows[:i+1]`. A rule
   deciding in week i must not know week i+1 — otherwise every result would be
@@ -228,7 +252,7 @@ strategy always yields the identical result.
 
 | File | Purpose |
 |---|---|
-| `src/boersenspiel/instruments.py` | The 24 instruments (7 barbell base + 10 single-stock satellite + 7 from the diversified barbell/benchmark; ticker, ISIN) – source-independent |
+| `src/boersenspiel/instruments.py` | The 26 instruments (7 barbell base + 10 single-stock satellite + 7 from the diversified barbell/benchmark + 2 dividend/value; ticker, ISIN) – source-independent |
 | `src/boersenspiel/strategies.py` | Interchangeable strategy definitions (weights, buckets, rebalancing threshold) + cross-strategy tax/fee constants |
 | `src/boersenspiel/history_store.py` | Only write path to `data/price_history.csv` / `data/fetch_log.csv` |
 | `src/boersenspiel/sources/` | Interchangeable price sources (default: `alphavantage.py`) |
@@ -255,6 +279,36 @@ mapping lives exclusively in this file. A manual, non-Actions entry point
 (via Cowork/web search) existed earlier but was removed
 ([#51](https://github.com/S540d/Boersenspiel/issues/51)) in favor of a single,
 consistent GitHub Actions path.
+
+### Two-day price fetch
+
+Alpha Vantage's free tier allows 25 requests per day and API key. Fetching all
+26 tickers needs 27 (26 `GLOBAL_QUOTE`/crypto calls + 1
+`CURRENCY_EXCHANGE_RATE`), so the weekly fetch runs on **two consecutive days**,
+each covering one batch:
+
+| Batch | Tickers | Requests | Cron |
+|---|---|---|---|
+| 1 | the ones needing a foreign-currency or crypto endpoint (all 9 USD tickers + `BTC-EUR`), plus the single EUR/USD request | 11 | Sun 06:00 UTC |
+| 2 | the EUR/Xetra tickers | 16 | Mon 06:00 UTC |
+
+Every ticker is still updated exactly once per week, just no longer all on the
+same weekday. The split is *derived*, not hard-coded
+(`sources/alphavantage.batch_tickers()`): batch 1 is exactly the set that needs
+FX or crypto, batch 2 is the rest. That keeps the one EUR/USD request in a
+single run, and a future instrument lands in the right batch automatically
+instead of silently falling out of a stored list.
+
+**Sunday + Monday, not Monday + Tuesday.** Prices are filed under the *trading
+day* reported by the source, not the fetch date. Both runs sit before Monday's
+Xetra open and therefore see the same last trading day (Friday) and land in
+the same ISO week. A Tuesday run would already see Monday's close — the
+following week — and its batch would end up permanently one week behind.
+
+The merge in `record_week()` is what makes this safe; see "① Fetch price data"
+above. `tests/test_backfill_history.py` guards the budget per batch (each batch
+≤ 25 requests, the batches cover every ticker exactly once, and only one batch
+needs the FX request).
 
 ### Setting up Alpha Vantage
 
@@ -294,13 +348,20 @@ the historical `FX_WEEKLY` rate for the same week (forward-fill if no FX
 rate is available for a given week).
 
 ```bash
-python scripts/backfill_history.py --years 20  # default: 20 years back (lower bound only)
+python scripts/backfill_history.py --years 20 --batch 1  # day 1
+python scripts/backfill_history.py --years 20 --batch 2  # day 2
 ```
 
-Uses exactly 25 requests (23 non-crypto tickers + 1× `FX_WEEKLY` + 1× crypto)
-— the full daily free-tier limit, with no headroom left since the seven
-additional instruments were added. A re-run after a network error, a debug
-call, or the weekly fetch on the same day will all breach it. An unresolvable
+A backfill of all tickers needs 27 requests (25 non-crypto tickers + 1×
+`FX_WEEKLY` + 1× crypto) and therefore no longer fits into the daily
+free-tier limit of 25. A full backfill runs in two batches on two consecutive
+days, in this order: batch 1 (foreign-currency/crypto tickers, 11 requests)
+resets the CSVs and rebuilds the history, batch 2 (EUR/Xetra tickers, 16
+requests) does **not** reset but merges its tickers additively into the rows
+already written, through the same `record_week()` merge as the weekly fetch.
+Running `--batch 2` first would leave the batch-1 tickers empty. Without
+`--batch`, the single-day run over all tickers still exists but needs a
+premium key. An unresolvable
 ticker symbol aborts the run without returning the requests already spent, so
 verify symbols (`SYMBOL_SEARCH`) before adding an instrument;
 `tests/test_backfill_history.py` guards the budget itself. **Replaces** `price_history.csv` completely -
@@ -668,8 +729,9 @@ pytest -q
   its high rather than across the full period — see
   [#56](https://github.com/S540d/Boersenspiel/issues/56).
 - **Alpha Vantage free-tier limit:** 25 requests/day, max. 1 request/second.
-  Still unproblematic for the current 24 tickers fetched once a week, but
-  barely any headroom for additional manual fetches on the same day;
+  The current 26 tickers need 27 requests and therefore no longer fit into a
+  single day — the weekly fetch is split across two consecutive days (see
+  "Two-day price fetch"), leaving headroom only in batch 2;
   `AlphaVantageSource` sleeps between requests. If a price still fails (e.g.
   due to rate limiting or an empty response), the last known price is
   carried forward and noted in `fetch_log.csv` (a row is never left with a

--- a/scripts/backfill_history.py
+++ b/scripts/backfill_history.py
@@ -12,12 +12,26 @@ EUR umgerechnet, damit die Historie waehrungskonsistent zum Rest des
 Portfolios ist - dieselbe Umrechnung, die auch der laufende Live-Abruf
 (``run_fetch.py``) fuer diese Ticker vornimmt.
 
-Verbraucht 25 Requests (23 nicht-Krypto-Ticker + 1x FX_WEEKLY + 1x Krypto) -
-das ist GENAU das taegliche Alpha-Vantage-Free-Tier-Limit, seit #64 die sieben
-zusaetzlichen Datenreihen dazugekommen sind. Es gibt damit keinen Puffer mehr:
-ein Re-Run nach einem Netzwerkfehler, ein Debug-Abruf oder der Wochenabruf am
-selben Tag reissen das Limit (es gilt pro Tag und API-Key, nicht pro
-Skriptlauf). Ein nicht aufloesbares Ticker-Symbol bricht den Lauf ab, ohne die
+Ein Backfill ALLER Ticker braucht 27 Requests (25 nicht-Krypto-Ticker + 1x
+FX_WEEKLY + 1x Krypto) und passt damit seit den beiden Instrumenten aus #99
+NICHT mehr in das taegliche Alpha-Vantage-Free-Tier-Limit von 25 Requests (es
+gilt pro Tag und API-Key, nicht pro Skriptlauf). Ein vollstaendiger Backfill
+laeuft deshalb wie der Wochenabruf in zwei Batches an zwei aufeinanderfolgenden
+Tagen:
+
+    Tag 1:  python scripts/backfill_history.py --years 20 --batch 1
+    Tag 2:  python scripts/backfill_history.py --years 20 --batch 2
+
+Batch 1 (Fremdwaehrungs-/Krypto-Ticker, 11 Requests) setzt die CSVs wie bisher
+zurueck und baut die Historie neu auf; Batch 2 (EUR/XETRA-Ticker, 16 Requests)
+setzt NICHT zurueck, sondern mischt seine Ticker ueber denselben
+``record_week``-Merge additiv in die bereits geschriebenen Wochenzeilen (#99).
+Die Reihenfolge ist deshalb bindend - ein Lauf mit ``--batch 2`` zuerst laesse
+die Historie der Batch-1-Ticker leer. Ohne ``--batch`` laeuft weiterhin ein
+Ein-Tages-Lauf ueber alle Ticker; der ist nur noch mit einem Premium-Key (oder
+einem reduzierten Instrumentenset) moeglich.
+
+Ein nicht aufloesbares Ticker-Symbol bricht den Lauf ab, ohne die
 bereits verbrauchten Requests zurueckzugeben - Symbole deshalb vorher pruefen
 (SYMBOL_SEARCH). Der Regressionstest dazu steht in tests/test_backfill_history.py. BTC-EUR laeuft dabei ueber denselben einen FX_WEEKLY-
 Request wie die USD-Einzelaktien (kein zusaetzlicher Request) - siehe
@@ -54,7 +68,8 @@ waehrend ``manual_prices.csv`` nur fuer Kurse gedacht ist, die Alpha Vantage
 ueberhaupt nicht liefert.
 
 Nutzung:
-    python scripts/backfill_history.py --years 20
+    python scripts/backfill_history.py --years 20 --batch 1   # Tag 1
+    python scripts/backfill_history.py --years 20 --batch 2   # Tag 2
 """
 
 from __future__ import annotations
@@ -71,7 +86,12 @@ import _bootstrap  # noqa: F401
 from boersenspiel.history_store import DEFAULT_DATA_DIR, FETCH_LOG_HEADER, PRICE_HISTORY_HEADER, record_week
 from boersenspiel.instruments import TICKERS
 from boersenspiel.sources import PriceQuote
-from boersenspiel.sources.alphavantage import USD_TICKERS, AlphaVantageSource
+from boersenspiel.sources.alphavantage import (
+    FETCH_BATCHES,
+    USD_TICKERS,
+    AlphaVantageSource,
+    batch_tickers,
+)
 
 _REQUEST_INTERVAL_SECONDS = 1.1
 
@@ -347,11 +367,22 @@ def collect_weekly_series(
     return per_ticker
 
 
-def write_backfilled_history(per_ticker: dict[str, dict[date, float]], data_dir: Path) -> int:
+def write_backfilled_history(
+    per_ticker: dict[str, dict[date, float]],
+    data_dir: Path,
+    reset: bool = True,
+    tickers: list[str] | None = None,
+) -> int:
     """Schreibt die gesammelte Kurshistorie ueber ``history_store.record_week``
     (einziger Schreibzugriff auf die CSVs) und liefert die Anzahl geschriebener
     Wochen. Nutzt fuer fehlende Ticker/Wochen exakt denselben Carry-Forward-
-    Mechanismus wie der Live-Abruf."""
+    Mechanismus wie der Live-Abruf.
+
+    ``reset=False`` haengt einen zweiten Backfill-Batch (#99) an eine bereits
+    geschriebene Historie an, statt sie zu leeren - ``record_week`` mischt die
+    Ticker dieses Batches dann additiv in die bestehenden Wochenzeilen.
+    ``tickers`` benennt die Ticker dieses Batches; nur fuer sie wird eine
+    fehlende Woche protokolliert (Default: alle)."""
     by_week: dict[str, dict[tuple[int, int], float]] = {
         ticker: {_iso_week(d): price for d, price in series.items()} for ticker, series in per_ticker.items()
     }
@@ -363,7 +394,8 @@ def write_backfilled_history(per_ticker: dict[str, dict[date, float]], data_dir:
             if key not in weeks or d > weeks[key]:
                 weeks[key] = d
 
-    _reset_data_files(data_dir)
+    if reset:
+        _reset_data_files(data_dir)
 
     for week_key, week_date in sorted(weeks.items()):
         quotes: dict[str, PriceQuote] = {}
@@ -373,7 +405,7 @@ def write_backfilled_history(per_ticker: dict[str, dict[date, float]], data_dir:
                 quotes[ticker] = PriceQuote(ticker, None, "missing", "alphavantage-backfill")
             else:
                 quotes[ticker] = PriceQuote(ticker, price, "ok", "alphavantage-backfill")
-        record_week(week_date, quotes, data_dir=data_dir)
+        record_week(week_date, quotes, data_dir=data_dir, angefragte_ticker=tickers)
 
     return len(weeks)
 
@@ -387,6 +419,18 @@ def main() -> int:
         help="Wie viele Jahre historischer Daten, nur untere Schranke (Default: 20 = so weit wie verfuegbar)",
     )
     parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR, help="Zielverzeichnis (Default: data/)")
+    parser.add_argument(
+        "--batch",
+        type=int,
+        choices=FETCH_BATCHES,
+        default=None,
+        help=(
+            "Nur die Ticker dieses Batches backfillen (Default: alle - passt seit #99 "
+            "nicht mehr in das Alpha-Vantage-Tageslimit). Batch 1 setzt die CSVs "
+            "zurueck und baut neu auf, Batch 2 mischt additiv dazu - in dieser "
+            "Reihenfolge an zwei aufeinanderfolgenden Tagen laufen lassen."
+        ),
+    )
     args = parser.parse_args()
 
     since = date.today() - timedelta(days=365 * args.years)
@@ -395,9 +439,19 @@ def main() -> int:
     manual_fx = read_manual_fx(args.data_dir)
     manual_prices = read_manual_prices(args.data_dir)
 
-    print(f"Backfill ab {since.isoformat()} fuer {len(TICKERS)} Ticker ...", file=sys.stderr)
-    per_ticker = collect_weekly_series(source, TICKERS, since, manual_fx, manual_prices)
-    week_count = write_backfilled_history(per_ticker, args.data_dir)
+    tickers = TICKERS if args.batch is None else batch_tickers(TICKERS, args.batch)
+    # Nur Batch 1 (bzw. der Ein-Tages-Lauf ueber alle Ticker) setzt die CSVs
+    # zurueck - Batch 2 wuerde sonst die Historie des Vortages loeschen.
+    reset = args.batch != 2
+    batch_hinweis = "" if args.batch is None else f"Batch {args.batch}: "
+
+    print(
+        f"{batch_hinweis}Backfill ab {since.isoformat()} fuer {len(tickers)} von "
+        f"{len(TICKERS)} Tickern ...",
+        file=sys.stderr,
+    )
+    per_ticker = collect_weekly_series(source, tickers, since, manual_fx, manual_prices)
+    week_count = write_backfilled_history(per_ticker, args.data_dir, reset=reset, tickers=tickers)
 
     print(f"Fertig: {week_count} Wochen zurueckgeschrieben nach {args.data_dir / 'price_history.csv'}")
     return 0

--- a/scripts/run_fetch.py
+++ b/scripts/run_fetch.py
@@ -8,6 +8,12 @@ an Yahoos Crumb/Cookie-Authentifizierung scheiterte) und schreibt das Ergebnis
 Umgebungsvariable ``ALPHAVANTAGE_API_KEY`` (als GitHub-Actions-Secret
 hinterlegt). Läuft ausschließlich über GitHub Actions (siehe #51) - der
 frühere manuelle/Cowork-Weg über ``record_prices.py`` wurde gestrichen.
+
+Seit #99 holt ein Lauf nur noch eine Ticker-Teilmenge (``--batch``): alle
+Ticker zusammen brauchen mehr Requests, als Alpha Vantages Free Tier pro Tag
+erlaubt. Der Workflow startet deshalb zwei Läufe an zwei aufeinanderfolgenden
+Tagen; ``history_store.record_week`` mischt den zweiten additiv in die Zeile
+derselben ISO-Woche.
 """
 
 from __future__ import annotations
@@ -20,7 +26,7 @@ import _bootstrap  # noqa: F401
 
 from boersenspiel.history_store import record_week, row_date_from_quotes
 from boersenspiel.instruments import TICKERS
-from boersenspiel.sources.alphavantage import AlphaVantageSource
+from boersenspiel.sources.alphavantage import FETCH_BATCHES, AlphaVantageSource, batch_tickers
 
 
 def main() -> int:
@@ -36,14 +42,32 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--batch",
+        type=int,
+        choices=FETCH_BATCHES,
+        default=None,
+        help=(
+            "Nur die Ticker dieses Wochen-Batches abrufen (Default: alle). Seit #99 "
+            "braucht ein Abruf aller Ticker mehr als die 25 Requests, die Alpha "
+            "Vantages Free Tier pro Tag erlaubt - der Wochenabruf laeuft deshalb an "
+            "zwei aufeinanderfolgenden Tagen mit je einem Batch. Batch 1 sind die "
+            "Ticker mit Fremdwaehrungs-/Krypto-Endpunkt (inkl. des einen "
+            "EUR/USD-Requests), Batch 2 die EUR/XETRA-Ticker."
+        ),
+    )
+    parser.add_argument(
         "--ignore-handelstag",
         action="store_true",
         help="Kurse stur unter --date ablegen, statt unter ihrem Handelstag",
     )
     args = parser.parse_args()
 
+    tickers = TICKERS if args.batch is None else batch_tickers(TICKERS, args.batch)
+    if args.batch is not None:
+        print(f"Batch {args.batch}: {len(tickers)} von {len(TICKERS)} Tickern ({', '.join(tickers)})")
+
     source = AlphaVantageSource()
-    quotes = source.fetch(TICKERS, args.date)
+    quotes = source.fetch(tickers, args.date)
 
     missing = [t for t, q in quotes.items() if q.status != "ok"]
     if missing:
@@ -71,7 +95,10 @@ def main() -> int:
     if as_of != args.date:
         print(f"Kurse beziehen sich auf den Handelstag {as_of.isoformat()} (Abruf: {args.date.isoformat()})")
 
-    row = record_week(as_of, quotes)
+    # angefragte_ticker: nur fuer die Ticker DIESES Batches darf ein fehlender
+    # Kurs als Luecke protokolliert werden - die des anderen Batches kommen am
+    # anderen Wochentag und sind nicht "eingefroren" (siehe record_week).
+    row = record_week(as_of, quotes, angefragte_ticker=tickers)
     print(f"Kurshistorie aktualisiert fuer {row.date.isoformat()}: {row.prices}")
     return 0
 

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -113,6 +113,24 @@ def _real_investierbarer_zeitraum(rows: list[PriceRow], strategy: Strategy) -> l
     return rows
 
 
+def _hat_kurshistorie(rows: list[PriceRow], strategy: Strategy) -> bool:
+    """Ob ueberhaupt EIN Zeitpunkt existiert, an dem alle Zielinstrumente einen
+    Kurs haben.
+
+    Ein neu ergaenztes Instrument steht bis zum naechsten Kursabruf bzw. dem
+    naechsten Backfill mit leerer Spalte in price_history.csv. Ohne diese
+    Pruefung liefe seine Strategie ueber die volle Historie mit dauerhaft
+    geparktem Kapital (handelbare_gewichte() findet kein einziges handelbares
+    Ziel) und stuende mit einer flachen Linie und 0% Rendite in der
+    Vergleichstabelle - eine Aussage ueber die Strategie, die die Daten gar
+    nicht hergeben. `_real_investierbarer_zeitraum()` kann diesen Fall nicht
+    abfangen: es gibt schlicht keinen Zeitraum, auf den es zuschneiden koennte.
+    `build_dashboard()` laesst solche Strategien deshalb ganz weg, bis Kurse da
+    sind."""
+    ziel_ticker = set(strategy.alle_ticker_gewichte())
+    return any(ziel_ticker <= set(row.prices) for row in rows)
+
+
 # --- #80: laengerer Betrachtungszeitraum per Ersatzbond-Annahme --------------
 #
 # _real_investierbarer_zeitraum() (F4/#63) schneidet die Historie auf den
@@ -1353,6 +1371,12 @@ def build_dashboard(
     # bewusst auf der vollen, unveraenderten Historie berechnet (betrifft nur die
     # juengsten Wochen).
     rows_ohne_btc_fruehphase = _ohne_btc_fruehphase(rows)
+    # Strategien, deren Instrumente noch gar keinen Kurs haben (frisch ergaenzt,
+    # Backfill/Wochenabruf noch nicht gelaufen), bleiben ganz weg statt mit einer
+    # flachen 0%-Linie in der Vergleichstabelle zu stehen - siehe _hat_kurshistorie().
+    strategies = [s for s in strategies if _hat_kurshistorie(rows_ohne_btc_fruehphase, s)]
+    if not strategies:
+        raise ValueError("Keine Strategie hat Kurse fuer alle ihre Instrumente - kein Dashboard erzeugbar")
     strategie_rows = {s.name: _real_investierbarer_zeitraum(rows_ohne_btc_fruehphase, s) for s in strategies}
 
     views = [

--- a/src/boersenspiel/history_store.py
+++ b/src/boersenspiel/history_store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import csv
 import os
 from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -137,18 +138,40 @@ def record_week(
     as_of: date,
     quotes: dict[str, PriceQuote],
     data_dir: Path = DEFAULT_DATA_DIR,
+    angefragte_ticker: Iterable[str] | None = None,
 ) -> PriceRow:
     """Schreibt/aktualisiert die Zeile für die ISO-Kalenderwoche von ``as_of``.
 
     - Für Ticker mit Status "ok" wird der gelieferte Kurs übernommen.
     - Für Ticker mit Status "missing" (oder wenn ein Ticker in ``quotes``
-      fehlt) wird der letzte bekannte Kurs aus der bisherigen Historie
-      übernommen ("carry forward") und in fetch_log.csv vermerkt - so
-      entsteht nie eine Zeile mit Lücke, solange es einen Vorwert gibt.
+      fehlt) wird der letzte bekannte Kurs übernommen ("carry forward") und in
+      fetch_log.csv vermerkt - so entsteht nie eine Zeile mit Lücke, solange es
+      einen Vorwert gibt.
     - Läuft ein zweiter Abruf in derselben ISO-Kalenderwoche (z. B. ein
       manueller Re-Dispatch), wird die bestehende Zeile aktualisiert statt
       eine Dublette anzuhängen - das macht "wöchentlich" robust unabhängig
       vom genauen Wochentag des Laufs.
+
+    **Teilabrufe derselben Woche sind additiv (#99).** Der Wochenabruf läuft
+    seit #99 an zwei aufeinanderfolgenden Tagen mit je einer Ticker-Teilmenge
+    (Alpha-Vantage-Tageslimit, siehe ``sources.alphavantage.batch_tickers``).
+    Existiert für die Zielwoche bereits eine Zeile, gilt für einen Ticker ohne
+    frischen Kurs deshalb zuerst der **bereits in dieser Zeile stehende Wert**
+    und erst danach der Carry-Forward aus früheren Wochen. Ohne diesen Vorrang
+    würde der zweite Teilabruf die am Vortag frisch geholten Kurse des ersten
+    Batches auf den Stand der Vorwoche zurücksetzen.
+
+    ``angefragte_ticker`` benennt die Ticker, für die dieser Lauf zuständig
+    war (Default: alle). Nur für sie wird ein fehlender Kurs in fetch_log.csv
+    protokolliert - ein Ticker aus dem jeweils anderen Batch ist nicht
+    "eingefroren", sondern kommt schlicht am anderen Wochentag, und ein
+    Log-Eintrag dafür würde im Dashboard (#42) eine Kurslücke melden, die es
+    nicht gibt.
+
+    Das Zeilendatum bleibt bei einer bestehenden Wochenzeile das **frühere**
+    der beiden Daten: für die ISO-Wochen-Einordnung zählt ohnehin nur die
+    Kalenderwoche, und so hängt die Historie nicht davon ab, welcher der
+    beiden Läufe zuletzt durchlief.
     """
     _ensure_files(data_dir)
     existing_rows = read_price_history(data_dir)
@@ -172,12 +195,29 @@ def record_week(
             continue
         last_known.update(r.prices)
 
+    # Bereits in DIESER Woche stehende Kurse (aus einem frueheren Teilabruf
+    # derselben Woche) - haben Vorrang vor last_known, siehe Docstring.
+    bereits_diese_woche: dict[str, Decimal] = (
+        dict(existing_rows[same_week_index].prices) if same_week_index is not None else {}
+    )
+    zustaendig = set(TICKERS) if angefragte_ticker is None else set(angefragte_ticker)
+
+    # Bei einer bestehenden Wochenzeile gewinnt das fruehere Datum: welcher der
+    # beiden Wochenlaeufe zuletzt lief, soll die Historie nicht verschieben.
+    row_date = as_of if same_week_index is None else min(as_of, existing_rows[same_week_index].date)
+
     new_prices: dict[str, Decimal] = {}
     log_entries: list[list[str]] = []
     for ticker in TICKERS:
         quote = quotes.get(ticker)
         if quote is not None and quote.status == "ok" and quote.price is not None:
             new_prices[ticker] = Decimal(str(quote.price))
+            continue
+
+        if ticker in bereits_diese_woche:
+            # Frischer Kurs aus einem frueheren Teilabruf derselben Woche -
+            # weder ueberschreiben noch als Kursluecke protokollieren.
+            new_prices[ticker] = bereits_diese_woche[ticker]
             continue
 
         source = quote.source if quote else ""
@@ -189,26 +229,28 @@ def record_week(
                 if rate_limited
                 else "Kein aktueller Kurs verfuegbar, letzter bekannter Kurs uebernommen"
             )
-            log_entries.append([as_of.isoformat(), ticker, "carried_forward", source, note])
+            if ticker in zustaendig:
+                log_entries.append([row_date.isoformat(), ticker, "carried_forward", source, note])
         else:
             note = (
                 "Rate-Limit der Quelle erreicht, kein historischer Kurs verfuegbar"
                 if rate_limited
                 else "Kein aktueller und kein historischer Kurs verfuegbar"
             )
-            log_entries.append([as_of.isoformat(), ticker, "missing", source, note])
+            if ticker in zustaendig:
+                log_entries.append([row_date.isoformat(), ticker, "missing", source, note])
 
     if same_week_index is not None:
-        existing_rows[same_week_index] = PriceRow(date=as_of, prices=new_prices)
+        existing_rows[same_week_index] = PriceRow(date=row_date, prices=new_prices)
     else:
-        existing_rows.append(PriceRow(date=as_of, prices=new_prices))
+        existing_rows.append(PriceRow(date=row_date, prices=new_prices))
     existing_rows.sort(key=lambda r: r.date)
 
     _write_price_history(existing_rows, data_dir)
     if log_entries:
         _append_fetch_log(log_entries, data_dir)
 
-    return PriceRow(date=as_of, prices=new_prices)
+    return PriceRow(date=row_date, prices=new_prices)
 
 
 def _write_price_history(rows: list[PriceRow], data_dir: Path) -> None:

--- a/src/boersenspiel/instruments.py
+++ b/src/boersenspiel/instruments.py
@@ -246,6 +246,55 @@ INSTRUMENTS: dict[str, Instrument] = {
             thesaurierend=True,
             ter=Decimal("0.0046"),
         ),
+        # --- Dividende und Value (#99) ------------------------------------------
+        # Zwei Faktor-/Stil-Bausteine, die es im bisherigen Instrumentenset gar
+        # nicht gab: eine gezielte Dividenden- und eine gezielte
+        # Value-Ausrichtung. `Instrument.dividendenrendite` (#74) modelliert nur
+        # die Ausschuettung der ohnehin gehaltenen Instrumente - eine
+        # Dividendenstrategie ist etwas anderes als ein hoch ausschuettendes
+        # Instrument in einem beliebigen Topf.
+        #
+        # Beide bewusst als XETRA-Symbol in EUR (Konvention seit #64): kein
+        # zusaetzlicher FX-Request, und das Waehrungsproblem aus #62 entsteht
+        # fuer sie gar nicht erst. Am 28.08.2026 per SYMBOL_SEARCH/GLOBAL_QUOTE
+        # geprueft - beide loesen auf XETRA in EUR auf.
+        #
+        # Der im Issue vorgeschlagene Value-Ticker `IUVL` existiert bei Alpha
+        # Vantage NICHT (SYMBOL_SEARCH liefert keinen Treffer); die
+        # EUR-/XETRA-Notierung desselben iShares-Fonds laeuft unter `IS3S.DEX`
+        # (die LSE-Notierung `IWVL.LON` waere USD und damit FX-pflichtig).
+        # Entsprechend ist auch die ISIN die der tatsaechlich an der XETRA
+        # gehandelten Acc-Anteilsklasse (IE00BP3QZB59), nicht die im Issue
+        # vorgeschlagene.
+        #
+        # Historie (per TIME_SERIES_MONTHLY geprueft): ISPA ab 2009-11, IS3S ab
+        # 2014-11. Value-Faktor-ETFs sind wie im Issue vermutet juenger als die
+        # uebrigen Instrumente - die Strategie startet nach der F4-Regel
+        # (#63, _real_investierbarer_zeitraum) deshalb fruehestens Ende 2014.
+        Instrument(
+            "ISPA",
+            "Dividenden-ETF global (iShares STOXX Global Select Dividend 100, aussch.)",
+            "DE000A0F5UH1",
+            # Haelt 100 dividendenstarke Aktien -> Aktienfonds-Teilfreistellung.
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            ausschuettend=True,
+            # Der ganze Zweck des Fonds: eine deutlich ueber dem Markt liegende
+            # Ausschuettung (justETF/extraETF, Stand 2026 rund 5%). Bei einer
+            # Dividendenstrategie ist das kein Nebeneffekt, sondern der
+            # wesentliche Teil des Gesamtertrags - der Platzhalter aus #74 waere
+            # hier besonders irrefuehrend.
+            dividendenrendite=Decimal("0.050"),
+            ter=Decimal("0.0046"),
+        ),
+        Instrument(
+            "IS3S",
+            "Value-Faktor-ETF (iShares Edge MSCI World Value Factor, thes.)",
+            "IE00BP3QZB59",
+            teilfreistellung=_TEILFREISTELLUNG_AKTIENFONDS,
+            # USD (Acc)-Anteilsklasse, an der XETRA in EUR gehandelt.
+            thesaurierend=True,
+            ter=Decimal("0.0030"),
+        ),
     ]
 }
 

--- a/src/boersenspiel/sources/alphavantage.py
+++ b/src/boersenspiel/sources/alphavantage.py
@@ -2,11 +2,12 @@
 Scraping - deutlich zuverlässiger für GitHub Actions als yfinance, das
 wiederholt an Yahoos Crumb/Cookie-Authentifizierung scheiterte (siehe README).
 
-Free-Tier-Limits: 25 Requests/Tag, max. 1 Request/Sekunde. Bei aktuell 17
-Tickern (7 Barbell-Basisinstrumente + 10 Einzelaktien-Satellit) einmal
-wöchentlich noch unproblematisch, lässt aber kaum noch Spielraum für
-zusätzliche manuelle Abrufe am selben Tag; zwischen den Requests wird ein
-kleiner Sleep eingehalten, um das Sekundenlimit nicht zu reißen.
+Free-Tier-Limits: 25 Requests/Tag, max. 1 Request/Sekunde. Die aktuell 26
+Ticker brauchen 27 Requests und passen damit nicht mehr in einen Tag - der
+wöchentliche Abruf läuft deshalb seit #99 in zwei Batches an zwei
+aufeinanderfolgenden Tagen (siehe ``batch_tickers`` weiter unten). Zwischen
+den Requests wird ein kleiner Sleep eingehalten, um das Sekundenlimit nicht zu
+reißen.
 
 Läuft in GitHub Actions gegen die reine REST-API (nicht über den
 Alpha-Vantage-MCP-Server, der nur innerhalb einer Claude-Session verfügbar
@@ -73,11 +74,55 @@ ALPHAVANTAGE_SYMBOLS: dict[str, str] = {
     "IBCI": "IBCI.DEX",
     "IQQ6": "IQQ6.DEX",
     "EXXY": "EXXY.DEX",
+    # Dividende und Value (#99) - ebenfalls XETRA/EUR. Am 28.08.2026 per
+    # SYMBOL_SEARCH und GLOBAL_QUOTE geprueft. Der im Issue vorgeschlagene
+    # Value-Ticker "IUVL" loest bei Alpha Vantage NICHT auf; die XETRA-Notierung
+    # desselben Fonds laeuft unter "IS3S.DEX" (die Alternative "IWVL.LON" waere
+    # USD-notiert und damit FX-pflichtig, siehe #62).
+    "ISPA": "ISPA.DEX",
+    "IS3S": "IS3S.DEX",
 }
 
 # Ticker, deren Alpha-Vantage-Symbol in USD notiert - Kurs wird bei jedem
 # Abruf per aktuellem EUR/USD-Kurs in EUR umgerechnet.
 USD_TICKERS: frozenset[str] = frozenset({"LITE", "BYDDY", "SEDG", "TSLA", "PLTR", "MSTR", "RIVN", "KO", "RHHBY"})
+
+# --- Wochenabruf in zwei Batches (#99) ---------------------------------------
+#
+# Alpha Vantages Free Tier erlaubt 25 Requests pro Tag und API-Key. Seit den
+# beiden Instrumenten aus #99 braucht ein Abruf ALLER Ticker 27 Requests
+# (26 Ticker + 1x CURRENCY_EXCHANGE_RATE) und passt damit nicht mehr in einen
+# einzigen Tag. Der Wochenabruf laeuft deshalb an zwei aufeinanderfolgenden
+# Tagen, jeder Lauf holt nur seinen Batch (siehe scripts/run_fetch.py --batch
+# und .github/workflows/weekly-update.yml). Jeder Ticker wird weiterhin genau
+# einmal pro Woche aktualisiert, nur eben nicht mehr alle am selben Wochentag;
+# history_store.record_week() mischt den zweiten Teilabruf additiv in die
+# bereits geschriebene Zeile derselben ISO-Woche.
+#
+# Die Aufteilung wird BEWUSST abgeleitet statt als zwei feste Listen
+# hinterlegt: Batch 1 sind genau die Ticker, die einen Fremdwaehrungs- oder
+# Krypto-Endpunkt brauchen (alle USD_TICKERS plus BTC-EUR), Batch 2 der Rest.
+# Damit faellt der EUR/USD-Request zwangslaeufig nur in einem der beiden Laeufe
+# an - er wird in fetch() einmal je Aufruf geholt und gilt fuer alle
+# USD-Ticker gemeinsam. Ein kuenftig ergaenztes Instrument landet ausserdem
+# automatisch im richtigen Batch, statt eine hinterlegte Liste stillschweigend
+# unvollstaendig zu lassen.
+#
+# Request-Bilanz aktuell: Batch 1 = 9 USD-Ticker + FX + BTC-EUR = 11 Requests,
+# Batch 2 = 16 EUR/XETRA-Ticker = 16 Requests. Beide klar unter 25; der
+# Spielraum liegt in Batch 2 (siehe tests/test_backfill_history.py).
+FETCH_BATCHES = (1, 2)
+
+
+def batch_tickers(tickers: list[str], batch: int) -> list[str]:
+    """Die Teilmenge von ``tickers``, die im angegebenen Wochen-Batch abgerufen
+    wird. ``batch`` ausserhalb von ``FETCH_BATCHES`` ist ein Programmierfehler."""
+    if batch not in FETCH_BATCHES:
+        raise ValueError(f"Unbekannter Batch {batch!r}, erlaubt sind {FETCH_BATCHES}")
+    fremdwaehrung = [t for t in tickers if t in USD_TICKERS or t == "BTC-EUR"]
+    if batch == 1:
+        return fremdwaehrung
+    return [t for t in tickers if t not in fremdwaehrung]
 
 _REQUEST_INTERVAL_SECONDS = 1.1
 

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -174,6 +174,7 @@ RUBRIK_CHARTTECHNIK = "Charttechnik"
 RUBRIK_WEITERE_ANALYSEN = "Weitere Analysen"
 RUBRIK_REFERENZ = "Referenz"
 RUBRIK_KLASSISCHE_PORTFOLIOS = "Klassische Portfolios"
+RUBRIK_FAKTOR = "Faktor-Strategien"
 
 # --- Strategie 1: Barbell 20/80 (Pflichtenheft v2.0) -----------------------
 
@@ -552,6 +553,81 @@ PERMANENT_PORTFOLIO = Strategy(
     ),
 )
 
+# --- Strategie 8: Dividende & Value (#99) -----------------------------------
+#
+# Dividenden-Investing und Value/Faktor-Investing gehoeren zu den bekanntesten
+# Boersenstrategien ueberhaupt - im bisherigen Instrumentenset hatte aber kein
+# einziges Instrument eine gezielte Dividenden- oder Value-Ausrichtung.
+# `Instrument.dividendenrendite` (#74) modelliert nur die Ausschuettung der
+# ohnehin gehaltenen Instrumente; das ist etwas anderes als ein Portfolio, das
+# nach genau diesem Merkmal AUSGEWAEHLT wird.
+#
+# Anders als das 60/40- und das Permanent Portfolio (#98) liess sich das nicht
+# aus vorhandenen Instrumenten bauen: ISPA und IS3S sind dafuer neu
+# dazugekommen (siehe instruments.py) - und mit ihnen die Aufteilung des
+# Wochenabrufs auf zwei Tage, weil das Alpha-Vantage-Tagesbudget vorher exakt
+# ausgeschoepft war (siehe sources/alphavantage.py, `batch_tickers`).
+#
+# Umgesetzt ist die im Issue vorgeschlagene KOMBINIERTE Variante (ein
+# Strategie-Eintrag, zwei gleich grosse Toepfe) statt zweier getrennter
+# Strategien - die Vergleichstabelle bleibt damit kompakt. Der isolierte
+# Effekt jedes der beiden Faktoren bleibt trotzdem sichtbar: die Detailseite
+# weist die Topf-Gewichtung Ist/Ziel je Topf aus. Sollen "Dividende" und
+# "Value" spaeter als eigene Zeilen verglichen werden, sind das zwei weitere
+# Eintraege in STRATEGIES ohne jede Aenderung an Engine oder Dashboard.
+#
+# Eigene Rubrik statt RUBRIK_KLASSISCHE_PORTFOLIOS: 60/40 und Permanent
+# Portfolio teilen ueber ANLAGEKLASSEN auf (Aktien/Anleihen/Gold/Cash), diese
+# Strategie dagegen innerhalb derselben Anlageklasse nach einem
+# AUSWAHLMERKMAL der Aktien. Das ist der inhaltlich andere Ansatz, und die
+# Rubrik ist der Platz fuer weitere Faktoren (Quality, Low-Vol, Momentum als
+# eigenes Instrument), die dieses Issue bewusst ausklammert.
+#
+# Erster Ansatz wie bei allen Strategien: die 50/50-Aufteilung ist die
+# naheliegende Gleichgewichtung, nicht fuer dieses Instrumentenset optimiert
+# oder gebacktestet. IS3S hat erst ab November 2014 Kurse - die Strategie
+# startet nach der F4-Regel (#63) entsprechend spaeter als die uebrigen.
+
+DIVIDENDE_UND_VALUE = Strategy(
+    name="Dividende & Value",
+    rubrik=RUBRIK_FAKTOR,
+    startkapital=Decimal("10000"),
+    toepfe=[
+        Topf(
+            name="Topf A - Dividende",
+            gewicht_gesamt=Decimal("0.50"),
+            sub_gewichte={"ISPA": Decimal("1")},
+        ),
+        Topf(
+            name="Topf B - Value",
+            gewicht_gesamt=Decimal("0.50"),
+            sub_gewichte={"IS3S": Decimal("1")},
+        ),
+    ],
+    ziel_topf="Topf A - Dividende",
+    ziel_gewicht=Decimal("0.50"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
+    beschreibung=(
+        "Zwei der meistdiskutierten Aktien-Stile zu gleichen Teilen: 50% "
+        "Dividendenstrategie (STOXX Global Select Dividend 100 - die 100 "
+        "dividendenstärksten Titel weltweit) und 50% Value-Faktor (MSCI World "
+        "Value - günstig bewertete Titel des Weltindex). Anders als bei 60/40 "
+        "oder dem Permanent Portfolio wird hier nicht zwischen Anlageklassen "
+        "aufgeteilt, sondern innerhalb der Aktien nach einem Auswahlmerkmal. "
+        "Rebalancing nach der 5/25-Regel."
+    ),
+    beschreibung_en=(
+        "Two of the most widely discussed equity styles in equal parts: 50% "
+        "dividend strategy (STOXX Global Select Dividend 100 - the 100 highest "
+        "dividend-paying stocks worldwide) and 50% value factor (MSCI World "
+        "Value - the cheaply valued names in the world index). Unlike 60/40 or "
+        "the Permanent Portfolio, this splits within equities by a selection "
+        "criterion rather than across asset classes. Rebalances using the 5/25 "
+        "rule."
+    ),
+)
+
 STRATEGIES: list[Strategy] = [
     BARBELL_20_80,
     BARBELL_30_70,
@@ -560,6 +636,7 @@ STRATEGIES: list[Strategy] = [
     SP500_BENCHMARK,
     PORTFOLIO_60_40,
     PERMANENT_PORTFOLIO,
+    DIVIDENDE_UND_VALUE,
 ]
 
 STRATEGIES_BY_NAME: dict[str, Strategy] = {s.name: s for s in STRATEGIES}

--- a/tests/test_backfill_history.py
+++ b/tests/test_backfill_history.py
@@ -20,6 +20,11 @@ import backfill_history as bh  # noqa: E402
 
 from boersenspiel.history_store import read_price_history  # noqa: E402
 from boersenspiel.instruments import TICKERS  # noqa: E402
+from boersenspiel.sources.alphavantage import (  # noqa: E402
+    FETCH_BATCHES,
+    USD_TICKERS,
+    batch_tickers,
+)
 
 
 class _FakeSource:
@@ -416,41 +421,75 @@ def test_mitgelieferte_fx_datei_deckt_die_luecke_bis_zum_api_beginn():
     assert fx[date(2010, 7, 9)] == pytest.approx(0.791327, abs=1e-6)
 
 
-# --- Request-Budget (#64) -----------------------------------------------------
+# --- Request-Budget (#64, seit #99 je Batch) ---------------------------------
 #
-# Alpha Vantages Free Tier erlaubt 25 Requests pro Tag und API-Key. Mit den
-# sieben Datenreihen aus #64 sind beide Laeufe bei exakt 25 - es gibt keinen
-# Puffer mehr. Ein weiteres Instrument macht jeden Lauf unmoeglich, und ein
-# nicht aufloesbares Symbol bricht den Backfill ab, ohne dass die bereits
-# verbrauchten Requests zurueckkommen. Deshalb als Test statt als Kommentar.
+# Alpha Vantages Free Tier erlaubt 25 Requests pro Tag und API-Key. Bis #64
+# passten Backfill UND Wochenabruf in je genau 25 Requests - ohne Puffer. Mit
+# den beiden Instrumenten aus #99 sind es 27, ein Ein-Tages-Lauf ist damit
+# nicht mehr moeglich: beide Laeufe holen ihre Ticker seither in zwei Batches
+# an zwei aufeinanderfolgenden Tagen (siehe sources/alphavantage.py
+# `batch_tickers`, scripts/run_fetch.py --batch).
+#
+# Der Regressionsschutz bleibt derselbe wie vorher, nur mit der neuen
+# Zaehlweise: nicht mehr "die Gesamtzahl passt in einen Tag", sondern "JEDER
+# EINZELNE Batch passt in einen Tag". Ein weiteres Instrument darf keinen der
+# beiden Batches ueber das Limit heben - und ein nicht aufloesbares Symbol
+# bricht den Backfill weiterhin ab, ohne die verbrauchten Requests
+# zurueckzugeben.
 
 _ALPHAVANTAGE_TAGESLIMIT = 25
 
 
-def _backfill_requests() -> int:
-    """1x FX_WEEKLY + 1x DIGITAL_CURRENCY_WEEKLY + je 1x TIME_SERIES pro
+def _backfill_requests(tickers: list[str]) -> int:
+    """1x FX_WEEKLY (nur wenn USD-Ticker oder BTC dabei sind) + 1x
+    DIGITAL_CURRENCY_WEEKLY (nur mit BTC) + je 1x TIME_SERIES pro
     nicht-Krypto-Ticker."""
-    return 1 + 1 + len([t for t in TICKERS if t != "BTC-EUR"])
+    braucht_fx = any(t in USD_TICKERS for t in tickers) or "BTC-EUR" in tickers
+    return int(braucht_fx) + int("BTC-EUR" in tickers) + len([t for t in tickers if t != "BTC-EUR"])
 
 
-def _wochenabruf_requests() -> int:
-    """1x CURRENCY_EXCHANGE_RATE (einmal je fetch(), nicht je Ticker) + je 1x
-    GLOBAL_QUOTE bzw. Krypto-Endpunkt pro Ticker."""
-    return 1 + len(TICKERS)
+def _wochenabruf_requests(tickers: list[str]) -> int:
+    """1x CURRENCY_EXCHANGE_RATE (einmal je fetch(), nicht je Ticker, und nur
+    wenn USD-Ticker dabei sind) + je 1x GLOBAL_QUOTE bzw. Krypto-Endpunkt pro
+    Ticker."""
+    return int(any(t in USD_TICKERS for t in tickers)) + len(tickers)
 
 
-def test_backfill_passt_in_das_tageslimit():
-    assert _backfill_requests() <= _ALPHAVANTAGE_TAGESLIMIT, (
-        f"Backfill braucht {_backfill_requests()} Requests, erlaubt sind "
-        f"{_ALPHAVANTAGE_TAGESLIMIT}. Ein Instrument entfernen oder Premium-Key."
-    )
+def test_jeder_backfill_batch_passt_in_das_tageslimit():
+    for batch in FETCH_BATCHES:
+        tickers = batch_tickers(TICKERS, batch)
+        assert _backfill_requests(tickers) <= _ALPHAVANTAGE_TAGESLIMIT, (
+            f"Backfill-Batch {batch} braucht {_backfill_requests(tickers)} Requests, "
+            f"erlaubt sind {_ALPHAVANTAGE_TAGESLIMIT}. Ein Instrument entfernen, "
+            f"die Batch-Aufteilung anpassen oder Premium-Key."
+        )
 
 
-def test_wochenabruf_passt_in_das_tageslimit():
-    assert _wochenabruf_requests() <= _ALPHAVANTAGE_TAGESLIMIT, (
-        f"Wochenabruf braucht {_wochenabruf_requests()} Requests, erlaubt sind "
-        f"{_ALPHAVANTAGE_TAGESLIMIT}."
-    )
+def test_jeder_wochenabruf_batch_passt_in_das_tageslimit():
+    for batch in FETCH_BATCHES:
+        tickers = batch_tickers(TICKERS, batch)
+        assert _wochenabruf_requests(tickers) <= _ALPHAVANTAGE_TAGESLIMIT, (
+            f"Wochenabruf-Batch {batch} braucht {_wochenabruf_requests(tickers)} "
+            f"Requests, erlaubt sind {_ALPHAVANTAGE_TAGESLIMIT}."
+        )
+
+
+def test_die_batches_decken_jeden_ticker_genau_einmal_ab():
+    """Sonst wuerde ein Ticker entweder nie aktualisiert oder doppelt abgerufen
+    - Letzteres kostet einen Request aus dem knappen Tagesbudget."""
+    zusammen = [t for batch in FETCH_BATCHES for t in batch_tickers(TICKERS, batch)]
+    assert sorted(zusammen) == sorted(TICKERS)
+    assert len(zusammen) == len(set(zusammen))
+
+
+def test_nur_ein_batch_braucht_den_fx_request():
+    """Der EUR/USD-Kurs wird einmal je fetch()-Aufruf geholt und gilt fuer alle
+    USD-Ticker gemeinsam. Verteilten sich die USD-Ticker ueber beide Batches,
+    kostete derselbe Kurs zweimal einen Request."""
+    mit_usd = [
+        batch for batch in FETCH_BATCHES if any(t in USD_TICKERS for t in batch_tickers(TICKERS, batch))
+    ]
+    assert len(mit_usd) == 1
 
 
 def test_neue_datenreihen_sind_in_euro_notiert():

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -25,7 +25,9 @@ from boersenspiel.dashboard import (
     _build_strategy_view,
     _cagr_pct,
     _ERSATZBOND_TICKER,
+    _cash_anteil_max,
     _gemeinsamer_beginn,
+    _hat_kurshistorie,
     _downside_deviation,
     _f,
     _GELDMARKT_TICKER,
@@ -50,7 +52,7 @@ from boersenspiel.dashboard import (
     _ZINS_MIN_WOCHEN,
     build_dashboard,
 )
-from boersenspiel.engine import simulate
+from boersenspiel.engine import ValuePoint, simulate
 from boersenspiel.history_store import FetchLogEntry, PriceRow
 from boersenspiel.instruments import TICKERS
 from boersenspiel.strategies import (
@@ -818,24 +820,35 @@ def test_praemissen_seite_zeigt_null_prozent_cash_wenn_immer_alles_investiert_is
     assert html.count(">0.0<") >= 2
 
 
-def test_praemissen_seite_zeigt_cash_hoechststand_wenn_kein_zielinstrument_handelbar(tmp_path: Path):
-    # T2 hat in KEINER Zeile einen Kurs -> das Kapital dieses (isolierten)
-    # Topfs bleibt vollstaendig geparkt (pending_cash), da handelbare_gewichte()
-    # nichts zum Umlegen findet.
-    strategie = Strategy(
-        name="Nur T2",
-        startkapital=Decimal("1000"),
-        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={"T2": Decimal("1")})],
-        ziel_topf="Topf",
-        ziel_gewicht=Decimal("1"),
-        rebalancing_schwelle_pp=Decimal("1000"),
-    )
-    build_dashboard(_rows(), [strategie], output_path=tmp_path / "index.html")
-    html = (tmp_path / "praemissen.html").read_text(encoding="utf-8")
+def test_cash_anteil_max_findet_hoechststand_und_datum():
+    """Der Wert, den die Praemissen-Seite je Strategie ausweist: der groesste
+    Anteil technischen ``pending_cash`` (Kapital ohne handelbares Ziel) samt
+    Datum.
 
-    assert "hält aktuell nicht jede" in html
-    assert "100.0" in html
-    assert "2024-01-01" in html.split("Cash und ungenutztes Kapital", 1)[1]
+    Bis #99 lief dieser Test ueber ``build_dashboard()`` mit einer Strategie,
+    deren einziges Instrument in KEINER Kurszeile vorkam. Genau solche
+    Strategien laesst das Dashboard seither weg (siehe ``_hat_kurshistorie``) -
+    "ein Instrument, das es nie gab" ist kein Cash-Fall, sondern eine noch
+    nicht befuellte Datenreihe. Der Cash-Hoechststand wird deshalb direkt
+    geprueft, mit einer Wertreihe, in der ein Teil des Kapitals
+    voruebergehend nicht investiert ist."""
+    punkte = [
+        ValuePoint(date(2024, 1, 1), Decimal("1000"), {"T1": Decimal("400")}, {}, {}, {}),
+        ValuePoint(date(2024, 1, 8), Decimal("1000"), {"T1": Decimal("1000")}, {}, {}, {}),
+    ]
+    pct, datum = _cash_anteil_max(punkte)
+    assert pct == pytest.approx(60.0)
+    assert datum == "2024-01-01"
+
+
+def test_praemissen_seite_weist_den_cash_hoechststand_je_strategie_aus(tmp_path: Path):
+    build_dashboard(_rows(), ZWEI_STRATEGIEN, output_path=tmp_path / "index.html")
+    abschnitt = (tmp_path / "praemissen.html").read_text(encoding="utf-8").split(
+        "Cash und ungenutztes Kapital", 1
+    )[1]
+
+    for strategie in ZWEI_STRATEGIEN:
+        assert strategie.name in abschnitt
 
 
 # --- F6b/c (#63): CAGR als Leitkennzahl -------------------------------------------
@@ -1695,3 +1708,41 @@ def test_ohne_zusaetzliche_historie_kein_schalter(tmp_path: Path):
     # In den Datenzeilen steht kein Zweitwert (die Spaltenkoepfe tragen ihre
     # Zweitbeschriftung dagegen immer - ohne Schalter greift sie nie).
     assert "data-erweitert=" not in _summary_tabelle(tmp_path).split("<tbody>", 1)[1]
+
+
+# --- Strategien ohne Kursdaten (#99) -----------------------------------------
+#
+# Ein frisch ergaenztes Instrument steht bis zum naechsten Kursabruf/Backfill
+# mit leerer Spalte in price_history.csv. Seine Strategie darf dann nicht mit
+# einer flachen 0%-Linie in der Vergleichstabelle stehen.
+
+
+def _strategie_auf(ticker: str, name: str) -> Strategy:
+    return Strategy(
+        name=name,
+        startkapital=Decimal("1000"),
+        toepfe=[Topf(name="Topf", gewicht_gesamt=Decimal("1"), sub_gewichte={ticker: Decimal("1")})],
+        ziel_topf="Topf",
+        ziel_gewicht=Decimal("1"),
+        rebalancing_schwelle_pp=Decimal("1000"),
+    )
+
+
+def test_hat_kurshistorie_erkennt_instrumente_ohne_kurse():
+    assert _hat_kurshistorie(_rows(), _strategie_auf("T1", "vorhanden"))
+    assert not _hat_kurshistorie(_rows(), _strategie_auf("NEU", "frisch ergaenzt"))
+
+
+def test_strategie_ohne_kursdaten_erscheint_nicht_im_dashboard(tmp_path: Path):
+    ohne_daten = _strategie_auf("NEU", "Z: Ohne Kursdaten")
+    build_dashboard(_rows(), [*ZWEI_STRATEGIEN, ohne_daten], tmp_path / "index.html")
+
+    assert "Z: Ohne Kursdaten" not in _summary_tabelle(tmp_path)
+    assert not (tmp_path / f"{_slug(ohne_daten.name)}.html").exists()
+    # Die uebrigen Strategien bleiben unberuehrt.
+    assert "A: Verdoppler" in _summary_tabelle(tmp_path)
+
+
+def test_dashboard_ohne_jede_bewertbare_strategie_bricht_ab(tmp_path: Path):
+    with pytest.raises(ValueError):
+        build_dashboard(_rows(), [_strategie_auf("NEU", "Z: Ohne Kursdaten")], tmp_path / "index.html")

--- a/tests/test_dividende_value.py
+++ b/tests/test_dividende_value.py
@@ -1,0 +1,108 @@
+"""Tests für die Strategie "Dividende & Value" und ihre zwei neuen Instrumente (#99).
+
+Dividenden- und Value-Investing gehören zu den bekanntesten Börsenstrategien;
+im bisherigen Instrumentenset gab es dafür kein einziges gezielt
+ausgerichtetes Instrument. ``ISPA`` (Dividende) und ``IS3S`` (Value-Faktor)
+sind deshalb neu - und mit ihnen die Aufteilung des Wochenabrufs auf zwei Tage,
+weil das Alpha-Vantage-Tagesbudget vorher exakt ausgeschöpft war (die
+Batch-Tests dazu stehen in ``tests/test_backfill_history.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from boersenspiel.engine import simulate
+from boersenspiel.history_store import PriceRow
+from boersenspiel.instruments import INSTRUMENTS
+from boersenspiel.sources.alphavantage import ALPHAVANTAGE_SYMBOLS, USD_TICKERS
+from boersenspiel.strategies import (
+    DIVIDENDE_UND_VALUE,
+    RUBRIK_FAKTOR,
+    STRATEGIES,
+)
+
+
+def test_strategie_ist_registriert():
+    assert DIVIDENDE_UND_VALUE in STRATEGIES
+    assert DIVIDENDE_UND_VALUE.rubrik == RUBRIK_FAKTOR
+
+
+def test_ticker_gewichte_summieren_zu_eins():
+    assert sum(DIVIDENDE_UND_VALUE.alle_ticker_gewichte().values()) == Decimal("1")
+
+
+def test_zwei_gleich_grosse_toepfe_je_ein_instrument():
+    assert DIVIDENDE_UND_VALUE.alle_ticker_gewichte() == {
+        "ISPA": Decimal("0.50"),
+        "IS3S": Decimal("0.50"),
+    }
+    for topf in DIVIDENDE_UND_VALUE.toepfe:
+        assert topf.gewicht_gesamt == Decimal("0.50")
+        assert sum(topf.sub_gewichte.values()) == Decimal("1")
+
+
+def test_nutzt_die_5_25_regel_wie_die_uebrigen_neueren_strategien():
+    assert DIVIDENDE_UND_VALUE.rebalancing_schwelle_pp == Decimal("5")
+    assert DIVIDENDE_UND_VALUE.rebalancing_schwelle_relativ == Decimal("0.25")
+
+
+def test_neue_instrumente_haben_ein_symbol_mapping():
+    """Ohne Eintrag in ALPHAVANTAGE_SYMBOLS liefert der Abruf stillschweigend
+    "missing" - der Ticker stünde dann dauerhaft leer in der Historie."""
+    for ticker in DIVIDENDE_UND_VALUE.alle_ticker_gewichte():
+        assert ticker in ALPHAVANTAGE_SYMBOLS
+
+
+def test_neue_instrumente_sind_in_euro_notiert():
+    """Beide sind bewusst XETRA-Symbole (Konvention seit #64). Landete eines in
+    USD_TICKERS, bräuchte es die Umrechnung - und hätte damit vor November 2014
+    gar keinen Kurs, weil FX_WEEKLY erst dann beginnt (#62)."""
+    for ticker in DIVIDENDE_UND_VALUE.alle_ticker_gewichte():
+        assert ticker not in USD_TICKERS
+        assert ALPHAVANTAGE_SYMBOLS[ticker].endswith(".DEX")
+
+
+def test_steuerattribute_der_neuen_instrumente():
+    """Gegen die Fondsanbieter-Angaben belegt (siehe Kommentar in
+    instruments.py): ISPA ist die ausschüttende Dividenden-Anteilsklasse mit
+    einer deutlich über dem Markt liegenden Ausschüttung, IS3S die
+    thesaurierende Acc-Anteilsklasse. Beide sind Aktienfonds und bekommen
+    damit die 30% Teilfreistellung."""
+    ispa = INSTRUMENTS["ISPA"]
+    assert ispa.ausschuettend is True
+    assert ispa.thesaurierend is False
+    assert ispa.dividendenrendite == Decimal("0.050")
+    assert ispa.teilfreistellung == Decimal("0.30")
+    assert ispa.ter > 0
+
+    is3s = INSTRUMENTS["IS3S"]
+    assert is3s.thesaurierend is True
+    assert is3s.ausschuettend is False
+    assert is3s.teilfreistellung == Decimal("0.30")
+    assert is3s.ter > 0
+
+
+def _rows() -> list[PriceRow]:
+    return [
+        PriceRow(date(2024, 1, 1), {"ISPA": Decimal("30"), "IS3S": Decimal("40")}),
+        PriceRow(date(2024, 6, 1), {"ISPA": Decimal("33"), "IS3S": Decimal("44")}),
+    ]
+
+
+def test_runs_end_to_end():
+    result = simulate(_rows(), DIVIDENDE_UND_VALUE)
+    assert result.strategy_name == "Dividende & Value"
+    assert result.value_history[-1].total_value > 0
+
+
+def test_bestehende_strategien_halten_die_neuen_instrumente_nicht():
+    """Regressionsschutz analog zu #64: die neuen Datenreihen dürfen die
+    veröffentlichten Kennzahlen der bereits bestehenden Strategien nicht
+    verschieben."""
+    neu = {"ISPA", "IS3S"}
+    for strategy in STRATEGIES:
+        if strategy is DIVIDENDE_UND_VALUE:
+            continue
+        assert not (neu & set(strategy.alle_ticker_gewichte()))

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -28,8 +28,85 @@ def test_record_week_updates_same_iso_week_instead_of_duplicating(tmp_path: Path
 
     rows = read_price_history(tmp_path)
     assert len(rows) == 1
-    assert rows[0].date == date(2024, 1, 3)
+    # Seit #99 gewinnt bei einer bestehenden Wochenzeile das FRUEHERE Datum:
+    # der Wochenabruf laeuft an zwei Tagen, und welcher der beiden Laeufe
+    # zuletzt durchlief, soll die Historie nicht verschieben. Fuer die
+    # ISO-Wochen-Einordnung zaehlt ohnehin nur die Kalenderwoche.
+    assert rows[0].date == date(2024, 1, 1)
     assert rows[0].prices["EUNL"] == Decimal("82.0")
+
+
+# --- Teilabrufe derselben Woche (#99) ---------------------------------------
+#
+# Der Wochenabruf laeuft seit #99 an zwei aufeinanderfolgenden Tagen mit je
+# einer Ticker-Teilmenge (Alpha-Vantage-Tageslimit). Ohne den Merge-Modus in
+# record_week() wuerde der zweite Teilabruf die frisch geholten Kurse des
+# ersten auf den Stand der Vorwoche zurueckwerfen - genau der Fall, den diese
+# Tests festhalten.
+
+
+def test_zweiter_teilabruf_behaelt_die_kurse_des_ersten(tmp_path: Path):
+    # Vorwoche: beide Ticker haben einen (alten) Kurs, an dem ein fehlerhafter
+    # Carry-Forward sichtbar wuerde.
+    record_week(date(2024, 1, 1), _quotes(EUNL=80.0, EUNA=5.0), data_dir=tmp_path)
+
+    # Batch 1 der Folgewoche: nur EUNL.
+    record_week(
+        date(2024, 1, 8), _quotes(EUNL=90.0), data_dir=tmp_path, angefragte_ticker=["EUNL"]
+    )
+    # Batch 2 derselben Woche: nur EUNA - EUNL steckt hier gar nicht in quotes.
+    record_week(
+        date(2024, 1, 9), _quotes(EUNA=6.0), data_dir=tmp_path, angefragte_ticker=["EUNA"]
+    )
+
+    rows = read_price_history(tmp_path)
+    assert len(rows) == 2
+    assert rows[1].prices["EUNL"] == Decimal("90.0")  # nicht auf 80.0 zurueckgefallen
+    assert rows[1].prices["EUNA"] == Decimal("6.0")
+
+
+def test_teilabruf_protokolliert_nur_die_eigenen_ticker(tmp_path: Path):
+    record_week(date(2024, 1, 1), _quotes(EUNL=80.0, EUNA=5.0), data_dir=tmp_path)
+    record_week(
+        date(2024, 1, 8), _quotes(EUNL=90.0), data_dir=tmp_path, angefragte_ticker=["EUNL"]
+    )
+
+    # EUNA ist nicht "eingefroren", sondern kommt am anderen Wochentag - ein
+    # carried_forward-Eintrag dafuer wuerde im Dashboard (#42) eine Kursluecke
+    # melden, die es gar nicht gibt.
+    protokolliert = {e.ticker for e in read_fetch_log(tmp_path) if e.date == date(2024, 1, 8)}
+    assert protokolliert == set()
+
+
+def test_fehlender_ticker_beider_batches_faellt_weiterhin_zurueck(tmp_path: Path):
+    """Sicherheitsnetz: ein Ticker, der auch in der bestehenden Wochenzeile
+    fehlt (in keinem der beiden Batches gewesen), nutzt weiterhin den alten
+    Carry-Forward aus frueheren Wochen."""
+    record_week(date(2024, 1, 1), _quotes(EUNL=80.0, EUNA=5.0), data_dir=tmp_path)
+    record_week(
+        date(2024, 1, 8), _quotes(EUNL=90.0), data_dir=tmp_path, angefragte_ticker=["EUNL", "EUNA"]
+    )
+
+    rows = read_price_history(tmp_path)
+    assert rows[1].prices["EUNA"] == Decimal("5.0")
+    log = [e for e in read_fetch_log(tmp_path) if e.date == date(2024, 1, 8) and e.ticker == "EUNA"]
+    assert [e.status for e in log] == ["carried_forward"]
+
+
+def test_teilabruf_haelt_das_fruehere_zeilendatum(tmp_path: Path):
+    """Beide Teilabrufe legen ihre Kurse unter dem gemeldeten Handelstag ab
+    (row_date_from_quotes) - liegen die beiden Handelstage in derselben Woche,
+    gewinnt der fruehere, unabhaengig von der Reihenfolge der Laeufe."""
+    record_week(
+        date(2024, 1, 11), _quotes(EUNL=90.0), data_dir=tmp_path, angefragte_ticker=["EUNL"]
+    )
+    record_week(
+        date(2024, 1, 12), _quotes(EUNA=6.0), data_dir=tmp_path, angefragte_ticker=["EUNA"]
+    )
+
+    rows = read_price_history(tmp_path)
+    assert len(rows) == 1
+    assert rows[0].date == date(2024, 1, 11)
 
 
 def test_record_week_new_iso_week_appends_second_row(tmp_path: Path):


### PR DESCRIPTION
Schließt #99.

## Neue Instrumente

| Ticker | Instrument | ISIN | Ausrichtung | Historie |
|---|---|---|---|---|
| `ISPA` | iShares STOXX Global Select Dividend 100 | DE000A0F5UH1 | Dividende, ausschüttend | ab 2009-11 |
| `IS3S` | iShares Edge MSCI World Value Factor | IE00BP3QZB59 | Value-Faktor, thesaurierend | ab 2014-11 |

Beide XETRA/EUR wie die #64-Instrumente — kein zusätzlicher FX-Request, das Währungsproblem aus #62 entsteht gar nicht erst.

**Abweichung vom Issue-Vorschlag:** der vorgeschlagene Value-Ticker `IUVL` löst bei Alpha Vantage nicht auf (SYMBOL_SEARCH liefert keinen Treffer). Die XETRA-Notierung desselben iShares-Fonds läuft unter `IS3S.DEX`; die Alternative `IWVL.LON` wäre USD-notiert und damit FX-pflichtig. Entsprechend ist auch die ISIN die der real gehandelten Acc-Anteilsklasse. Symbole und Historie per SYMBOL_SEARCH / GLOBAL_QUOTE / TIME_SERIES_MONTHLY geprüft; Steuerattribute, TER und Ausschüttungsrendite gegen die Anbieterangaben gesetzt (ISPA 5,0% Ausschüttung, TER 0,46%; IS3S thesaurierend, TER 0,30%; beide 30% Teilfreistellung als Aktienfonds).

## Neue Strategie

`DIVIDENDE_UND_VALUE` in einer eigenen Rubrik „Faktor-Strategien": zwei gleich große Töpfe (50% `ISPA`, 50% `IS3S`), 5/25-Rebalancing wie alle neueren Strategien.

Zur offenen Owner-Entscheidung aus dem Issue: umgesetzt ist die dort **vorgeschlagene kombinierte** Variante (ein Eintrag, zwei Töpfe). Zwei getrennte Strategien „Dividende"/„Value" wären zwei weitere `STRATEGIES`-Einträge ohne jede Änderung an Engine oder Dashboard — sagt gern Bescheid, wenn das lieber so soll.

Eigene Rubrik statt `RUBRIK_KLASSISCHE_PORTFOLIOS`: 60/40 und Permanent Portfolio teilen über Anlageklassen auf, diese Strategie dagegen innerhalb der Aktien nach einem Auswahlmerkmal — und die Rubrik ist der Platz für weitere Faktoren, die #99 bewusst ausklammert.

## Zwei-Tage-Kursabruf

26 Ticker brauchen 27 Requests, das Free Tier erlaubt 25/Tag.

- **`record_week()` mischt Teilabrufe derselben ISO-Woche additiv:** für einen Ticker ohne frischen Kurs gilt zuerst der bereits in dieser Zeile stehende Wert, erst danach der Carry-Forward aus früheren Wochen. Der neue Parameter `angefragte_ticker` begrenzt die `fetch_log`-Einträge auf die Ticker des jeweiligen Laufs — sonst meldete das Dashboard (#42) Kurslücken, die es nicht gibt. Zeilendatum: bei bestehender Wochenzeile gewinnt jetzt das **frühere** Datum (vorher das spätere), damit die Historie nicht von der Reihenfolge der Läufe abhängt.
- **`batch_tickers()` leitet die Aufteilung ab, statt sie zu hinterlegen:** Batch 1 sind genau die Ticker mit Fremdwährungs-/Krypto-Endpunkt (9 USD-Ticker + BTC-EUR, 11 Requests inkl. des einen FX-Requests), Batch 2 der Rest (16 EUR/XETRA-Ticker). Damit landet der eine FX-Request zwangsläufig in nur einem Lauf, und ein künftig ergänztes Instrument automatisch im richtigen Batch.
- `scripts/run_fetch.py` und `scripts/backfill_history.py` bekommen `--batch`; der Backfill setzt die CSVs nur in Batch 1 zurück und mischt in Batch 2 additiv dazu (Reihenfolge ist bindend, im Skript-Docstring und Workflow dokumentiert).
- `weekly-update.yml` läuft **sonntags und montags** statt nur montags. Bewusst nicht Montag+Dienstag: einsortiert wird über den gemeldeten Handelstag, beide Läufe liegen vor dem Xetra-Handelsbeginn und sehen denselben Freitagsschluss, landen also in derselben ISO-Woche. Ein Dienstagslauf sähe bereits den Montagsschluss — die Folgewoche — und sein Batch hinge dauerhaft eine Woche hinterher.
- `backfill.yml` bekommt denselben `batch`-Input.

## Zusätzlich: `dashboard._hat_kurshistorie()`

Nicht im Issue gefordert, aber eine direkte Folge davon: bis der erste Abruf/Backfill Kurse für `ISPA`/`IS3S` liefert, stünde die neue Strategie mit einer flachen Linie und 0% Rendite in der Vergleichstabelle — eine Aussage, die die Daten nicht hergeben (`_real_investierbarer_zeitraum()` kann das nicht abfangen, es gibt keinen Zeitraum zum Zuschneiden). Strategien ohne einen einzigen Zeitpunkt, an dem alle ihre Instrumente einen Kurs haben, bleiben deshalb ganz aus dem Dashboard weg.

**Folge für den Merge:** die Strategie erscheint erst nach dem nächsten Kursabruf bzw. einem Backfill auf der Seite.

## Tests

304 grün. Neu bzw. angepasst:

- `tests/test_history_store.py`: zweiter Batch wirft die Kurse des ersten nicht zurück, protokolliert nur seine eigenen Ticker, hält das frühere Zeilendatum; ein Ticker aus keinem Batch fällt weiterhin auf den alten Carry-Forward zurück.
- `tests/test_backfill_history.py`: Budget-Regressionstest bleibt, mit neuer Zählweise — jeder einzelne Batch passt in einen Tag, die Batches decken jeden Ticker genau einmal ab, nur einer braucht den FX-Request.
- `tests/test_dividende_value.py` (neu): Registrierung/Rubrik, Gewichte, 5/25-Regel, Symbol-Mapping und EUR-Notierung, Steuerattribute, End-to-End, plus Regressionstest analog zu #64, dass keine bestehende Strategie die neuen Instrumente hält.
- `tests/test_dashboard.py`: `_hat_kurshistorie()` und das Weglassen datenloser Strategien. Der bisherige Cash-Höchststand-Test lief über eine Strategie, deren einziges Instrument in keiner Kurszeile vorkam — genau der Fall, den das Dashboard jetzt weglässt; er prüft `_cash_anteil_max()` nun direkt.

README (Portfolio-Tabelle, neuer Abschnitt „Two-day price fetch", Backfill-Doku) und CLAUDE.md sind entsprechend ergänzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9ZWT2Vr7srKRnAeCAEes

---
_Generated by [Claude Code](https://claude.ai/code/session_01En9ZWT2Vr7srKRnAeCAEes)_