### PR TITLE
CLAUDE.md: Portfolio-overview-Tabelle korrekt als 26 Ticker beschreiben

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ inkrementell fortgeschrieben).
   noch die Prämissen-Seite leiten eine Instrumentenzahl mehr aus einer
   hartkodierten Konstante ab. Die README enthält seit der #64-Nachfolgearbeit
   einen `## Portfolio overview`-Abschnitt mit einer statischen Tabelle aller
-  24 Ticker samt der Strategie, die sie hält — bewusst als lesbare Übersicht
+  26 Ticker samt der Strategie, die sie hält — bewusst als lesbare Übersicht
   für Menschen, aber dadurch eine hartkodierte Momentaufnahme, die bei einer
   künftigen Strategie-Änderung von Hand nachgezogen werden muss (anders als
   Dashboard/Prämissen-Seite, die sich bei jedem Build automatisch aus


### PR DESCRIPTION
Follow-up zu #99 / PR #100.

Beim Review meiner eigenen Texte nach dem Merge von #100 aufgefallen: die README-„Portfolio overview"-Tabelle wurde dort bereits korrekt auf 26 Zeilen (inkl. `ISPA`/`IS3S`) aktualisiert, aber die Beschreibung dieser Tabelle in `CLAUDE.md` nannte noch die alte Zahl 24. Rein redaktioneller Ein-Zeilen-Fix, keine Code-/Verhaltensänderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9ZWT2Vr7srKRnAeCAEes

---
_Generated by [Claude Code](https://claude.ai/code/session_01En9ZWT2Vr7srKRnAeCAEes)_