### PR TITLE
Rebalancing-Trigger-Lücke schließen und defensivere Satellit-Variante ergänzen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,35 @@ inkrementell fortgeschrieben).
   hoch-volatile Wachstums-/Themenwerte (Lumentum, BYD, SolarEdge, SMA Solar,
   Tesla, Palantir, Strategy/vorm. MicroStrategy, Rivian) mit zwei defensiven
   Blue Chips (Coca-Cola, Roche) als Gegenbeispiel — erster Ansatz, keine
-  Optimierung/Backtesting der Auswahl oder Gewichtung. Optionales Feld
+  Optimierung/Backtesting der Auswahl oder Gewichtung.
+  **`BARBELL_20_60_20_SATELLIT_DEFENSIV` (Reaktion auf eine Projektprüfung):**
+  zusätzliche, additive Strategie neben `BARBELL_20_60_20_SATELLIT` (verändert
+  deren veröffentlichte Zahlen nicht) — eine Gegenprobe zum Rückschaufehler bei
+  der Aktienauswahl selbst, nicht nur beim Zeitraum (siehe `_real_
+  investierbarer_zeitraum()`/F4 weiter unten, der denselben Fehlertyp bei
+  ganzen Instrumenten adressiert, aber die Auswahl INNERHALB des bereits
+  investierbaren Satellit-Topfs unberührt lässt). Befund: `LITE` (+897%) und
+  `PLTR` (+703%) tragen über den Vergleichszeitraum praktisch den gesamten
+  Renditevorsprung von `BARBELL_20_60_20_SATELLIT` gegenüber `BARBELL_20_80` —
+  eine Größenordnung, die erst seit dem KI-Boom ab 2023 entstand und 2021 kein
+  plausibler Bestandteil einer Anlagethese gewesen wäre; nimmt man beide
+  Ticker heraus und verteilt ihr Gewicht gleichmäßig auf die übrigen acht,
+  fällt die Strategie von +145,8% auf +97,3% CAGR-Basis und damit UNTER
+  `BARBELL_20_80` (+118,9%). Die neue Variante nutzt bewusst dieselben zehn
+  Ticker (kein neues Instrument, kein zusätzlicher Alpha-Vantage-Request —
+  siehe Request-Budget oben), sondern gewichtet um: `LITE`/`PLTR` sinken von
+  je 10% auf je 5% des Topfs, die freiwerdenden 10 Prozentpunkte gehen zu
+  gleichen Teilen an die beiden bereits vorhandenen defensiven Blue Chips
+  `KO`/`RHHBY` (von je 10% auf je 15%) — die beiden Namen, die 2021 auch ohne
+  die spätere KI-Rally eine plausible Anlagethese hatten. Ausdrücklich KEIN
+  Anspruch, tatsächlich zu rekonstruieren, was 2021 gewählt worden wäre (nicht
+  nachprüfbar) — wie jedes Szenario in diesem Projekt ein erster, nicht
+  optimierter/gebacktesteter Ansatz, hier gezielt als Sensitivitätsprobe.
+  `rubrik=RUBRIK_BARBELL` (erscheint im selben Rubrik-Chart wie die übrigen
+  Barbell-Varianten), `im_startseiten_chart=False` (analog zu
+  `BARBELL_20_80_DIVERSIFIZIERT`, um das CAGR-Balkendiagramm nicht weiter zu
+  verdichten, siehe #92 weiter unten) — bleibt aber in Vergleichstabelle,
+  Rubrik-Chart und eigener Detailseite sichtbar. Optionales Feld
   `Strategy.beschreibung` liefert die Kurzbeschreibung, die das Dashboard je
   Strategie/Szenario anzeigt (leer = keine Beschreibung). Optionales Feld
   `Strategy.optimierungen` (Instanz von `Optimierungen`, fünf Bool-Schalter
@@ -347,6 +375,40 @@ inkrementell fortgeschrieben).
   ausschließlich in der Darstellungsschicht, bevor `rows` an `simulate()`
   übergeben werden — `engine.py` bleibt dadurch unverändert gegenüber den
   bestehenden, gegen die volle Testhistorie hand-gerechneten Engine-Tests.
+  **Zielgewicht-Änderungs-Trigger (Reaktion auf eine Projektprüfung, ergänzt
+  #63):** der Topf-Trigger oben vergleicht Ist- gegen Ziel-Gewicht je Topf —
+  eine `gewichte_fn` (siehe `scenarios.py`), die nur INNERHALB eines Topfs
+  umschichtet (Topf-Summe bleibt gleich), löste dadurch NIE ein Rebalancing
+  aus: das "Ziel" wird pro Zeile direkt aus der bereits verschobenen
+  `current_weights` abgeleitet, Topf-Ist und Topf-Ziel stimmten also immer
+  überein. Betroffen war vor allem das Momentum-Szenario (`scenarios.py`,
+  Top-2-Rotation der Wachstums-Instrumente): über den vollen
+  Vergleichszeitraum löste NUR der initiale Erstkauf ein einziges Mal aus,
+  danach folgte der simulierte Wertverlauf bis auf einen einzigen Handelstag
+  am Ende exakt dem zugrundeliegenden Barbell-Portfolio, obwohl die Regel
+  wöchentlich sieben verschiedene Ziel-Gewichtsvektoren berechnete (u. a.
+  40% Bitcoin + 40% Halbleiter-ETF) — die Rotation fand in den ausgewiesenen
+  Zahlen schlicht nie statt. `simulate()` führt seither zusätzlich
+  `letzte_ziel_gewichte` (die Ziel-Gewichte zum Zeitpunkt des letzten
+  vollständigen Rebalancings bzw. Initialkaufs) und prüft VOR dem
+  bestehenden Topf-Trigger für jedes Instrument dieselbe 5/25-Schwelle gegen
+  die Differenz aus `current_weights` und `letzte_ziel_gewichte` — sobald
+  sich das Ziel eines einzelnen Instruments seit dem letzten Rebalancing
+  ausreichend verschoben hat, löst das ein vollständiges
+  `rebalance_to_targets()` aus, unabhängig vom (unveränderten) Topf-Anteil.
+  `letzte_ziel_gewichte` wird nur bei tatsächlich vollständig erreichtem
+  Ziel aktualisiert (`opt.rebalancing=True`), nie bei der nur teilweisen
+  Neuinstrument-Finanzierung (`erstkauf_gewichte()`). Für Strategien ohne
+  `gewichte_fn` (alle Barbell-Strategien, deren Ziel-Gewichte konstant
+  bleiben) ändert sich dadurch nichts: `current_weights` weicht dort nach
+  vollständiger Instrumentenverfügbarkeit nie mehr von
+  `letzte_ziel_gewichte` ab, der neue Trigger feuert folglich nie zusätzlich
+  — bestätigt durch die unveränderte Test-Suite (alle handgerechneten
+  Engine-Tests bleiben bit-identisch). Regressionstest:
+  `tests/test_engine.py::test_zielgewicht_aenderung_innerhalb_eines_topfs_
+  loest_rebalancing_aus` (zwei Instrumente innerhalb eines Topfs tauschen bei
+  unveränderten Kursen ihre Zielgewichte, ein reiner Topf-Trigger sähe keine
+  Abweichung).
   **Werterhaltung beim Rebalancing (wichtig beim Ändern):**
   `rebalance_to_targets()` führt kein Cash-Konto — Verkaufserlöse werden
   nirgends gutgeschrieben, Kaufbeträge nirgends entnommen. Die Umschichtung
@@ -1142,7 +1204,13 @@ auslöst (der alte, nur-ziel_topf-Trigger hätte hier nicht ausgelöst), sowie
 ein Test-Paar mit identischem Kursverlauf, das mit gesetztem
 `rebalancing_schwelle_relativ=0.25` ein Rebalancing über die relative Schwelle
 auslöst und mit dem Default (`1`, effektiv deaktiviert) exakt das Verhalten
-vor #63 reproduziert (kein Rebalancing).
+vor #63 reproduziert (kein Rebalancing). Ergänzt um den
+Zielgewicht-Änderungs-Trigger: `test_zielgewicht_aenderung_innerhalb_eines_
+topfs_loest_rebalancing_aus` — zwei Instrumente innerhalb desselben Topfs
+tauschen bei UNVERÄNDERTEN Kursen ihre Zielgewichte (Topf-Ist und
+Topf-Ziel-effektiv bleiben beide exakt bei 50%, ein reiner Topf-Trigger sähe
+also keine Abweichung), trotzdem löst die Verschiebung des Ziels je
+Instrument (15pp) das Rebalancing aus.
 `tests/test_history_store.py` prüft Wochen-Idempotenz, Carry-Forward und
 `read_fetch_log()`.
 `tests/test_sources.py` / `tests/test_alphavantage.py` mocken die jeweilige
@@ -1246,7 +1314,12 @@ Rangfolge) sowie dass nicht beantwortbare Regeln still wegfallen.
 `tests/test_satellit_strategy.py` prüft den Einzelaktien-Satellit
 (`BARBELL_20_60_20_SATELLIT`): Symbol-Mapping-Vollständigkeit, Ziel-Gewichte
 summieren zu 1, 80/20-Risikoprofil bleibt erhalten, End-to-End-Smoke-Test
-mit allen 17 Instrumenten. `tests/test_backfill_history.py` prüft
+mit allen 17 Instrumenten. Analog für `BARBELL_20_60_20_SATELLIT_DEFENSIV`:
+Ziel-Gewichte summieren zu 1, 80/20-Risikoprofil bleibt erhalten, End-to-End-
+Smoke-Test, sowie ein Test, der die Gewichtsverschiebung gegen die
+Originalstrategie exakt nachrechnet (`LITE`/`PLTR` halbiert,
+`KO`/`RHHBY` um denselben Betrag angehoben, die übrigen sechs Ticker
+unverändert). `tests/test_backfill_history.py` prüft
 `scripts/backfill_history.py` (USD/EUR-Umrechnung inkl. Forward-Fill,
 ISO-Wochen-Gruppierung, Carry-Forward fehlender Ticker) gegen ein
 Fake-`AlphaVantageSource`-Objekt; seit #62 zusätzlich, dass

--- a/README.md
+++ b/README.md
@@ -34,7 +34,24 @@ the growth side becomes more concentrated. The 10 stocks deliberately mix
 highly volatile growth/thematic names (Lumentum, BYD, SolarEdge, SMA Solar,
 Tesla, Palantir, Strategy/formerly MicroStrategy, Rivian) with two defensive
 blue chips (Coca-Cola, Roche) as a counterexample — a first pass, not an
-optimized or backtested selection.
+optimized or backtested selection, and one made with full hindsight of how
+those 10 stocks actually performed since. Over the comparison window two of
+them, Lumentum and Palantir, gained +897% and +703% respectively — almost
+entirely since the AI-driven re-rating that started in 2023 — and account for
+practically the entire return advantage this strategy shows over plain
+`Barbell 20/80`. Leaving both out and redistributing their weight evenly
+across the other eight drops the strategy from +145.8% to +97.3% over the
+same period, *below* `Barbell 20/80`'s +118.9%.
+
+A sibling scenario, `Barbell 20/60/20 + Single-Stock Satellite (defensive
+tilt)`, is a check on that dependency rather than a fix for it: same 10
+stocks, same instruments (no new tickers, no extra Alpha Vantage request),
+but Lumentum and Palantir drop from 10% each to 5% each and the freed 10
+points move evenly to Coca-Cola and Roche (15% each) — the two names that
+already didn't need 2023's AI cycle to make sense as 2021-era picks. It
+makes no claim to reconstruct what would actually have been selected in
+2021; it exists to show how much of the original selection's edge rides on
+two names whose outperformance only looks obvious in retrospect.
 
 A fourth strategy, `Barbell 20/80 (diversified)`, keeps the same 20/80 risk
 profile but broadens both buckets: Bucket A trades half its bond-ETF slice
@@ -59,16 +76,16 @@ All 24 tracked instruments, and which strategy actually holds each one:
 | `SEMI` | Global Semiconductors ETF (iShares) | Barbell 20/80, 30/70, Satellite, Diversified |
 | `EIMI` | Emerging Markets IMI ETF (iShares Core) | Barbell 20/80, 30/70, Satellite, Diversified |
 | `BTC-EUR` | Bitcoin | Barbell 20/80, 30/70, Satellite, Diversified |
-| `LITE` | Lumentum Holdings | Barbell 20/60/20 + Single-Stock Satellite |
-| `BYDDY` | BYD Company (ADR) | Barbell 20/60/20 + Single-Stock Satellite |
-| `SEDG` | SolarEdge Technologies | Barbell 20/60/20 + Single-Stock Satellite |
-| `S92` | SMA Solar Technology | Barbell 20/60/20 + Single-Stock Satellite |
-| `TSLA` | Tesla | Barbell 20/60/20 + Single-Stock Satellite |
-| `PLTR` | Palantir Technologies | Barbell 20/60/20 + Single-Stock Satellite |
-| `MSTR` | Strategy Inc. (formerly MicroStrategy) | Barbell 20/60/20 + Single-Stock Satellite |
-| `RIVN` | Rivian Automotive | Barbell 20/60/20 + Single-Stock Satellite |
-| `KO` | Coca-Cola | Barbell 20/60/20 + Single-Stock Satellite |
-| `RHHBY` | Roche Holding (ADR) | Barbell 20/60/20 + Single-Stock Satellite |
+| `LITE` | Lumentum Holdings | Satellite, Satellite (defensive tilt) |
+| `BYDDY` | BYD Company (ADR) | Satellite, Satellite (defensive tilt) |
+| `SEDG` | SolarEdge Technologies | Satellite, Satellite (defensive tilt) |
+| `S92` | SMA Solar Technology | Satellite, Satellite (defensive tilt) |
+| `TSLA` | Tesla | Satellite, Satellite (defensive tilt) |
+| `PLTR` | Palantir Technologies | Satellite, Satellite (defensive tilt) |
+| `MSTR` | Strategy Inc. (formerly MicroStrategy) | Satellite, Satellite (defensive tilt) |
+| `RIVN` | Rivian Automotive | Satellite, Satellite (defensive tilt) |
+| `KO` | Coca-Cola | Satellite, Satellite (defensive tilt) |
+| `RHHBY` | Roche Holding (ADR) | Satellite, Satellite (defensive tilt) |
 | `IUSA` | S&P 500 ETF (iShares Core) | Benchmark only |
 | `XEON` | EUR money-market ETF (Xtrackers Overnight Rate) | Barbell 20/80 (diversified), Permanent Portfolio |
 | `EXSA` | STOXX Europe 600 ETF (iShares) | Barbell 20/80 (diversified) |

--- a/src/boersenspiel/engine.py
+++ b/src/boersenspiel/engine.py
@@ -238,6 +238,9 @@ def simulate(
     trades: list[Trade] = []
     last_rebalance_date: date | None = None
     last_harvest_date: date | None = None
+    # Zielgewichte zum Zeitpunkt des letzten vollstaendigen Rebalancings (bzw. des
+    # Initialkaufs) - Basis fuer den Zielgewicht-Aenderungs-Trigger weiter unten.
+    letzte_ziel_gewichte: dict[str, Decimal] = {}
 
     # Steuerledger-Zustand (lokal, kein persistenter Zustand außerhalb dieses Aufrufs)
     current_tax_year = rows[0].date.year
@@ -708,6 +711,7 @@ def simulate(
                 positions[t].cost_total = buy_value
                 positions[t].kauf_tage_gewichtet = units * Decimal(row.date.toordinal())
                 trades.append(Trade(row.date, t, "buy", units, price, gebuehr, None, "initial_buy"))
+            letzte_ziel_gewichte = initial_weights
         else:
             for t in tickers:
                 if pending_cash[t] > 0 and t in prices:
@@ -756,6 +760,8 @@ def simulate(
                     )
                     if rebalance_to_targets(prices, row.date, grund, einsatz_weights):
                         last_rebalance_date = row.date
+                        if opt.rebalancing:
+                            letzte_ziel_gewichte = current_weights
                     values = current_values(prices)
                     total_value = sum(values.values(), Decimal(0)) + total_cash()
                 # Rebalancing-Trigger (#63, F5): "5/25-Regel" je Topf statt nur fuer
@@ -769,22 +775,51 @@ def simulate(
                 # exakt die von B, bei drei oder mehr Toepfen (z. B. dem
                 # Einzelaktien-Satellit) kann ein einzelner Topf aber unbemerkt driften,
                 # waehrend Topf A zufaellig im Band bleibt.
+                #
+                # Zielgewicht-Aenderungs-Trigger: greift zusaetzlich, sobald sich das
+                # ZIEL selbst je Instrument seit dem letzten Rebalancing um mehr als die
+                # 5/25-Schwelle verschoben hat - unabhaengig davon, ob der (umgelegte)
+                # Topf-Zielanteil dabei gleich bleibt. Ohne diesen Trigger loesten
+                # gewichte_fn-Szenarien, die nur INNERHALB eines Topfs umschichten (z. B.
+                # Momentum-Rotation zwischen den Wachstums-Instrumenten), nie ein
+                # Rebalancing aus: der Topf-Ist-/Zielanteil blieb unveraendert, obwohl
+                # sich die gewuenschte Zusammensetzung komplett gedreht hatte - die
+                # betroffenen Szenarien liefen dadurch faktisch bit-identisch zum
+                # zugrundeliegenden Barbell-Portfolio.
                 if opt.rebalancing:
-                    for topf in strategy.toepfe:
-                        topf_ziel_effektiv = sum(
-                            (current_weights.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0)
-                        )
-                        topf_ist_wert = sum((values.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0))
-                        topf_ist_gewicht = topf_ist_wert / total_value
-                        abweichung_pp = abs(topf_ist_gewicht - topf_ziel_effektiv) * 100
+                    rebalanciert = False
+                    for t in tickers:
+                        ziel_t = current_weights.get(t, Decimal(0))
+                        vorheriges_ziel_t = letzte_ziel_gewichte.get(t, Decimal(0))
+                        aenderung_pp = abs(ziel_t - vorheriges_ziel_t) * 100
                         schwelle_pp = strategy.rebalancing_schwelle_pp
-                        if topf_ziel_effektiv > 0:
-                            relativ_schwelle_pp = topf_ziel_effektiv * 100 * strategy.rebalancing_schwelle_relativ
+                        if ziel_t > 0:
+                            relativ_schwelle_pp = ziel_t * 100 * strategy.rebalancing_schwelle_relativ
                             schwelle_pp = min(schwelle_pp, relativ_schwelle_pp)
-                        if abweichung_pp > schwelle_pp:
+                        if aenderung_pp > schwelle_pp:
                             if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
                                 last_rebalance_date = row.date
+                            rebalanciert = True
                             break
+                    if not rebalanciert:
+                        for topf in strategy.toepfe:
+                            topf_ziel_effektiv = sum(
+                                (current_weights.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0)
+                            )
+                            topf_ist_wert = sum((values.get(t, Decimal(0)) for t in topf.sub_gewichte), Decimal(0))
+                            topf_ist_gewicht = topf_ist_wert / total_value
+                            abweichung_pp = abs(topf_ist_gewicht - topf_ziel_effektiv) * 100
+                            schwelle_pp = strategy.rebalancing_schwelle_pp
+                            if topf_ziel_effektiv > 0:
+                                relativ_schwelle_pp = topf_ziel_effektiv * 100 * strategy.rebalancing_schwelle_relativ
+                                schwelle_pp = min(schwelle_pp, relativ_schwelle_pp)
+                            if abweichung_pp > schwelle_pp:
+                                if rebalance_to_targets(prices, row.date, "rebalance", current_weights):
+                                    last_rebalance_date = row.date
+                                rebalanciert = True
+                                break
+                    if rebalanciert:
+                        letzte_ziel_gewichte = current_weights
 
         # Laufende Fondskosten fuer diese Woche (#76) - vor Dividende/Vorabpauschale/
         # Harvest, damit alle nachfolgenden Schritte auf dem bereits um die Kosten

--- a/src/boersenspiel/strategies.py
+++ b/src/boersenspiel/strategies.py
@@ -324,12 +324,127 @@ BARBELL_20_60_20_SATELLIT = Strategy(
     beschreibung=(
         "Wie Barbell 20/80, aber der Wachstums-Topf sinkt von 80% auf 60% zugunsten "
         "eines dritten, gleichgewichteten Topfs aus 10 Einzelaktien (20%) - das "
-        "80/20-Risikoprofil bleibt erhalten, nur granularer gestreut."
+        "80/20-Risikoprofil bleibt erhalten, nur granularer gestreut. Die "
+        "Aktienauswahl selbst ist eine heutige (2026er) Zusammenstellung, kein "
+        "1:1-Nachbau einer 2021 tatsaechlich getroffenen Entscheidung - siehe die "
+        "Variante mit defensiverem Tilt daneben fuer eine Gegenprobe, wie stark "
+        "das Ergebnis von zwei rueckblickend dominanten Einzelwerten abhaengt."
     ),
     beschreibung_en=(
         "Like Barbell 20/80, but the growth bucket shrinks from 80% to 60% in "
         "favor of a third, equally weighted bucket of 10 individual stocks (20%) - "
-        "the 80/20 risk profile stays the same, just spread more granularly."
+        "the 80/20 risk profile stays the same, just spread more granularly. The "
+        "stock selection itself reflects today's (2026) vantage point, not a "
+        "faithful reconstruction of a decision actually made in 2021 - see the "
+        "defensive-tilt variant alongside it for a check on how much the result "
+        "depends on two names that only look obviously dominant in hindsight."
+    ),
+)
+
+# --- Strategie 3b: Einzelaktien-Satellit mit defensiverem Tilt -------------
+#
+# Reaktion auf den in einer Projektpruefung festgestellten Rueckschaufehler bei
+# der Aktienauswahl: die zehn Einzelaktien in BARBELL_20_60_20_SATELLIT sind zu
+# gleichen Teilen (je 10%) gewichtet, darunter LITE (Lumentum) und PLTR
+# (Palantir) - beide legten ueber den Vergleichszeitraum ganz ueberwiegend seit
+# dem KI-Boom ab 2023 um mehrere hundert Prozent zu (+897%/+703%), eine
+# Groessenordnung, die 2021 kein plausibler Anlagethesen-Bestandteil war,
+# sondern erst im Rueckblick so aussieht. Nimmt man beide aus dem Topf heraus
+# und verteilt ihr Gewicht gleichmaessig auf die uebrigen acht, faellt die
+# Strategie ueber denselben Zeitraum von +145,8% auf +97,3% CAGR-Basis und
+# damit UNTER das einfache Barbell 20/80 (+118,9%) - der Renditevorsprung des
+# Satelliten-Topfs steht und faellt praktisch komplett mit diesen zwei Werten.
+#
+# Diese Variante ersetzt NICHT die Instrumente (keine neuen Ticker, kein
+# zusaetzlicher Alpha-Vantage-Request - das Tagesbudget ist mit 24 Instrumenten
+# bereits voll ausgeschoepft, siehe instruments.py), sondern gewichtet um:
+# LITE und PLTR sinken von je 10% auf je 5%, die freiwerdenden 10 Prozentpunkte
+# wandern zu gleichen Teilen auf die beiden bereits vorhandenen defensiven Blue
+# Chips Coca-Cola und Roche (von je 10% auf je 15%) - die beiden "langlaufenden,
+# stabilen Werte", die eine 2021 zusammengestellte Auswahl eher getragen haette
+# als eine Wette auf eine damals noch nicht abzusehende KI-Rally. Die uebrigen
+# sechs Positionen (BYDDY, SEDG, S92, TSLA, MSTR, RIVN) bleiben bei je 10% -
+# das waren 2021 bereits grosse, oeffentlich bekannte Werte (Tesla als
+# wertvollster Autohersteller, BYD als Chinas fuehrender NEV-Hersteller,
+# MicroStrategy/Strategy fuer seine seit 2020 bekannte Bitcoin-Treasury-
+# Strategie), keine erst im Rueckblick auffaelligen Ausreisser wie LITE/PLTR.
+#
+# Ausdruecklich KEIN Anspruch, tatsaechlich zu rekonstruieren, was 2021 gewaehlt
+# worden waere (das laesst sich nicht nachpruefen) - wie jedes Szenario in
+# diesem Projekt ein erster, nicht optimierter/gebacktesteter Ansatz, hier
+# gezielt als Gegenprobe zur rueckschaufehler-anfaelligen Originalauswahl.
+
+BARBELL_20_60_20_SATELLIT_DEFENSIV = Strategy(
+    name="Barbell 20/60/20 + Einzelaktien-Satellit (defensiver Tilt)",
+    rubrik=RUBRIK_BARBELL,
+    im_startseiten_chart=False,
+    startkapital=Decimal("10000"),
+    toepfe=[
+        Topf(
+            name="Topf A - Sicherheit",
+            gewicht_gesamt=Decimal("0.20"),
+            sub_gewichte={
+                "EUNL": Decimal("0.50"),
+                "EUNA": Decimal("0.35"),
+                "4GLD": Decimal("0.15"),
+            },
+        ),
+        Topf(
+            name="Topf B - Wachstum",
+            gewicht_gesamt=Decimal("0.60"),
+            sub_gewichte={
+                "LYMS": Decimal("0.40"),
+                "SEMI": Decimal("0.30"),
+                "EIMI": Decimal("0.20"),
+                "BTC-EUR": Decimal("0.10"),
+            },
+        ),
+        Topf(
+            name="Topf C - Einzelaktien-Satellit (defensiver Tilt)",
+            gewicht_gesamt=Decimal("0.20"),
+            sub_gewichte={
+                "LITE": Decimal("0.05"),
+                "BYDDY": Decimal("0.10"),
+                "SEDG": Decimal("0.10"),
+                "S92": Decimal("0.10"),
+                "TSLA": Decimal("0.10"),
+                "PLTR": Decimal("0.05"),
+                "MSTR": Decimal("0.10"),
+                "RIVN": Decimal("0.10"),
+                "KO": Decimal("0.15"),
+                "RHHBY": Decimal("0.15"),
+            },
+        ),
+    ],
+    ziel_topf="Topf A - Sicherheit",
+    ziel_gewicht=Decimal("0.20"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    rebalancing_schwelle_relativ=Decimal("0.25"),
+    beschreibung=(
+        "Wie Barbell 20/60/20 + Einzelaktien-Satellit, aber mit einem defensiveren "
+        "Tilt innerhalb des Aktien-Topfs: LITE und PLTR sinken von je 10% auf je "
+        "5%, die freiwerdenden 10 Prozentpunkte gehen zu gleichen Teilen an die "
+        "beiden defensiven Blue Chips Coca-Cola und Roche (je 15% statt 10%). "
+        "Hintergrund: LITE (+897%) und PLTR (+703%) tragen im Vergleichszeitraum "
+        "praktisch den gesamten Renditevorsprung der Originalauswahl gegenueber "
+        "Barbell 20/80 - eine Groessenordnung, die erst seit dem KI-Boom ab 2023 "
+        "sichtbar wurde und 2021 kein plausibler Bestandteil einer Anlagethese "
+        "gewesen waere. Kein Rekonstruktionsversuch einer tatsaechlich 2021 "
+        "getroffenen Wahl, sondern eine Gegenprobe, wie stark das Ergebnis der "
+        "Originalauswahl von diesen zwei Werten abhaengt."
+    ),
+    beschreibung_en=(
+        "Like the Barbell 20/60/20 + individual-stock satellite, but with a more "
+        "defensive tilt within the stock bucket: LITE and PLTR drop from 10% each "
+        "to 5% each, and the freed 10 percentage points go equally to the two "
+        "defensive blue chips Coca-Cola and Roche (15% each instead of 10%). "
+        "Rationale: LITE (+897%) and PLTR (+703%) account for practically all of "
+        "the original selection's outperformance over Barbell 20/80 in the "
+        "comparison window - a magnitude that only became visible from the 2023 "
+        "AI boom onward and would not have been a plausible investment thesis in "
+        "2021. Not an attempt to reconstruct what was actually chosen in 2021, "
+        "but a check on how much the original selection's result depends on "
+        "these two names."
     ),
 )
 
@@ -556,6 +671,7 @@ STRATEGIES: list[Strategy] = [
     BARBELL_20_80,
     BARBELL_30_70,
     BARBELL_20_60_20_SATELLIT,
+    BARBELL_20_60_20_SATELLIT_DEFENSIV,
     BARBELL_20_80_DIVERSIFIZIERT,
     SP500_BENCHMARK,
     PORTFOLIO_60_40,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -830,6 +830,62 @@ def test_5_25_regel_relativ_default_aendert_altverhalten_nicht():
     assert result.last_rebalance_date is None
 
 
+# --- Zielgewicht-Aenderungs-Trigger fuer gewichte_fn-Szenarien --------------
+#
+# Der Topf-Trigger oben prueft Ist- gegen Ziel-Gewicht je Topf. Eine
+# gewichte_fn, die nur INNERHALB eines Topfs umschichtet (Topf-Summe bleibt
+# gleich), loeste vor dieser Ergaenzung nie ein Rebalancing aus: Ist- und
+# Ziel-Topfgewicht stimmten immer ueberein, weil "Ziel" pro Zeile direkt aus
+# der (bereits verschobenen) current_weights abgeleitet wird. Betroffen waren
+# u. a. das Momentum-Szenario, dessen Wertverlauf dadurch ueber weite Strecken
+# bit-identisch mit dem zugrundeliegenden Barbell-Portfolio war.
+
+
+def _rotations_gewichte(rows: list[PriceRow], i: int) -> dict[str, Decimal]:
+    if i == 0:
+        return {"A": Decimal("0.5"), "X": Decimal("0.25"), "Y": Decimal("0.25")}
+    # Ab Zeile 1 dreht sich die Zusammensetzung von TopfB komplett (X/Y
+    # tauschen ihre Gewichte), TopfB bleibt aber unveraendert bei 50%.
+    return {"A": Decimal("0.5"), "X": Decimal("0.4"), "Y": Decimal("0.1")}
+
+
+ROTATIONS_STRATEGY = Strategy(
+    name="Test-Rotation-Innerhalb-Topf",
+    startkapital=Decimal("1000"),
+    toepfe=[
+        Topf(name="TopfA", gewicht_gesamt=Decimal("0.5"), sub_gewichte={"A": Decimal("1")}),
+        Topf(
+            name="TopfB",
+            gewicht_gesamt=Decimal("0.5"),
+            sub_gewichte={"X": Decimal("0.5"), "Y": Decimal("0.5")},
+        ),
+    ],
+    ziel_topf="TopfA",
+    ziel_gewicht=Decimal("0.5"),
+    rebalancing_schwelle_pp=Decimal("5"),
+    gewichte_fn=_rotations_gewichte,
+)
+
+
+def test_zielgewicht_aenderung_innerhalb_eines_topfs_loest_rebalancing_aus():
+    rows = [
+        # Initialkauf 1000 EUR (gebuehrenfrei) auf 50/25/25 -> A=500, X=250, Y=250.
+        PriceRow(date(2024, 1, 1), {"A": Decimal("100"), "X": Decimal("100"), "Y": Decimal("100")}),
+        # Kurse UNVERAENDERT - TopfB-Ist bleibt exakt bei 50% (X=250+Y=250),
+        # ein reiner Topf-Trigger saehe hier ueberhaupt keine Abweichung. Das
+        # ZIEL innerhalb TopfB hat sich aber von 25/25 auf 40/10 verschoben
+        # (15pp je Instrument, klar ueber der 5pp-Schwelle).
+        PriceRow(date(2024, 1, 8), {"A": Decimal("100"), "X": Decimal("100"), "Y": Decimal("100")}),
+    ]
+    result = simulate(rows, ROTATIONS_STRATEGY, Optimierungen(**_OHNE_REIBUNG))
+
+    assert result.last_rebalance_date == date(2024, 1, 8)
+    last = result.value_history[-1]
+    assert last.ticker_values["A"] == Decimal("500")
+    assert last.ticker_values["X"] == Decimal("400")
+    assert last.ticker_values["Y"] == Decimal("100")
+
+
 # --- Ausschuettungsrendite je Instrument (#74) ------------------------------
 
 

--- a/tests/test_satellit_strategy.py
+++ b/tests/test_satellit_strategy.py
@@ -20,7 +20,11 @@ from boersenspiel.engine import simulate
 from boersenspiel.history_store import PriceRow
 from boersenspiel.instruments import TICKERS
 from boersenspiel.sources.alphavantage import ALPHAVANTAGE_SYMBOLS
-from boersenspiel.strategies import BARBELL_20_60_20_SATELLIT, STRATEGIES
+from boersenspiel.strategies import (
+    BARBELL_20_60_20_SATELLIT,
+    BARBELL_20_60_20_SATELLIT_DEFENSIV,
+    STRATEGIES,
+)
 
 EINZELAKTIEN_SATELLIT_TICKER = [
     "LITE",
@@ -116,6 +120,99 @@ def test_satellit_strategy_runs_end_to_end_with_all_17_instrumenten():
     result = simulate(rows, BARBELL_20_60_20_SATELLIT)
 
     assert result.strategy_name == "Barbell 20/60/20 + Einzelaktien-Satellit"
+    last_point = result.value_history[-1]
+    assert last_point.total_value > 0
+    total_weight = sum(last_point.ticker_weights.values())
+    assert abs(total_weight - Decimal("1")) < Decimal("0.0001")
+    assert all(units >= 0 for units in result.holdings.values())
+    for ticker in EINZELAKTIEN_SATELLIT_TICKER:
+        assert ticker in result.holdings
+
+
+# --- Defensiver-Tilt-Variante (Gegenprobe zum Rueckschaufehler bei der Auswahl) --
+
+
+def test_satellit_defensiv_strategy_is_registered_in_strategies_list():
+    assert BARBELL_20_60_20_SATELLIT_DEFENSIV in STRATEGIES
+
+
+def test_satellit_defensiv_strategy_ticker_gewichte_summieren_zu_eins():
+    gewichte = BARBELL_20_60_20_SATELLIT_DEFENSIV.alle_ticker_gewichte()
+    assert sum(gewichte.values()) == Decimal("1")
+
+
+def test_satellit_defensiv_strategy_haelt_barbell_risikoprofil_80_20():
+    gewichte = BARBELL_20_60_20_SATELLIT_DEFENSIV.alle_ticker_gewichte()
+    sicherheit = sum(g for t, g in gewichte.items() if t in {"EUNL", "EUNA", "4GLD"})
+    riskant = sum(g for t, g in gewichte.items() if t not in {"EUNL", "EUNA", "4GLD"})
+    assert sicherheit == Decimal("0.20")
+    assert riskant == Decimal("0.80")
+
+
+def test_satellit_defensiv_strategy_verschiebt_gewicht_von_lite_pltr_zu_ko_rhhby():
+    original = BARBELL_20_60_20_SATELLIT.alle_ticker_gewichte()
+    defensiv = BARBELL_20_60_20_SATELLIT_DEFENSIV.alle_ticker_gewichte()
+    # LITE/PLTR halbiert (20% Topf * 10% -> 20% Topf * 5%), KO/RHHBY um denselben
+    # Betrag angehoben - der Aktien-Topf bleibt insgesamt bei 20% des Depots.
+    for ticker in ("LITE", "PLTR"):
+        assert defensiv[ticker] == original[ticker] / 2
+    for ticker in ("KO", "RHHBY"):
+        assert defensiv[ticker] == original[ticker] + (original["LITE"] / 2)
+    # Die uebrigen sechs Einzelaktien sind unveraendert.
+    for ticker in ("BYDDY", "SEDG", "S92", "TSLA", "MSTR", "RIVN"):
+        assert defensiv[ticker] == original[ticker]
+
+
+def test_satellit_defensiv_strategy_runs_end_to_end_with_allen_instrumenten():
+    rows = [
+        PriceRow(
+            date(2024, 1, 1),
+            {
+                "EUNL": Decimal("80"),
+                "EUNA": Decimal("5"),
+                "4GLD": Decimal("60"),
+                "LYMS": Decimal("20"),
+                "SEMI": Decimal("45"),
+                "EIMI": Decimal("30"),
+                "BTC-EUR": Decimal("40000"),
+                "LITE": Decimal("70"),
+                "BYDDY": Decimal("55"),
+                "SEDG": Decimal("15"),
+                "S92": Decimal("60"),
+                "TSLA": Decimal("250"),
+                "PLTR": Decimal("40"),
+                "MSTR": Decimal("300"),
+                "RIVN": Decimal("12"),
+                "KO": Decimal("65"),
+                "RHHBY": Decimal("35"),
+            },
+        ),
+        PriceRow(
+            date(2024, 6, 1),
+            {
+                "EUNL": Decimal("90"),
+                "EUNA": Decimal("5.2"),
+                "4GLD": Decimal("65"),
+                "LYMS": Decimal("28"),
+                "SEMI": Decimal("55"),
+                "EIMI": Decimal("27"),
+                "BTC-EUR": Decimal("60000"),
+                "LITE": Decimal("90"),
+                "BYDDY": Decimal("48"),
+                "SEDG": Decimal("22"),
+                "S92": Decimal("50"),
+                "TSLA": Decimal("310"),
+                "PLTR": Decimal("62"),
+                "MSTR": Decimal("410"),
+                "RIVN": Decimal("9"),
+                "KO": Decimal("67"),
+                "RHHBY": Decimal("36"),
+            },
+        ),
+    ]
+    result = simulate(rows, BARBELL_20_60_20_SATELLIT_DEFENSIV)
+
+    assert result.strategy_name == "Barbell 20/60/20 + Einzelaktien-Satellit (defensiver Tilt)"
     last_point = result.value_history[-1]
     assert last_point.total_value > 0
     total_weight = sum(last_point.ticker_weights.values())


### PR DESCRIPTION
## Summary

Eine Projektprüfung ergab zwei konkrete Korrekturbedarfe, die dieser PR umsetzt:

- **Rebalancing-Trigger-Bug (`engine.py`):** Der 5/25-Regel-Trigger prüfte bisher nur Ist- gegen Ziel-Gewicht *je Topf*. Eine `gewichte_fn` (siehe `scenarios.py`), die nur INNERHALB eines Topfs umschichtet (Topf-Summe bleibt gleich), löste dadurch nie ein Rebalancing aus – das Momentum-Szenario etwa lief über den vollen Vergleichszeitraum bis auf einen einzigen Handelstag bit-identisch mit dem zugrundeliegenden Barbell-Portfolio, obwohl seine Regel wöchentlich völlig unterschiedliche Ziel-Gewichte berechnete. `simulate()` prüft jetzt zusätzlich, ob sich das Ziel *je Instrument* seit dem letzten Rebalancing über die 5/25-Schwelle verschoben hat, unabhängig vom Topf-Anteil. Für Strategien ohne `gewichte_fn` (konstante Ziel-Gewichte) ändert sich nichts – bestätigt durch die unveränderte, bit-identische Test-Suite.
- **Neue Strategie `Barbell 20/60/20 + Einzelaktien-Satellit (defensiver Tilt)`:** Gegenprobe zum Rückschaufehler bei der Aktienauswahl selbst. `LITE` (+897%) und `PLTR` (+703%) tragen über den Vergleichszeitraum praktisch den gesamten Renditevorsprung des Einzelaktien-Satelliten gegenüber `Barbell 20/80` – eine Größenordnung, die erst mit dem KI-Boom ab 2023 sichtbar wurde und 2021 kein plausibler Bestandteil einer Anlagethese gewesen wäre. Die neue Variante nutzt dieselben zehn Ticker (kein neues Instrument, kein zusätzlicher Alpha-Vantage-Request), gewichtet aber `LITE`/`PLTR` von je 10% auf je 5% herunter und die beiden bereits vorhandenen defensiven Blue Chips Coca-Cola/Roche von je 10% auf je 15% herauf.

Bewusst **nicht** angefasst: das Alpha-Vantage-Request-Budget (25 Requests/Tag, kein Puffer). Das ist eine dokumentierte, explizite Owner-Entscheidung aus #64 (Budget bewusst voll ausgeschöpft) mit eigenem Regressionstest – eine Reduzierung würde diese Entscheidung revertieren, nicht nur einen Bug fixen.

## Details

### Rebalancing-Trigger
- `simulate()` führt neu `letzte_ziel_gewichte` (Ziel-Gewichte zum Zeitpunkt des letzten vollständigen Rebalancings/Initialkaufs) und prüft VOR dem bestehenden Topf-Trigger jedes Instrument gegen dieselbe 5/25-Schwelle.
- Regressionstest `tests/test_engine.py::test_zielgewicht_aenderung_innerhalb_eines_topfs_loest_rebalancing_aus`: zwei Instrumente tauschen bei unveränderten Kursen ihre Zielgewichte innerhalb eines Topfs – ein reiner Topf-Trigger sähe keine Abweichung, der neue Trigger löst trotzdem aus.
- CLAUDE.md dokumentiert die Modellierungsentscheidung und den beobachteten Effekt (Momentum-Szenario) ausführlich.

### Defensivere Satellit-Variante
- `BARBELL_20_60_20_SATELLIT_DEFENSIV` in `strategies.py`, zusätzlich zu (nicht anstelle von) `BARBELL_20_60_20_SATELLIT` – verändert deren veröffentlichte Zahlen nicht.
- Eigene Tests in `tests/test_satellit_strategy.py` (Gewichtssumme, 80/20-Risikoprofil, exakte Gewichtsverschiebung gegenüber der Originalstrategie, End-to-End-Smoke-Test).
- README und CLAUDE.md aktualisiert (Portfolio-Übersicht, Strategie-Beschreibung, Modellierungsentscheidung).

## Test plan

- [x] `pytest -q` – 291 passed (vorher 285; 6 neue Tests)
- [x] `python scripts/build_dashboard.py` läuft durch, neue Strategie erscheint in Vergleichstabelle und eigener Detailseite mit plausiblem, von der Originalstrategie verschiedenem Ergebnis
- [x] Vor/Nach-Vergleich der Rebalancing-Termine je Strategie/Szenario manuell geprüft (Momentum: 1 → 77 Termine über den Vergleichszeitraum)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LumPgQkizSfGYBEXKVmwrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LumPgQkizSfGYBEXKVmwrf)_