### PR TITLE
Rückschaufehler-Warnung auf Prämissen-Seite mit konkreter Zahl unterlegen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -793,8 +793,19 @@ inkrementell fortgeschrieben).
   denen alle Zahlen beruhen — seit #93 auch das Kombinationsverfahren
   zusammengesetzter Strategien (`id="kombination"`, Regelliste aus
   `Strategy.beitraege` abgeleitet) und seit #91 die Ersatzbond-Annahme hinter
-  dem verlängerten Auswertezeitraum (`id="erweiterter-zeitraum"`) —
-  Datenbasis und Zeitraum, Instrumententabelle
+  dem verlängerten Auswertezeitraum (`id="erweiterter-zeitraum"`) — sowie
+  (Reaktion auf eine Projektprüfung) im Bullet „Rückschaufehler bei der
+  Instrumentenauswahl" einen zusätzlichen, konkreten Satz: der direkte
+  CAGR-Vergleich zwischen `BARBELL_20_60_20_SATELLIT` und
+  `BARBELL_20_60_20_SATELLIT_DEFENSIV`
+  (`dashboard._praemissen_kontext()`, Feld `satellit_rueckschau_vergleich`,
+  `None` wenn eine der beiden Strategien in der aktuellen Ansicht fehlt —
+  z. B. in Tests mit eigener Ad-hoc-Strategieliste). Macht die sonst
+  abstrakte Rückschaufehler-Warnung an einer konkreten, bei jedem Build neu
+  berechneten Zahl fest (Vergleichszeitraum-CAGR, Rückfall auf den eigenen
+  Zeitraum), statt einen Wert hart ins Template zu schreiben, der gegenüber
+  einer künftig verschobenen Aktienauswahl veralten könnte — dasselbe Prinzip
+  wie der Rest der Seite. Datenbasis und Zeitraum, Instrumententabelle
   mit **erstem Kurstag je Ticker** (⚠ bei später verfügbaren), Handels- und
   Steuerregeln, die Kennzahl-Definitionen sowie eine explizite Liste des
   nicht Modellierten (jahresgenaue Dividendenhistorien — je Instrument gilt

--- a/src/boersenspiel/dashboard.py
+++ b/src/boersenspiel/dashboard.py
@@ -1305,6 +1305,36 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
     cash_werte = [s["cash_max_label"] for s in strategie_liste]
     cash_ueberall_null = all(float(v.replace(",", ".")) == 0.0 for v in cash_werte)
 
+    # Konkrete, selbst-aktualisierende Illustration des Rueckschaufehlers oben:
+    # der direkte CAGR-Vergleich zwischen dem Einzelaktien-Satelliten und seiner
+    # defensiveren Gegenprobe (BARBELL_20_60_20_SATELLIT_DEFENSIV, siehe
+    # strategies.py) - macht die abstrakte Warnung an einer konkreten Zahl fest,
+    # ohne einen Wert hart ins Template zu schreiben, der gegenueber einer
+    # kuenftig verschobenen Aktienauswahl veralten koennte. Nutzt den
+    # Vergleichszeitraum-CAGR (#73/#78), wenn verfuegbar, sonst den eigenen
+    # Zeitraum der Strategie - dieselbe Rueckfalllogik wie die Uebersichtstabelle.
+    # None, wenn eine der beiden Strategien in dieser Ansicht fehlt (z. B. in
+    # Tests mit einer eigenen Ad-hoc-Strategieliste) - der Hinweis im Template
+    # entfaellt dann einfach, statt eine tote Referenz zu zeigen.
+    satellit_original = views_by_id.get(_slug("Barbell 20/60/20 + Einzelaktien-Satellit"))
+    satellit_defensiv = views_by_id.get(
+        _slug("Barbell 20/60/20 + Einzelaktien-Satellit (defensiver Tilt)")
+    )
+    satellit_rueckschau_vergleich = None
+    if satellit_original and satellit_defensiv:
+        original_cagr = satellit_original.get("vergleich_cagr_pct")
+        if original_cagr is None:
+            original_cagr = satellit_original["cagr_pct"]
+        defensiv_cagr = satellit_defensiv.get("vergleich_cagr_pct")
+        if defensiv_cagr is None:
+            defensiv_cagr = satellit_defensiv["cagr_pct"]
+        satellit_rueckschau_vergleich = {
+            "original_label": f"{original_cagr:+.2f}",
+            "defensiv_label": f"{defensiv_cagr:+.2f}",
+            "differenz_label": f"{original_cagr - defensiv_cagr:+.2f}",
+            "defensiv_id": satellit_defensiv["id"],
+        }
+
     return {
         "instrumente": instrumente,
         "nicht_allokierte_instrumente": nicht_allokierte_instrumente,
@@ -1343,6 +1373,7 @@ def _praemissen_kontext(rows: list[PriceRow], strategies: list[Strategy], views:
             for s_ in strategies
             if s_.beitraege
         ],
+        "satellit_rueckschau_vergleich": satellit_rueckschau_vergleich,
     }
 
 

--- a/src/boersenspiel/templates/praemissen.html.j2
+++ b/src/boersenspiel/templates/praemissen.html.j2
@@ -22,7 +22,7 @@
       schwerer als jede Renditezahl auf der Übersichtsseite:
     </p>
     <ul class="hint">
-      <li data-i18n-en="Look-ahead bias in instrument selection. The {{ instrumente|length }} instruments were chosen once their price development was already known. A back-calculated return therefore doesn't answer &quot;what would I have earned?&quot;, but at best &quot;how would these rules have performed on these instruments, selected in hindsight?&quot;. Two effects are therefore deliberately kept out of the simulation (owner decision on #63, F4): Bitcoin is treated as untradable before {{ btc_fruehphase_ende }}, because a German retail investor had no realistic EUR access to Bitcoin before that; and every strategy/scenario only starts its simulation at the point where its complete instrument set was actually tradable - see &quot;simulation start&quot; in the strategy table below - instead of letting the proportional reallocation onto early-existing instruments (next section) also affect the published metrics. Both remain a simplification, not proof of investability at every point in time. The look-ahead bias applies exclusively to these {{ instrumente|length }} instruments actually assigned to a strategy. {% if nicht_allokierte_instrumente %}The {{ nicht_allokierte_instrumente|length }} additionally captured data series (section &quot;Data series without allocation&quot; below) are not a look-ahead bias, because they were added as a neutral benchmark independent of their price development, not selected into a strategy.{% endif %}">
+      <li data-i18n-en="Look-ahead bias in instrument selection. The {{ instrumente|length }} instruments were chosen once their price development was already known. A back-calculated return therefore doesn't answer &quot;what would I have earned?&quot;, but at best &quot;how would these rules have performed on these instruments, selected in hindsight?&quot;. Two effects are therefore deliberately kept out of the simulation (owner decision on #63, F4): Bitcoin is treated as untradable before {{ btc_fruehphase_ende }}, because a German retail investor had no realistic EUR access to Bitcoin before that; and every strategy/scenario only starts its simulation at the point where its complete instrument set was actually tradable - see &quot;simulation start&quot; in the strategy table below - instead of letting the proportional reallocation onto early-existing instruments (next section) also affect the published metrics. Both remain a simplification, not proof of investability at every point in time. The look-ahead bias applies exclusively to these {{ instrumente|length }} instruments actually assigned to a strategy. {% if nicht_allokierte_instrumente %}The {{ nicht_allokierte_instrumente|length }} additionally captured data series (section &quot;Data series without allocation&quot; below) are not a look-ahead bias, because they were added as a neutral benchmark independent of their price development, not selected into a strategy.{% endif %} {% if satellit_rueckschau_vergleich %}The look-ahead bias isn't just about WHICH instruments show up, but also how heavily individual ones are weighted within a strategy: the single-stock satellite weights two names whose price history stood out in hindsight ({{ satellit_rueckschau_vergleich.original_label }}% CAGR) the same as all the others. A more defensive counter-check with the same instruments, but a lower weight on exactly those two names, comes to {{ satellit_rueckschau_vergleich.defensiv_label }}% CAGR - a {{ satellit_rueckschau_vergleich.differenz_label }} percentage point difference from weighting alone, without swapping a single instrument.{% endif %}">
         <strong>Rückschaufehler bei der Instrumentenauswahl.</strong> Die
         {{ instrumente|length }} Instrumente wurden ausgewählt, als ihre
         Kursentwicklung bereits bekannt war. Eine rückgerechnete Rendite
@@ -48,6 +48,20 @@
         Rückschaufehler, weil sie unabhängig von ihrer Kursentwicklung als
         neutraler Vergleichsmaßstab ergänzt wurden, nicht in eine Strategie
         hinein ausgewählt.
+        {% endif %}
+        {% if satellit_rueckschau_vergleich %}
+        Der Rückschaufehler betrifft nicht nur, WELCHE Instrumente überhaupt
+        auftauchen, sondern auch, wie stark einzelne davon innerhalb einer
+        Strategie gewichtet sind: der Einzelaktien-Satellit gewichtet zwei
+        Werte, deren Kursverlauf im Rückblick besonders auffällig war
+        ({{ satellit_rueckschau_vergleich.original_label }}% CAGR), gleich wie
+        alle übrigen. Eine <a href="{{ satellit_rueckschau_vergleich.defensiv_id }}.html">defensivere
+        Gegenprobe</a> mit denselben Instrumenten, aber geringerem Gewicht auf
+        genau diesen beiden Werten, kommt auf
+        {{ satellit_rueckschau_vergleich.defensiv_label }}% CAGR – ein
+        Unterschied von {{ satellit_rueckschau_vergleich.differenz_label }}
+        Prozentpunkten allein durch die Gewichtung, ohne ein einziges
+        Instrument auszutauschen.
         {% endif %}
       </li>
       <li data-i18n-en="The rules are not optimized and not backtested. Thresholds, time windows and quotas of the scenarios are a first approach, not parameters fitted to data. The &quot;Robustness across sub-periods&quot; section on every detail page shows how much a return varies between periods.">


### PR DESCRIPTION
## Summary

Follow-up zu #102: der Bullet "Rückschaufehler bei der Instrumentenauswahl" auf der Prämissen-Seite war bisher eine rein abstrakte Warnung ohne konkretes Beispiel. Ergänzt um einen Satz mit dem direkten CAGR-Vergleich zwischen `BARBELL_20_60_20_SATELLIT` und der in #102 eingeführten defensiveren Gegenprobe `BARBELL_20_60_20_SATELLIT_DEFENSIV`.

- `dashboard._praemissen_kontext()`: neues Feld `satellit_rueckschau_vergleich` – bei jedem Build neu aus den bereits berechneten Strategie-`views` abgeleitet (Vergleichszeitraum-CAGR, Rückfall auf den eigenen Zeitraum), kein hinterlegter Text. `None`, wenn eine der beiden Strategien in der aktuellen Ansicht fehlt (z. B. Tests mit eigener Ad-hoc-Strategieliste) – der Hinweis entfällt dann einfach.
- `templates/praemissen.html.j2`: zusätzlicher, bedingter Satz im bestehenden Rückschaufehler-Bullet, deutsch und englisch (im `data-i18n-en`-Attribut).
- CLAUDE.md entsprechend dokumentiert.

## Test plan

- [x] `pytest -q` – 310 passed
- [x] `python scripts/build_dashboard.py` – neuer Satz erscheint korrekt auf `docs/praemissen.html`, deutsch und englisch geprüft

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LumPgQkizSfGYBEXKVmwrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LumPgQkizSfGYBEXKVmwrf)_