### PR TITLE
chore: Dependabot-Config anlegen – monatlich, gruppiert (pip)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot – kostenlose Dependency-Updates + Security-Alerts (Issue #60).
+#
+# Drosselung siehe project-templates Issue #144:
+#   - interval: monthly statt weekly
+#   - EIN Gruppen-Block ohne update-types-Filter, damit auch Major-Updates
+#     gebündelt werden statt je einen eigenen PR zu öffnen.
+#
+# Abweichungen von automation-templates/dependabot.yml:
+#   - "pip" statt "npm": dieses Repo ist Python (requirements.txt).
+#   - KEIN target-branch: dieses Repo hat keinen testing-Branch. Ein
+#     target-branch auf einen nicht existierenden Branch würde dazu führen,
+#     dass Dependabot gar keine PRs mehr anlegt.
+
+version: 2
+updates:
+  # GitHub-Actions-Versionen.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      # Kein update-types-Filter → Major landet mit im Sammel-PR.
+      actions-all:
+        patterns:
+          - "*"
+
+  # Python-Abhängigkeiten (requirements.txt).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    groups:
+      pip-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Übernimmt die gedrosselte Dependabot-Vorlage aus S540d/project-templates#144.

## Warum
Dieses Repo hatte bisher **keine** `.github/dependabot.yml`. Die Vorlagen lagen seit Issue #60 nur „zum Kopieren" in `automation-templates/` und wurden hier nie ausgerollt — Updates liefen ungesteuert.

## Änderungen
- `interval: "monthly"`
- EIN Sammel-Gruppenblock mit `patterns: ["*"]`, damit auch Major-Updates gebündelt werden

## Zwei bewusste Abweichungen von der Vorlage
1. **`pip` statt `npm`** — dieses Repo ist Python (`requirements.txt`), kein Node. Die offenen Dependabot-PRs (jinja2, pytest, requests) bestätigen das.
2. **Kein `target-branch`** — dieses Repo hat **keinen `testing`-Branch**. Ein `target-branch` auf einen nicht existierenden Branch würde dazu führen, dass Dependabot gar keine PRs mehr anlegt. PRs gehen daher weiter gegen `main`.

Falls hier später ein `testing`-Branch eingeführt wird, sollte `target-branch: "testing"` nachgezogen werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)